### PR TITLE
Updates for tx0.66v1 and additional changes

### DIFF
--- a/cime_config/config_compsets.xml
+++ b/cime_config/config_compsets.xml
@@ -4,9 +4,9 @@
 
   <help>
     =========================================
-    compset naming convention 
+    compset naming convention
     =========================================
-    The compset longname below has the specified order 
+    The compset longname below has the specified order
     atm, lnd, ice, ocn, river, glc wave cesm-options
 
     The notation for the compset longname is
@@ -20,17 +20,17 @@
     ROF  = [RTM, SROF]
     GLC  = [CISM1, CISM2, SGLC]
     WAV  = [SWAV]
-    BGC  = optional BGC scenario 
+    BGC  = optional BGC scenario
 
     The OPTIONAL %phys attributes specify submodes of the given system
     For example DOCN%DOM is the data ocean model for DOCN
-    ALL the possible %phys choices for each component are listed 
+    ALL the possible %phys choices for each component are listed
     with the -list command for create_newcase
-    ALL data models must have a %phys option that corresponds to the data  model mode 
+    ALL data models must have a %phys option that corresponds to the data  model mode
 
     Each compset node is associated with the following elements
-    - lname      
-    - alias        
+    - lname
+    - alias
     - support  (optional description of the support level for this compset)
     Each compset node can also have the following attributes
     - grid  (optional regular expression match for grid to work with the compset)
@@ -39,90 +39,25 @@
   <!-- C compsets -->
 
   <compset>
-    <alias>CMOM</alias>    
-    <lname>2000_DATM%NYF_SLND_DICE%SSMI_MOM6_DROF%NYF_SGLC_WW3</lname>
+    <alias>CMOM</alias>
+    <lname>2000_DATM%NYF_SLND_DICE%SSMI_MOM6_DROF%NYF_SGLC_SWAV</lname>
   </compset>
 
   <compset>
-    <alias>CIAF</alias> 
-    <lname>2000_DATM%IAF_SLND_DICE%SIAF_POP2_DROF%IAF_SGLC_WW3</lname>
-  </compset>
-
-  <compset>
-    <alias>CECO</alias> 
-    <lname>1850_DATM%NYF_SLND_DICE%SSMI_POP2%ECO_DROF%NYF_SGLC_WW3</lname>
+    <alias>CMOM_IAF</alias>
+    <lname>2000_DATM%IAF_SLND_DICE%IAF_MOM6_DROF%IAF_SGLC_SWAV</lname>
   </compset>
 
   <!-- G compsets -->
 
   <compset>
-    <alias>G</alias>   
-    <lname>2000_DATM%NYF_SLND_CICE_POP2_DROF%NYF_SGLC_WW3</lname>
+    <alias>GMOM</alias>
+    <lname>2000_DATM%NYF_SLND_CICE_MOM6_DROF%NYF_SGLC_SWAV</lname>
   </compset>
 
   <compset>
-    <alias>GIAF</alias>
-    <lname>2000_DATM%IAF_SLND_CICE_POP2_DROF%IAF_SGLC_WW3</lname>
-  </compset>
-
-  <compset>
-    <alias>GECO</alias>
-    <lname>1850_DATM%NYF_SLND_CICE_POP2%ECO_DROF%NYF_SGLC_WW3</lname>
-  </compset>
-
-  <!-- Single Column POP -->
-
-  <compset>
-    <alias>C1D</alias>    
-    <lname>2000_DATM%NYF_SLND_DICE%SSMI_POP2%1D_DROF%NYF_SGLC_SWAV</lname>
-  </compset>
-
-  <compset>
-    <alias>C1DECO</alias> 
-    <lname>1850_DATM%NYF_SLND_DICE%SSMI_POP2%1D_POP2%ECO_DROF%NYF_SGLC_SWAV</lname>
-  </compset>
-
-  <compset>
-    <alias>G1D</alias>    
-    <lname>2000_DATM%NYF_SLND_CICE_POP2%1D_DROF%NYF_SGLC_SWAV</lname>
-  </compset>
-
-  <!-- Prognostic wave -->
-
-  <compset> 
-    <alias>C_WAV</alias>
-    <lname>2000_DATM%NYF_SLND_DICE%SSMI_POP2_DROF%NYF_SGLC_WW3</lname>
-  </compset>
-  <compset>
-    <alias>CIAF_WAV</alias>
-    <lname>2000_DATM%IAF_SLND_DICE%SIAF_POP2_DROF%IAF_SGLC_WW3</lname>
-  </compset>
-  <compset>
-    <alias>G_WAV</alias>
-    <lname>2000_DATM%NYF_SLND_CICE_POP2_DROF%NYF_SGLC_WW3</lname>
-  </compset>
-  <compset>
-    <alias>GIAF_WAV</alias>
-    <lname>2000_DATM%IAF_SLND_CICE_POP2_DROF%IAF_SGLC_WW3</lname>
-  </compset>
-
-  <!-- Data wave -->
-
-  <compset>
-    <alias>C_DWAV</alias>
-    <lname>2000_DATM%NYF_SLND_DICE%SSMI_POP2_DROF%NYF_SGLC_DWAV%COPY</lname>
-  </compset>
-  <compset>
-    <alias>CIAF_DWAV</alias>
-    <lname>2000_DATM%IAF_SLND_DICE%SIAF_POP2_DROF%IAF_SGLC_DWAV%COPY</lname>
-  </compset>
-  <compset>
-    <alias>G_DWAV</alias>
-    <lname>2000_DATM%NYF_SLND_CICE_POP2_DROF%NYF_SGLC_DWAV%COPY</lname>
-  </compset>
-  <compset>
-    <alias>GIAF_DWAV</alias>
-    <lname>2000_DATM%IAF_SLND_CICE_POP2_DROF%IAF_SGLC_DWAV%COPY</lname>
+    <alias>GMOM_IAF</alias>
+    <lname>2000_DATM%IAF_SLND_CICE_MOM6_DROF%IAF_SGLC_SWAV</lname>
   </compset>
 
 </compsets>

--- a/cime_config/testdefs/testlist_mom.xml
+++ b/cime_config/testdefs/testlist_mom.xml
@@ -1,18 +1,35 @@
 <?xml version="1.0"?>
 <testlist version="2.0">
-  <test name="SMS" grid="T62_g16" compset="CMOM">
+  <test name="SMS" grid="T62_g16" compset="CMOM_IAF">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="prealpha">
+      <machine name="cheyenne" compiler="intel" category="aux_mom">
         <options>
           <option name="wallclock">00:30:00</option>
         </options>
       </machine>
-      <machine name="hobart" compiler="intel" category="prealpha">
+      <machine name="hobart" compiler="intel" category="aux_mom">
         <options>
           <option name="wallclock">00:30:00</option>
         </options>
       </machine>
     </machines>
   </test>
-
+  <test name="SMS" grid="T62_t061" compset="CMOM_IAF">
+    <machines>
+      <machine name="cheyenne" compiler="intel" category="aux_mom">
+        <options>
+          <option name="wallclock">00:30:00</option>
+        </options>
+      </machine>
+    </machines>
+  </test>
+  <test name="ERS" grid="T62_g16" compset="GMOM">
+    <machines>
+      <machine name="cheyenne" compiler="intel" category="aux_mom">
+        <options>
+          <option name="wallclock">00:30:00</option>
+        </options>
+      </machine>
+    </machines>
+  </test>
 </testlist>

--- a/input_templates/T62_t061/MOM_input
+++ b/input_templates/T62_t061/MOM_input
@@ -175,11 +175,14 @@ TOPO_CONFIG = "file"            !
                                 !     USER - call a user modified routine.
 MAXIMUM_DEPTH = 6000.0          !   [m]
                                 ! The maximum depth of the ocean.
-MINIMUM_DEPTH = 0.5             !   [m] default = 0.0
+MINIMUM_DEPTH = 9.5             !   [m] default = 0.0
                                 ! If MASKING_DEPTH is unspecified, then anything shallower than
                                 ! MINIMUM_DEPTH is assumed to be land and all fluxes are masked out.
                                 ! If MASKING_DEPTH is specified, then all depths shallower than
                                 ! MINIMUM_DEPTH but depper than MASKING_DEPTH are rounded to MINIMUM_DEPTH.
+MASKING_DEPTH = 0.0             !   [m] default = -9999.0
+                                ! The depth below which to mask points as land points, for which all
+                                ! fluxes are zeroed out. MASKING_DEPTH is ignored if negative.
 CHANNEL_CONFIG = "none"         ! default = "none"
                                 ! A parameter that determines which set of channels are
                                 ! restricted to specific  widths.  Options are:


### PR DESCRIPTION
- Update the _DEPTH parameters of tx0.66v1 grid.
- add the "aux_mom" test suite.
- remove POP2 compsets.
- replace WW3 with SWAV in GMOM and CMOM compsets.
- add GMOM_IAF and CMOM_IAF compsets.
