### PR TITLE
Build MARBL as part of MOM6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,11 @@
+# Externals
+MOM6/
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]
+cime_config/buildnmlc
+cime_config/buildlibc
 *$py.class
 
 # C extensions

--- a/cime_config/buildlib
+++ b/cime_config/buildlib
@@ -37,6 +37,7 @@ def buildlib(caseroot, libroot, bldroot):
             expect(stat==0, "FMS build Failed {}".format(err))
 
         # Find CVMix source code, which might be in several different locations
+        logger.info("Looking for CVMix source code...")
         # (1) If $CESMROOT/libraries/CVMix exists, build that copy
         cvmix_srcdir = os.path.join(srcroot,"libraries","CVMix","src","shared")
         # (2) Otherwise, look for CVMix in the POP component
@@ -48,9 +49,10 @@ def buildlib(caseroot, libroot, bldroot):
         # If none of those exist, abort
         if not os.path.exists(cvmix_srcdir):
             expect(False, "CVMix external not found")
-        logger.info("Building CVMix with source from {}".format(cvmix_srcdir))
+        logger.info("... CVMix will be built with source from {}\n".format(cvmix_srcdir))
 
         # Find MARBL source code, which might be in several different locations
+        logger.info("Looking for MARBL source code...")
         # (1) If $CESMROOT/libraries/MARBL exists, build that copy
         marbl_srcdir = os.path.join(srcroot,"libraries","MARBL","src")
         # (2) Otherwise, look for MARBL in the POP component
@@ -62,7 +64,7 @@ def buildlib(caseroot, libroot, bldroot):
         # If none of those exist, abort
         if not os.path.exists(marbl_srcdir):
             expect(False, "MARBL external not found")
-        logger.info("Building MARBL with source from {}".format(marbl_srcdir))
+        logger.info("... MARBL will be built with source from {}\n".format(marbl_srcdir))
 
         casetools = case.get_value("CASETOOLS")
         gmake_j = case.get_value("GMAKE_J")

--- a/cime_config/buildlib
+++ b/cime_config/buildlib
@@ -31,7 +31,7 @@ def buildlib(caseroot, libroot, bldroot):
         fmsbuilddir = os.path.join(bldroot,"FMS")
         if not os.path.exists(fmsbuildlib):
             #todo: call checkout_externals to get this component
-            raise FileNotFoundError("FMS external not found")
+            raise RuntimeError("FMS external not found")
         else:
             stat, _, err = run_cmd("{} {} {} {}".format(fmsbuildlib, bldroot, fmsbuilddir, caseroot), verbose=True)
             expect(stat==0, "FMS build Failed {}".format(err))
@@ -47,7 +47,7 @@ def buildlib(caseroot, libroot, bldroot):
             cvmix_srcdir = os.path.join(srcroot,"components","mom","MOM6","pkg","CVMix-src","src","shared")
         # If none of those exist, abort
         if not os.path.exists(cvmix_srcdir):
-            raise FileNotFoundError("CVMix external not found")
+            raise RuntimeError("CVMix external not found")
         logger.info("Building CVMix with source from {}".format(cvmix_srcdir))
 
         # Find MARBL source code, which might be in several different locations
@@ -61,7 +61,7 @@ def buildlib(caseroot, libroot, bldroot):
             marbl_srcdir = os.path.join(srcroot,"components","mom","MOM6","pkg","MARBL","src")
         # If none of those exist, abort
         if not os.path.exists(marbl_srcdir):
-            raise FileNotFoundError("MARBL external not found")
+            raise RuntimeError("MARBL external not found")
         logger.info("Building MARBL with source from {}".format(marbl_srcdir))
 
         casetools = case.get_value("CASETOOLS")

--- a/cime_config/buildlib
+++ b/cime_config/buildlib
@@ -31,29 +31,38 @@ def buildlib(caseroot, libroot, bldroot):
         fmsbuilddir = os.path.join(bldroot,"FMS")
         if not os.path.exists(fmsbuildlib):
             #todo: call checkout_externals to get this component
-            expect(False, "FMS external not found")
+            raise FileNotFoundError("FMS external not found")
         else:
             stat, _, err = run_cmd("{} {} {} {}".format(fmsbuildlib, bldroot, fmsbuilddir, caseroot), verbose=True)
             expect(stat==0, "FMS build Failed {}".format(err))
 
-        # todo:  Need to do the same with CVMix, for now I'm just pointing to the cvmix in pop
-        momcvmix = os.path.join(srcroot,"components","mom","MOM6","pkg","CVMix-src")
-        popcvmix = os.path.join(srcroot,"components","pop","externals","CVMix")
-        tlcvmix = os.path.join(srcroot,"libraries","CVMix")
-        if os.path.exists(popcvmix):
-            cvmixdir = popcvmix
-        else:
-            cvmixdir = tlcvmix
+        # Find CVMix source code, which might be in several different locations
+        # (1) If $CESMROOT/libraries/CVMix exists, build that copy
+        cvmix_srcdir = os.path.join(srcroot,"libraries","CVMix","src","shared")
+        # (2) Otherwise, look for CVMix in the POP component
+        if not os.path.exists(cvmix_srcdir):
+            cvmix_srcdir = os.path.join(srcroot,"components","pop","externals","CVMix","src","shared")
+        # (3) Lastly, look for the CVMix submodule in MOM6
+        if not os.path.exists(cvmix_srcdir):
+            cvmix_srcdir = os.path.join(srcroot,"components","mom","MOM6","pkg","CVMix-src","src","shared")
+        # If none of those exist, abort
+        if not os.path.exists(cvmix_srcdir):
+            raise FileNotFoundError("CVMix external not found")
+        logger.info("Building CVMix with source from {}".format(cvmix_srcdir))
 
-        if not os.path.exists(os.path.join(momcvmix,"bin")):
-            expect(os.path.exists(cvmixdir) or os.path.exists(tlcvmix), "Could not find CVMix in {} or {}"
-                   .format(cvmixdir, tlcvmix))
-
-            for _dir in glob.iglob(os.path.join(cvmixdir,"*")):
-                dst = os.path.join(momcvmix,os.path.basename(_dir))
-                logger.info("link {} to {}".format(_dir,dst))
-                if not os.path.exists(dst):
-                    os.symlink(_dir,dst)
+        # Find MARBL source code, which might be in several different locations
+        # (1) If $CESMROOT/libraries/MARBL exists, build that copy
+        marbl_srcdir = os.path.join(srcroot,"libraries","MARBL","src")
+        # (2) Otherwise, look for MARBL in the POP component
+        if not os.path.exists(marbl_srcdir):
+            marbl_srcdir = os.path.join(srcroot,"components","pop","externals","MARBL","src")
+        # (3) Lastly, look for the MARBL submodule in MOM6
+        if not os.path.exists(marbl_srcdir):
+            marbl_srcdir = os.path.join(srcroot,"components","mom","MOM6","pkg","MARBL","src")
+        # If none of those exist, abort
+        if not os.path.exists(marbl_srcdir):
+            raise FileNotFoundError("MARBL external not found")
+        logger.info("Building MARBL with source from {}".format(marbl_srcdir))
 
         casetools = case.get_value("CASETOOLS")
         gmake_j = case.get_value("GMAKE_J")
@@ -88,7 +97,8 @@ def buildlib(caseroot, libroot, bldroot):
                      os.path.join(srcroot,"components","mom","MOM6","src","ocean_data_assim"),
                      os.path.join(srcroot,"components","mom","MOM6","src","ocean_data_assim", "core"),
                      os.path.join(srcroot,"components","mom","MOM6","src","ocean_data_assim", "geoKdTree"),
-                     os.path.join(srcroot,"components","mom","MOM6","src","parameterizations","CVmix"),
+                     cvmix_srcdir,
+                     marbl_srcdir,
                      os.path.join(srcroot,"components","mom","MOM6","src","parameterizations","lateral"),
                      os.path.join(srcroot,"components","mom","MOM6","src","parameterizations","vertical"),
                      os.path.join(srcroot,"components","mom","MOM6","src","tracer"),

--- a/cime_config/buildlib
+++ b/cime_config/buildlib
@@ -31,7 +31,7 @@ def buildlib(caseroot, libroot, bldroot):
         fmsbuilddir = os.path.join(bldroot,"FMS")
         if not os.path.exists(fmsbuildlib):
             #todo: call checkout_externals to get this component
-            raise RuntimeError("FMS external not found")
+            expect(False, "FMS external not found")
         else:
             stat, _, err = run_cmd("{} {} {} {}".format(fmsbuildlib, bldroot, fmsbuilddir, caseroot), verbose=True)
             expect(stat==0, "FMS build Failed {}".format(err))
@@ -47,7 +47,7 @@ def buildlib(caseroot, libroot, bldroot):
             cvmix_srcdir = os.path.join(srcroot,"components","mom","MOM6","pkg","CVMix-src","src","shared")
         # If none of those exist, abort
         if not os.path.exists(cvmix_srcdir):
-            raise RuntimeError("CVMix external not found")
+            expect(False, "CVMix external not found")
         logger.info("Building CVMix with source from {}".format(cvmix_srcdir))
 
         # Find MARBL source code, which might be in several different locations
@@ -61,7 +61,7 @@ def buildlib(caseroot, libroot, bldroot):
             marbl_srcdir = os.path.join(srcroot,"components","mom","MOM6","pkg","MARBL","src")
         # If none of those exist, abort
         if not os.path.exists(marbl_srcdir):
-            raise RuntimeError("MARBL external not found")
+            expect(False, "MARBL external not found")
         logger.info("Building MARBL with source from {}".format(marbl_srcdir))
 
         casetools = case.get_value("CASETOOLS")


### PR DESCRIPTION
Also, I cleaned up the logic in how CVMix source code is found (MARBL build
mimics this new logic) and added logger messages so that the location of CVMix
and MARBL appears in ocn.bldlog.

And I cleaned up .gitignore to include the MOM6 directory (populated by
manage_externals) as well as the compiled python in cime_config/ (buildnmlc and
buildlibc)

This PR depends on [alperaltuntas/cesm#3](https://github.com/alperaltuntas/cesm/pull/3) -- without the updated CESM tag, MOM6 builds should fail because MARBL can not be found.

```
ar: creating libfms.a

Looking for CVMix source code...
... CVMix will be built with source from /gpfs/fs1/work/mlevy/codes/CESM/cesm2.mom6/libraries/CVMix/src/shared

Looking for MARBL source code...
ERROR: MARBL external not found
```