### PR TITLE
fix auto data export.

### DIFF
--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -65,9 +65,10 @@ def prep_input(case):
     with open(os.path.join(rundir,"diag_table"), 'w') as diag_table:
         diag_table.write(diag_table_data)
 
-    # process MOM_input: (replace all the instances of "DIN_LOC_ROOT" with the actual local input directory)
+    # process MOM_input: (replace all the instances of "DIN_LOC_ROOT" with the local input directory)
     with open(os.path.join(rundir,"MOM_input"), 'r') as MOM_input:
-         MOM_input_data = MOM_input.read().replace('DIN_LOC_ROOT',din_loc_root)
+         inputdir = os.path.join(din_loc_root,'ocn','mom',ocn_gridname)
+         MOM_input_data = MOM_input.read().replace('DIN_LOC_ROOT',inputdir)
     with open(os.path.join(rundir,"MOM_input"), 'w') as MOM_input:
         MOM_input.write(MOM_input_data)
 

--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-"""POP namelist creator
+"""MOM6 namelist creator
 """
 
 # Typically ignore this.
@@ -28,6 +28,7 @@ logger = logging.getLogger(__name__)
 # prepares the input files of a case and places in rundir:
 def prep_input(case):
     casename        = case.get_value("CASE")
+    Buildconf       = case.get_value("CASEBUILD")
     rundir          = case.get_value("RUNDIR")
     gridname        = case.get_value("GRID")
     atm_gridname    = case.get_value("ATM_GRID")
@@ -64,20 +65,18 @@ def prep_input(case):
     with open(os.path.join(rundir,"diag_table"), 'w') as diag_table:
         diag_table.write(diag_table_data)
 
-    # symbolically link grid and forcing files:
-    logger.info("Symbolically linking grid and forcing files for %s\n"%(resolution))
-    src_input_dir = os.path.join(din_loc_root,"ocn","mom",ocn_gridname)
-    if not os.path.exists(src_input_dir):
-        expect(False, "Couldn't find grid and forcing files at "+src_input_dir)
-    dst_input_dir = os.path.join(rundir,"INPUT")
-    if not os.path.exists(dst_input_dir):
-        os.makedirs(dst_input_dir)
-    for filename in os.listdir(src_input_dir):
-        src = os.path.join(src_input_dir, filename)
-        dst = os.path.join(dst_input_dir, filename)
-        if os.path.exists(dst): # if there is, remove old link
-            os.unlink(dst)
-        os.symlink(src, dst)
+    # process MOM_input: (replace all the instances of "DIN_LOC_ROOT" with the actual local input directory)
+    with open(os.path.join(rundir,"MOM_input"), 'r') as MOM_input:
+         MOM_input_data = MOM_input.read().replace('DIN_LOC_ROOT',din_loc_root)
+    with open(os.path.join(rundir,"MOM_input"), 'w') as MOM_input:
+        MOM_input.write(MOM_input_data)
+
+    # generate input_data_list:
+    with open(os.path.join(input_templates_dir,"mom.input_data_list"), 'r') as input_data_list:
+        idl_data = input_data_list.read().replace('DIN_LOC_ROOT',din_loc_root)\
+                                         .replace('OCN_GRID',ocn_gridname)
+    with open(os.path.join(Buildconf,"mom.input_data_list"), 'w') as input_data_list:
+        input_data_list.write(idl_data)
 
 
 
@@ -85,7 +84,7 @@ def prep_input(case):
 ###############################################################################
 def buildnml(case, caseroot, compname):
 ###############################################################################
-    """Build the pop namelist """
+    """Build the MOM6 namelist """
 
     # Build the component namelist
     if compname != "mom":

--- a/input_templates/T62_g16/MOM_input
+++ b/input_templates/T62_g16/MOM_input
@@ -126,7 +126,7 @@ USE_IDEAL_AGE_TRACER = True     !   [Boolean] default = False
                                 ! If true, use the ideal_age_example tracer package.
 
 ! === module ideal_age_example ===
-INPUTDIR = "INPUT"              ! default = "."
+INPUTDIR = "DIN_LOC_ROOT"       ! default = "."
                                 ! The directory in which input files are found.
 COORD_CONFIG = "none"           !
                                 ! This specifies how layers are to be defined:

--- a/input_templates/T62_g16/diag_table
+++ b/input_templates/T62_g16/diag_table
@@ -1,4 +1,4 @@
-"MOM6 tx0.66v1 Experiment"
+"MOM6 CASENAME Experiment"
 1 1 1 0 0 0
 "CASENAME.mom6.prog.%4yr-%3dy",           5,"days",1,"days","Time",365,"days"
 "CASENAME.mom6.sfc.day.%4yr-%3dy",      1,"days",1,"days","Time",365,"days"

--- a/input_templates/T62_g16/mom.input_data_list
+++ b/input_templates/T62_g16/mom.input_data_list
@@ -1,0 +1,4 @@
+ocean_hgrid = DIN_LOC_ROOT/ocn/mom/OCN_GRID/ocean_hgrid.nc
+ocean_vgrid = DIN_LOC_ROOT/ocn/mom/OCN_GRID/ocean_vgrid.nc
+ocean_topog = DIN_LOC_ROOT/ocn/mom/OCN_GRID/ocean_topog.nc
+tempsalt = DIN_LOC_ROOT/ocn/mom/OCN_GRID/WOA05_pottemp_salt.nc

--- a/input_templates/T62_t061/MOM_input
+++ b/input_templates/T62_t061/MOM_input
@@ -126,7 +126,7 @@ USE_IDEAL_AGE_TRACER = True     !   [Boolean] default = False
                                 ! If true, use the ideal_age_example tracer package.
 
 ! === module ideal_age_example ===
-INPUTDIR = "INPUT"              ! default = "."
+INPUTDIR = "DIN_LOC_ROOT"       ! default = "."
                                 ! The directory in which input files are found.
 COORD_CONFIG = "none"           !
                                 ! This specifies how layers are to be defined:

--- a/input_templates/T62_t061/diag_table
+++ b/input_templates/T62_t061/diag_table
@@ -1,4 +1,4 @@
-"MOM6 tx0.66v1 Experiment"
+"MOM6 CASENAME Experiment"
 1 1 1 0 0 0
 "CASENAME.mom6.prog.%4yr-%3dy",           5,"days",1,"days","Time",365,"days"
 "CASENAME.mom6.sfc.day.%4yr-%3dy",      1,"days",1,"days","Time",365,"days"

--- a/input_templates/T62_t061/mom.input_data_list
+++ b/input_templates/T62_t061/mom.input_data_list
@@ -1,0 +1,4 @@
+ocean_hgrid = DIN_LOC_ROOT/ocn/mom/OCN_GRID/ocean_hgrid.nc
+ocean_vgrid = DIN_LOC_ROOT/ocn/mom/OCN_GRID/ocean_vgrid.nc
+ocean_topog = DIN_LOC_ROOT/ocn/mom/OCN_GRID/ocean_topog.nc
+tempsalt = DIN_LOC_ROOT/ocn/mom/OCN_GRID/WOA05_pottemp_salt.nc


### PR DESCRIPTION
A temporary fix for auto data export:
 - Instead of symbolically linking *nc files to rundir/INPUT, change INPUTDIR parameter in MOM_input to DIN_LOC_ROOT/ocn/mom/OCN_GRID.
 - generate mom.input_data_list during buildnml. this is necessary for CESM to automatically import the input files.
 - when ./case.submit is executed, input files are now automatically downloaded to DIN_LOC_ROOT. (users will need write permissions to DIN_LOC_ROOT).

Testing: SMS.T62_g16.CMOM on hobart. (successfully imported the data, and ran the case).

Note: This is a *temporary* fix. A more proper fix based on a CESM-like xml-based input handling is planned. 