### PR TITLE
Add JRA forced compsets and update buildlib 

### DIFF
--- a/cime_config/buildlib
+++ b/cime_config/buildlib
@@ -16,6 +16,7 @@ from standard_script_setup import *
 from CIME.buildlib import parse_input
 from CIME.case import Case
 from CIME.utils import run_cmd, expect
+from CIME.build import get_standard_makefile_args
 
 logger = logging.getLogger(__name__)
 
@@ -64,9 +65,10 @@ def buildlib(caseroot, libroot, bldroot):
         #-------------------------------------------------------
         sharedlibroot = case.get_value("SHAREDLIBROOT")
 
-        incroot = " -I " + os.path.join(srcroot,"libraries","FMS","src","include") + \
-                  " -I " + os.path.join(srcroot,"libraries","FMS","src","mpp","include") + \
-                  " -I " + fmsbuilddir
+        user_incldir = "\"-I{} -I{} -I{}\"".\
+                        format(os.path.join(srcroot,"libraries","FMS","src","include"),
+                               os.path.join(srcroot,"libraries","FMS","src","mpp","include"),
+                               fmsbuilddir)
         filepath_file = os.path.join(bldroot,"Filepath")
         if not os.path.isfile(filepath_file):
 #todo: are these needed in mom or only for fms?
@@ -107,7 +109,8 @@ def buildlib(caseroot, libroot, bldroot):
         # build the library
         makefile = os.path.join(casetools, "Makefile")
         complib = os.path.join(libroot,"libocn.a")
-        cmd = "{} complib -j {} MODEL=mom COMPLIB={} -f {} INCROOT=\"{}\"" .format(gmake, gmake_j, complib, makefile, incroot)
+        cmd = "{} complib -j {} MODEL=mom COMPLIB={} -f {} USER_INCLDIR={} {}"\
+                .format(gmake, gmake_j, complib, makefile, user_incldir, get_standard_makefile_args(case))
 
         rc, out, err = run_cmd(cmd)
         logger.info("%s: \n\n output:\n %s \n\n err:\n\n%s\n"%(cmd,out,err))

--- a/cime_config/config_compsets.xml
+++ b/cime_config/config_compsets.xml
@@ -48,6 +48,11 @@
     <lname>2000_DATM%IAF_SLND_DICE%IAF_MOM6_DROF%IAF_SGLC_SWAV</lname>
   </compset>
 
+  <compset>
+    <alias>CMOM_JRA</alias>
+    <lname>2000_DATM%JRA_SLND_DICE%SSMI_MOM6_DROF%JRA_SGLC_SWAV</lname>
+  </compset>
+
   <!-- G compsets -->
 
   <compset>
@@ -58,6 +63,11 @@
   <compset>
     <alias>GMOM_IAF</alias>
     <lname>2000_DATM%IAF_SLND_CICE_MOM6_DROF%IAF_SGLC_SWAV</lname>
+  </compset>
+
+  <compset>
+    <alias>GMOM_JRA</alias>
+    <lname>2000_DATM%JRA_SLND_CICE_MOM6_DROF%JRA_SGLC_SWAV</lname>
   </compset>
 
   <!-- Ocean-Only compsets -->


### PR DESCRIPTION
To run JRA:

- pull the latest CIME (altuntas/MOM6_mct) 
- and latest CICE (master)

- To create a C case:
create_newcase --res TL319_t061 --compset CMOM_JRA --run-unsupported --case c.e20.CMOM_JRA.TL319_t061.test_jra.001

- To create a G case:
create_newcase --res TL319_t061 --compset GMOM_JRA --run-unsupported --case g.e20.GMOM_JRA.TL319_t061.test_jra.001