### PR TITLE
Remove salinity restoring from fully-coupled (B) cases

### DIFF
--- a/input_templates/tx0.66v1/B/MOM_input
+++ b/input_templates/tx0.66v1/B/MOM_input
@@ -703,7 +703,7 @@ OCEAN_SURFACE_STAGGER = "A"     ! default = "C"
                                 ! staggering of the surface velocity field that is
                                 ! returned to the coupler.  Valid values include
                                 ! 'A', 'B', or 'C'.
-RESTORE_SALINITY = True         !   [Boolean] default = False
+RESTORE_SALINITY = False        !   [Boolean] default = False
                                 ! If true, the coupled driver will add a globally-balanced
                                 ! fresh-water flux that drives sea-surface salinity
                                 ! toward specified values.


### PR DESCRIPTION
No restoring should be used in fully-coupled simulations. This PR sets RESTORE_SALINITY = False in input_templates/tx0.66v1/B/MOM_input .
