### PR TITLE
Change vertical resolution and BAD_VAL_* values

### DIFF
--- a/input_templates/tx0.66v1/B/MOM_input
+++ b/input_templates/tx0.66v1/B/MOM_input
@@ -753,7 +753,7 @@ RESTINT = 365.0                 !   [days] default = 0.0
                                 ! The interval between saves of the restart file in units
                                 ! of TIMEUNIT.  Use 0 (the default) to not save
                                 ! incremental restart files at all.
-ENERGYSAVEDAYS = 0.5            !   [days] default = 1.0
+ENERGYSAVEDAYS = 1.0            !   [days] default = 1.0
                                 ! The interval in units of TIMEUNIT between saves of the
                                 ! energies of the run and other globally summed diagnostics.
 ENERGYSAVEDAYS_GEOMETRIC = 0.25 !   [days] default = 0.0

--- a/input_templates/tx0.66v1/B/MOM_input
+++ b/input_templates/tx0.66v1/B/MOM_input
@@ -65,7 +65,7 @@ IO_LAYOUT = 1, 1                ! default = 0
 
 ! === module MOM_verticalGrid ===
 ! Parameters providing information about the vertical grid.
-NK = 60                         !   [nondim]
+NK = 63                         !   [nondim]
                                 ! The number of model layers.
 
 ! === module MOM ===
@@ -139,6 +139,9 @@ C_P = 3992.0                    !   [J kg-1 K-1] default = 3991.86795711963
                                 ! of conservative temperature.
 CHECK_BAD_SURFACE_VALS = True   !   [Boolean] default = False
                                 ! If true, check the surface state for ridiculous values.
+BAD_VAL_SST_MIN = -2.5          !   [deg C] default = -2.1
+                                ! The value of SST below which a bad value message is
+                                ! triggered, if CHECK_BAD_SURFACE_VALS is true.
 SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
                                 ! If true, write the initial conditions to a file given
                                 ! by IC_OUTPUT_FILE.
@@ -298,7 +301,7 @@ REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
                                 !  HYCOM1 - HyCOM-like hybrid coordinate
                                 !  SLIGHT - stretched coordinates above continuous isopycnal
                                 !  ADAPTIVE - optimize for smooth neutral density surfaces
-ALE_COORDINATE_CONFIG = "FILE:ocean_vgrid_180829.nc,dz" ! default = "UNIFORM"
+ALE_COORDINATE_CONFIG = "FILE:ocean_vgrid_190320.nc,dz" ! default = "UNIFORM"
                                 ! Determines how to specify the coordinate
                                 ! resolution. Valid options are:
                                 !  PARAM       - use the vector-parameter ALE_RESOLUTION

--- a/input_templates/tx0.66v1/C/MOM_input
+++ b/input_templates/tx0.66v1/C/MOM_input
@@ -753,7 +753,7 @@ RESTINT = 365.0                 !   [days] default = 0.0
                                 ! The interval between saves of the restart file in units
                                 ! of TIMEUNIT.  Use 0 (the default) to not save
                                 ! incremental restart files at all.
-ENERGYSAVEDAYS = 0.5            !   [days] default = 1.0
+ENERGYSAVEDAYS = 1.0            !   [days] default = 1.0
                                 ! The interval in units of TIMEUNIT between saves of the
                                 ! energies of the run and other globally summed diagnostics.
 ENERGYSAVEDAYS_GEOMETRIC = 0.25 !   [days] default = 0.0

--- a/input_templates/tx0.66v1/C/MOM_input
+++ b/input_templates/tx0.66v1/C/MOM_input
@@ -65,7 +65,7 @@ IO_LAYOUT = 1, 1                ! default = 0
 
 ! === module MOM_verticalGrid ===
 ! Parameters providing information about the vertical grid.
-NK = 60                         !   [nondim]
+NK = 63                         !   [nondim]
                                 ! The number of model layers.
 
 ! === module MOM ===
@@ -139,6 +139,9 @@ C_P = 3992.0                    !   [J kg-1 K-1] default = 3991.86795711963
                                 ! of conservative temperature.
 CHECK_BAD_SURFACE_VALS = True   !   [Boolean] default = False
                                 ! If true, check the surface state for ridiculous values.
+BAD_VAL_SST_MIN = -2.5          !   [deg C] default = -2.1
+                                ! The value of SST below which a bad value message is
+                                ! triggered, if CHECK_BAD_SURFACE_VALS is true.
 SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
                                 ! If true, write the initial conditions to a file given
                                 ! by IC_OUTPUT_FILE.
@@ -298,7 +301,7 @@ REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
                                 !  HYCOM1 - HyCOM-like hybrid coordinate
                                 !  SLIGHT - stretched coordinates above continuous isopycnal
                                 !  ADAPTIVE - optimize for smooth neutral density surfaces
-ALE_COORDINATE_CONFIG = "FILE:ocean_vgrid_180829.nc,dz" ! default = "UNIFORM"
+ALE_COORDINATE_CONFIG = "FILE:ocean_vgrid_190320.nc,dz" ! default = "UNIFORM"
                                 ! Determines how to specify the coordinate
                                 ! resolution. Valid options are:
                                 !  PARAM       - use the vector-parameter ALE_RESOLUTION

--- a/input_templates/tx0.66v1/G/MOM_input
+++ b/input_templates/tx0.66v1/G/MOM_input
@@ -756,7 +756,7 @@ RESTINT = 365.0                 !   [days] default = 0.0
                                 ! The interval between saves of the restart file in units
                                 ! of TIMEUNIT.  Use 0 (the default) to not save
                                 ! incremental restart files at all.
-ENERGYSAVEDAYS = 0.5            !   [days] default = 1.0
+ENERGYSAVEDAYS = 1.0            !   [days] default = 1.0
                                 ! The interval in units of TIMEUNIT between saves of the
                                 ! energies of the run and other globally summed diagnostics.
 ENERGYSAVEDAYS_GEOMETRIC = 0.25 !   [days] default = 0.0

--- a/input_templates/tx0.66v1/G/MOM_input
+++ b/input_templates/tx0.66v1/G/MOM_input
@@ -65,7 +65,7 @@ IO_LAYOUT = 1, 1                ! default = 0
 
 ! === module MOM_verticalGrid ===
 ! Parameters providing information about the vertical grid.
-NK = 60                         !   [nondim]
+NK = 63                         !   [nondim]
                                 ! The number of model layers.
 
 ! === module MOM ===
@@ -139,6 +139,12 @@ C_P = 3992.0                    !   [J kg-1 K-1] default = 3991.86795711963
                                 ! of conservative temperature.
 CHECK_BAD_SURFACE_VALS = True   !   [Boolean] default = False
                                 ! If true, check the surface state for ridiculous values.
+BAD_VAL_SSS_MAX = 75.0          !   [PPT] default = 45.0
+                                ! The value of SSS above which a bad value message is
+                                ! triggered, if CHECK_BAD_SURFACE_VALS is true.
+BAD_VAL_SST_MIN = -2.5          !   [deg C] default = -2.1
+                                ! The value of SST below which a bad value message is
+                                ! triggered, if CHECK_BAD_SURFACE_VALS is true.
 SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
                                 ! If true, write the initial conditions to a file given
                                 ! by IC_OUTPUT_FILE.
@@ -298,7 +304,7 @@ REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
                                 !  HYCOM1 - HyCOM-like hybrid coordinate
                                 !  SLIGHT - stretched coordinates above continuous isopycnal
                                 !  ADAPTIVE - optimize for smooth neutral density surfaces
-ALE_COORDINATE_CONFIG = "FILE:ocean_vgrid_180829.nc,dz" ! default = "UNIFORM"
+ALE_COORDINATE_CONFIG = "FILE:ocean_vgrid_190320.nc,dz" ! default = "UNIFORM"
                                 ! Determines how to specify the coordinate
                                 ! resolution. Valid options are:
                                 !  PARAM       - use the vector-parameter ALE_RESOLUTION


### PR DESCRIPTION
This PR changes the default vertical resolution in all compsets using tx0.666. Now, NK = 63 and the vertical grid spacing is 2.5 m in the first 10 m of the water column. 

@alperaltuntas, please copy /glade/work/gmarques/cesm/mom6_input_files/vertical_grids/ocean_vgrid_190320.nc into /glade/p/cesmdata/cseg/inputdata/ocn/mom/tx0.66v1

This PR also sets BAD_VAL_SST_MIN = -2.5 in all compsets and BAD_VAL_SSS_MAX = 75.0 in the B compset.