### PR TITLE
Removes unneeded options and updates default parametes

### DIFF
--- a/input_templates/tx0.66v1/MOM_input
+++ b/input_templates/tx0.66v1/MOM_input
@@ -471,9 +471,6 @@ DEPTH_MIN_DYN_PSURF = 1.0       !   [m] default = 1.0E-06
                                 ! The minimum depth to use in limiting the size of the
                                 ! dynamic surface pressure for stability, if
                                 ! DYNAMIC_SURFACE_PRESSURE is true.
-USE_RIGID_SEA_ICE = True        !   [Boolean] default = False
-                                ! If true, sea-ice is rigid enough to exert a
-                                ! nonhydrostatic pressure that resist vertical motion.
 ! === module MOM_thickness_diffuse ===
 KHTH = 800.0                    !   [m2 s-1] default = 0.0
                                 ! The background horizontal thickness diffusivity.

--- a/input_templates/tx0.66v1/MOM_input
+++ b/input_templates/tx0.66v1/MOM_input
@@ -210,17 +210,6 @@ MINIMUM_DEPTH = 9.5             !   [m] default = 0.0
 MASKING_DEPTH = 0.0             !   [m] default = -9999.0
                                 ! The depth below which to mask points as land points, for which all
                                 ! fluxes are zeroed out. MASKING_DEPTH is ignored if negative.
-CHANNEL_CONFIG = "none"         ! default = "none"
-                                ! A parameter that determines which set of channels are
-                                ! restricted to specific  widths.  Options are:
-                                !     none - All channels have the grid width.
-                                !     global_1deg - Sets 16 specific channels appropriate
-                                !       for a 1-degree model, as used in CM2G.
-                                !     list - Read the channel locations and widths from a
-                                !       text file, like MOM_channel_list in the MOM_SIS
-                                !       test case.
-                                !     file - Read open face widths everywhere from a
-                                !       NetCDF file on the model grid.
 REMAPPING_SCHEME = "PPM_H4"     ! default = "PLM"
                                 ! This sets the reconstruction scheme used
                                 ! for vertical remapping for all variables.
@@ -269,22 +258,12 @@ USE_STORED_SLOPES = True        !   [Boolean] default = False
                                 ! If true, the isopycnal slopes are calculated once and
                                 ! stored for re-use. This uses more memory but avoids calling
                                 ! the equation of state more times than should be necessary.
-VISC_RES_FN_POWER = 100         !   [nondim] default = 100
-                                ! The power of dx/Ld in the Kh resolution function.  Any
-                                ! positive integer may be used, although even integers
-                                ! are more efficient to calculate.  Setting this greater
-                                ! than 100 results in a step-function being used.
-                                ! This function affects lateral viscosity, Kh, and not KhTh.
 ! === module MOM_set_visc ===
 CHANNEL_DRAG = True             !   [Boolean] default = False
                                 ! If true, the bottom drag is exerted directly on each
                                 ! layer proportional to the fraction of the bottom it
                                 ! overlies.
 ! === module MOM_continuity ===
-VELOCITY_TOLERANCE = 3.0E+08    !   [m s-1] default = 3.0E+08
-                                ! The tolerance for barotropic velocity discrepancies
-                                ! between the barotropic solution and  the sum of the
-                                ! layer thicknesses.
 ETA_TOLERANCE = 1.0E-06         !   [m] default = 3.15E-09
                                 ! The tolerance for the differences between the
                                 ! barotropic and baroclinic estimates of the sea surface
@@ -292,12 +271,6 @@ ETA_TOLERANCE = 1.0E-06         !   [m] default = 3.15E-09
                                 ! tolerance for SSH is 4 times this value.  The default
                                 ! is 0.5*NK*ANGSTROM, and this should not be set less x
                                 ! than about 10^-15*MAXIMUM_DEPTH.
-ETA_TOLERANCE_AUX = 0.001       !   [m] default = 1.0E-06
-                                ! The tolerance for free-surface height discrepancies
-                                ! between the barotropic solution and the sum of the
-                                ! layer thicknesses when calculating the auxiliary
-                                ! corrected velocities. By default, this is the same as
-                                ! ETA_TOLERANCE, but can be made larger for efficiency.
 ! === module MOM_neutral_diffusion ===
 ! This module implements neutral diffusion of tracers
 USE_NEUTRAL_DIFFUSION = True    !   [Boolean] default = False
@@ -361,6 +334,8 @@ MASS_WEIGHT_IN_PRESSURE_GRADIENT = True !   [Boolean] default = False
 ! === module MOM_hor_visc ===
 LAPLACIAN = True                !   [Boolean] default = False
                                 ! If true, use a Laplacian horizontal viscosity.
+KH = 1000.0                     !   [m2 s-1] default = 0.0
+                                ! The background Laplacian horizontal viscosity.
 KH_VEL_SCALE = 0.01             !   [m s-1] default = 0.0
                                 ! The velocity scale which is multiplied by the grid
                                 ! spacing to calculate the Laplacian viscosity.
@@ -377,19 +352,6 @@ AH_VEL_SCALE = 0.01             !   [m s-1] default = 0.0
                                 ! the grid spacing to calculate the Laplacian viscosity.
                                 ! The final viscosity is the largest of this scaled
                                 ! viscosity, the Smagorinsky viscosity and AH.
-SMAGORINSKY_KH = True           !   [Boolean] default = False
-                                ! If true, use a Smagorinsky nonlinear eddy viscosity.
-SMAG_LAP_CONST = 0.15           !   [nondim] default = 0.0
-                                ! The nondimensional Laplacian Smagorinsky constant,
-                                ! often 0.15.
-
-SMAGORINSKY_AH = True           !   [Boolean] default = False
-                                ! If true, use a biharmonic Smagorinsky nonlinear eddy
-                                ! viscosity.
-SMAG_BI_CONST = 0.06            !   [nondim] default = 0.0
-                                ! The nondimensional biharmonic Smagorinsky constant,
-                                ! typically 0.015 - 0.06.
-
 ! === module MOM_vert_friction ===
 HMIX_FIXED = 0.5                !   [m]
                                 ! The prescribed depth over which the near-surface
@@ -418,12 +380,6 @@ V_TRUNC_FILE = "V_velocity_truncations" ! default = ""
 KV = 1.0E-04                    !   [m2 s-1]
                                 ! The background kinematic viscosity in the interior.
                                 ! The molecular value, ~1e-6 m2 s-1, may be used.
-ADD_KV_SLOW = False             !   [Boolean] default = False
-                                ! If true, the background vertical viscosity in the interior
-                                ! (i.e., tidal + background + shear + convenction) is addded
-                                ! when computing the coupling coefficient. The purpose of this
-                                ! flag is to be able to recover previous answers and it will likely
-                                ! be removed in the future since this option should always be true.
 HBBL = 10.0                     !   [m]
                                 ! The thickness of a bottom boundary layer with a
                                 ! viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or
@@ -566,13 +522,15 @@ MLE_MLD_DECAY_TIME = 2.592E+06  !   [s] default = 0.0
                                 ! depth used in the MLE restratification parameterization. When
                                 ! the MLD deepens below the current running-mean the running-mean
                                 ! is instantaneously set to the current MLD.
+! === module MOM_CVMix_conv ===
+! Parameterization of enhanced mixing due to convection via CVMix
+USE_CVMix_CONVECTION = True     !   [Boolean] default = False
+                                ! If true, turns on the enhanced mixing due to convection
+                                ! via CVMix. This scheme increases diapycnal diffs./viscs.
+                                !  at statically unstable interfaces. Relevant parameters are
+                                ! contained in the CVMix_CONVECTION% parameter block.
 ! === module MOM_diabatic_driver ===
 ! The following parameters are used for diabatic processes.
-USE_CVMix_CONVECTION = True     !
-ENERGETICS_SFC_PBL = False      !   [Boolean] default = False
-                                ! If true, use an implied energetics planetary boundary
-                                ! layer scheme to determine the diffusivity and viscosity
-                                ! in the surface boundary layer.
 BBL_MIXING_AS_MAX = False       !   [Boolean] default = True
                                 ! If true, take the maximum of the diffusivity from the
                                 ! BBL mixing and the other diffusivities. Otherwise,
@@ -650,9 +608,6 @@ INT_TIDE_DISSIPATION = True     !   [Boolean] default = False
                                 ! If true, use an internal tidal dissipation scheme to
                                 ! drive diapycnal mixing, along the lines of St. Laurent
                                 ! et al. (2002) and Simmons et al. (2004).
-READ_TIDEAMP = False            !   [Boolean] default = False
-                                ! If true, read a file (given by TIDEAMP_FILE) containing
-                                ! the tidal amplitude with INT_TIDE_DISSIPATION.
 TIDAL_ENERGY_FILE = "energy_new_t0.66v1_conserve_180608.nc" !
                                 ! The path to the file containing tidal energy
                                 ! dissipation. Used with CVMix tidal mixing schemes.
@@ -703,14 +658,6 @@ HMIX_MIN = 2.0                  !   [m] default = 0.0
 ! === module MOM_regularize_layers ===
 
 ! === module MOM_opacity ===
-VAR_PEN_SW = False              !   [Boolean] default = False
-                                ! If true, use one of the CHL_A schemes specified by
-                                ! OPACITY_SCHEME to determine the e-folding depth of
-                                ! incoming short wave radiation.
-                                ! CHL_FILE is the file containing chl_a concentrations in
-                                ! the variable CHL_A. It is used when VAR_PEN_SW and
-                                ! CHL_FROM_FILE are true.
-                                ! The number of bands of penetrating shortwave radiation.
 PEN_SW_SCALE = 15.0             !   [m] default = 0.0
                                 ! The vertical absorption e-folding depth of the
                                 ! penetrating shortwave radiation.
@@ -746,58 +693,6 @@ MAX_TR_DIFFUSION_CFL = 2.0      !   [nondim] default = -1.0
                                 ! diffusivity to keep the diffusive CFL locally at or
                                 ! below this value.  The number of diffusive iterations
                                 ! is often this value or the next greater integer.
-! === module MOM_surface_forcing ===
-BUOY_CONFIG = "file"            !
-                                ! The character string that indicates how buoyancy forcing
-                                ! is specified. Valid options include (file), (zero),
-                                ! (linear), (USER), and (NONE).
-ARCHAIC_OMIP_FORCING_FILE = False !   [Boolean] default = True
-                                ! If true, use the forcing variable decomposition from
-                                ! the old German OMIP prescription that predated CORE. If
-                                ! false, use the variable groupings available from MOM
-                                ! output diagnostics of forcing variables.
-LONGWAVE_FILE = "ocean_forcing_daily.nc" !
-                                ! The file with the longwave heat flux, in the variable
-                                ! given by LONGWAVE_FORCING_VAR.
-SHORTWAVE_FILE = "ocean_forcing_daily.nc" !
-                                ! The file with the shortwave heat flux, in the variable
-                                ! given by SHORTWAVE_FORCING_VAR.
-EVAPORATION_FILE = "ocean_forcing_daily.nc" !
-                                ! The file with the evaporative moisture flux, in the
-                                ! variable given by EVAP_FORCING_VAR.
-LATENTHEAT_FILE = "ocean_forcing_daily.nc" !
-                                ! The file with the latent heat flux, in the variable
-                                ! given by LATENT_FORCING_VAR.
-SENSIBLEHEAT_FILE = "ocean_forcing_daily.nc" !
-                                ! The file with the sensible heat flux, in the variable
-                                ! given by SENSIBLE_FORCING_VAR.
-RAIN_FILE = "ocean_precip_monthly.nc" !
-                                ! The file with the liquid precipitation flux, in the
-                                ! variable given by RAIN_FORCING_VAR.
-SNOW_FILE = "ocean_precip_monthly.nc" !
-                                ! The file with the frozen precipitation flux, in the
-                                ! variable given by SNOW_FORCING_VAR.
-RUNOFF_FILE = "ocean_precip_monthly.nc" !
-                                ! The file with the fresh and frozen runoff/calving
-                                ! fluxes, in variables given by LIQ_RUNOFF_FORCING_VAR
-                                ! and FROZ_RUNOFF_FORCING_VAR.
-SSTRESTORE_FILE = "ocean_forcing_daily.nc" !
-                                ! The file with the SST toward which to restore in the
-                                ! variable given by SST_RESTORE_VAR.
-SALINITYRESTORE_FILE = "ocean_forcing_daily.nc" !
-                                ! The file with the surface salinity toward which to
-                                ! restore in the variable given by SSS_RESTORE_VAR.
-WIND_CONFIG = "file"            !
-                                ! The character string that indicates how wind forcing
-                                ! is specified. Valid options include (file), (2gyre),
-                                ! (1gyre), (gyres), (zero), and (USER).
-WIND_FILE = "ocean_forcing_daily.nc" !
-                                ! The file in which the wind stresses are found in
-                                ! variables STRESS_X and STRESS_Y.
-WINDSTRESS_X_VAR = "taux"       ! default = "STRESS_X"
-                                ! The name of the x-wind stress variable in WIND_FILE.
-WINDSTRESS_Y_VAR = "tauy"       ! default = "STRESS_Y"
-                                ! The name of the y-wind stress variable in WIND_FILE.
 ! === module MOM_sum_output ===
 MAXTRUNC = 5000                 !   [truncations save_interval-1] default = 0
                                 ! The run will be stopped, and the day set to a very
@@ -848,7 +743,7 @@ RESTINT = 365.0                 !   [days] default = 0.0
                                 ! The interval between saves of the restart file in units
                                 ! of TIMEUNIT.  Use 0 (the default) to not save
                                 ! incremental restart files at all.
-ENERGYSAVEDAYS = 30.0           !   [days] default = 1.0
+ENERGYSAVEDAYS = 0.5            !   [days] default = 1.0
                                 ! The interval in units of TIMEUNIT between saves of the
                                 ! energies of the run and other globally summed diagnostics.
 ENERGYSAVEDAYS_GEOMETRIC = 0.25 !   [days] default = 0.0

--- a/input_templates/tx0.66v1/MOM_input
+++ b/input_templates/tx0.66v1/MOM_input
@@ -344,11 +344,9 @@ KH_SIN_LAT = 2000.0             !   [m2 s-1] default = 0.0
 KH_PWR_OF_SINE = 4.0            !   [nondim] default = 4.0
                                 ! The power used to raise SIN(LAT) when using a latidutinally-
                                 ! dependent background viscosity.
-AH_VEL_SCALE = 0.01             !   [m s-1] default = 0.0
-                                ! The velocity scale which is multiplied by the cube of
-                                ! the grid spacing to calculate the Laplacian viscosity.
-                                ! The final viscosity is the largest of this scaled
-                                ! viscosity, the Smagorinsky viscosity and AH.
+BIHARMONIC = False              !   [Boolean] default = True
+                                ! If true, use a biharmonic horizontal viscosity.
+                                ! BIHARMONIC may be used with LAPLACIAN.
 ! === module MOM_vert_friction ===
 HMIX_FIXED = 0.5                !   [m]
                                 ! The prescribed depth over which the near-surface

--- a/input_templates/tx0.66v1/MOM_input
+++ b/input_templates/tx0.66v1/MOM_input
@@ -143,10 +143,6 @@ SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
                                 ! If true, write the initial conditions to a file given
                                 ! by IC_OUTPUT_FILE.
 ! === module MOM_tracer_registry ===
-TFREEZE_DP = -7.75E-08         !   [deg C Pa-1] default = 0.0
-                                ! When TFREEZE_FORM=LINEAR,
-                                ! this is the derivative of the freezing potential
-                                ! temperature with pressure.
 DTFREEZE_DP = -7.75E-08         !   [deg C Pa-1] default = 0.0
                                 ! When TFREEZE_FORM=LINEAR,
                                 ! this is the derivative of the freezing potential

--- a/input_templates/tx0.66v1/MOM_input
+++ b/input_templates/tx0.66v1/MOM_input
@@ -247,9 +247,6 @@ RESOLN_SCALED_KH = True         !   [Boolean] default = False
 KHTH_USE_EBT_STRUCT = True      !   [Boolean] default = False
                                 ! If true, uses the equivalent barotropic structure
                                 ! as the vertical structure of thickness diffusivity.
-KHTR_SLOPE_CFF = 0.25           !   [nondim] default = 0.0
-                                ! The nondimensional coefficient in the Visbeck formula
-                                ! for the epipycnal tracer diffusivity
 RESOLN_SCALED_KHTH = True       !   [Boolean] default = False
                                 ! If true, the interface depth diffusivity is scaled away
                                 ! when the first baroclinic deformation radius is well

--- a/input_templates/tx0.66v1/MOM_input
+++ b/input_templates/tx0.66v1/MOM_input
@@ -668,7 +668,7 @@ TRACER_ADVECTION_SCHEME = "PPM:H3" ! default = "PLM"
                                 !   PPM:H3 - Piecewise Parabolic Method (Huyhn 3rd order)
 
 ! === module MOM_tracer_hor_diff ===
-KHTR = 75.0                     !   [m2 s-1] default = 0.0
+KHTR = 800.0                     !   [m2 s-1] default = 0.0
                                 ! The background along-isopycnal tracer diffusivity.
 KHTR_MIN = 50.0                 !   [m2 s-1] default = 0.0
                                 ! The minimum along-isopycnal tracer diffusivity.

--- a/input_templates/tx0.66v1/MOM_input
+++ b/input_templates/tx0.66v1/MOM_input
@@ -470,9 +470,6 @@ DTBT = -0.95                    !   [s or nondim] default = -0.98
                                 ! Setting DTBT to 0 is the same as setting it to -0.98.
                                 ! The value of DTBT that will actually be used is an
                                 ! integer fraction of DT, rounding down.
-DYNAMIC_SURFACE_PRESSURE = True !   [Boolean] default = False
-                                ! If true, add a dynamic pressure due to a viscous ice
-                                ! shelf, for instance.
 DEPTH_MIN_DYN_PSURF = 1.0       !   [m] default = 1.0E-06
                                 ! The minimum depth to use in limiting the size of the
                                 ! dynamic surface pressure for stability, if


### PR DESCRIPTION
This PR removes unneeded MOM_input parameters (ie., parameters that were set to the MOM6 default value). It also updates the following:
* DYNAMIC_SURFACE_PRESSURE = False
* KHTR_SLOPE_CFF=0.0 (needed to close surface heat balance)
* USE_RIGID_SEA_ICE = False
* KHTR = 800.0
* BIHARMONIC = False

**TODO**
Once different files are used for C and G cases, enable following option for G-case:
USE_RIGID_SEA_ICE = True       !   [Boolean] default = False
                                ! If true, sea-ice is rigid enough to exert a
                                ! nonhydrostatic pressure that resist vertical motion.