### PR TITLE
For test cases, set the frequency of history files to be daily

### DIFF
--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -82,11 +82,11 @@ def prep_input(case):
                         line = line[:-2] + "1\n"
                 # this changes output frequency and number of records per file
                 # using HIST_N and HIST_OPTION from case
-                if line.startswith("\""+casename):
+                if line.startswith("\""+casename) and testcase:
                     parts = line.split(',')
-                    parts[1] = "{}".format(hist_n)
-                    parts[2] = "\""+hist_option+"\""
                     if len(parts) > 7:
+                        parts[1] = "1"
+                        parts[2] = "days"
                         parts[6] = parts[1]
                         parts[7] = parts[2]
                     line = ','.join(parts)+"\n"

--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -80,16 +80,16 @@ def prep_input(case):
                     # this makes all real fields double precision
                     if line.endswith('2\n'):
                         line = line[:-2] + "1\n"
-                # this changes output frequency and number of records per file
-                # using HIST_N and HIST_OPTION from case
-                if line.startswith("\""+casename) and testcase:
-                    parts = line.split(',')
-                    if len(parts) > 7:
-                        parts[1] = "1"
-                        parts[2] = "days"
-                        parts[6] = parts[1]
-                        parts[7] = parts[2]
-                    line = ','.join(parts)+"\n"
+                    # this changes output frequency and number of records per file
+                    # using HIST_N and HIST_OPTION from case
+                    if line.startswith("\""+casename):
+                        parts = line.split(',')
+                        if len(parts) > 7:
+                            parts[1] = "1"
+                            parts[2] = "days"
+                            parts[6] = parts[1]
+                            parts[7] = parts[2]
+                        line = ','.join(parts)+"\n"
                 diag_table.writelines(line)
 
 


### PR DESCRIPTION
ERS runs may have unaligned runtimes (where base is 11 days and rest is 5+6 days). For FMS-controlled history files, this means the latest history files of base and rest runs do not cover the same timespans. The easiest fix is to output the history files daily, so when cprnc compares the latest files from both runs, the comparison will always be the latest day from both runs (e.g. 11.th day from both runs, as opposed to days 10-11 of base vs days 6-11 of rest).
