### PR TITLE
checkout dev/cesm branch, instead of dev/ncar

### DIFF
--- a/Externals_MOM.cfg
+++ b/Externals_MOM.cfg
@@ -1,5 +1,5 @@
 [mom]
-branch = dev/ncar
+branch = dev/cesm
 protocol = git
 local_path = MOM6
 repo_url = https://github.com/NCAR/MOM6.git


### PR DESCRIPTION
Let checkout_externals check out NCAR/MOM6 dev/cesm branch instead of dev/ncar. dev/ncar branch has commits not compatible with CESM yet, which includes an older version of CVMix.

Testing: 5-day cmom on cheyenne/intel

Todo: create and specify NCAR/MOM6 tags in Externals.cfg, instead of branches.