### PR TITLE
add izumi hobart and nuopc tests

### DIFF
--- a/cime_config/config_pes.xml
+++ b/cime_config/config_pes.xml
@@ -76,10 +76,6 @@
           <rootpe_glc>0</rootpe_glc>
         </rootpe>
       </pes>
-    </mach>
-  </grid>
-  <grid name="a%T62.+oi%gx1v6">
-    <mach name="any">
       <pes pesize="L" compset="DATM.+CICE.+SWAV">
         <comment>none</comment>
         <ntasks>
@@ -114,45 +110,6 @@
         </rootpe>
       </pes>
     </mach>
-  </grid>
-  <grid name="a%T62.+oi%gx1v6">
-    <mach name="any">
-      <pes pesize="L" compset="any">
-        <comment>none</comment>
-        <ntasks>
-          <ntasks_atm>24</ntasks_atm>
-          <ntasks_rof>8</ntasks_rof>
-          <ntasks_ice>80</ntasks_ice>
-          <ntasks_cpl>80</ntasks_cpl>
-          <ntasks_ocn>192</ntasks_ocn>
-          <ntasks_lnd>1</ntasks_lnd>
-          <ntasks_glc>1</ntasks_glc>
-          <ntasks_wav>1</ntasks_wav>
-        </ntasks>
-        <nthrds>
-          <nthrds_atm>1</nthrds_atm>
-          <nthrds_lnd>1</nthrds_lnd>
-          <nthrds_rof>1</nthrds_rof>
-          <nthrds_ice>1</nthrds_ice>
-          <nthrds_ocn>1</nthrds_ocn>
-          <nthrds_glc>1</nthrds_glc>
-          <nthrds_wav>1</nthrds_wav>
-          <nthrds_cpl>1</nthrds_cpl>
-        </nthrds>
-        <rootpe>
-          <rootpe_atm>0</rootpe_atm>
-          <rootpe_rof>0</rootpe_rof>
-          <rootpe_ice>0</rootpe_ice>
-          <rootpe_ocn>80</rootpe_ocn>
-          <rootpe_cpl>0</rootpe_cpl>
-          <rootpe_lnd>0</rootpe_lnd>
-          <rootpe_glc>0</rootpe_glc>
-          <rootpe_wav>0</rootpe_wav>
-        </rootpe>
-      </pes>
-    </mach>
-  </grid>
-  <grid name="a%T62.+oi%gx1v6">
     <mach name="cheyenne">
       <pes pesize="any" compset="DATM.+CICE.+SWAV">
         <comment>none</comment>
@@ -187,10 +144,6 @@
           <rootpe_glc>0</rootpe_glc>
         </rootpe>
       </pes>
-    </mach>
-  </grid>
-  <grid name="a%T62.+oi%gx1v6">
-    <mach name="cheyenne">
       <pes pesize="any" compset="DATM.+DICE.+SWAV">
         <comment>none</comment>
         <ntasks>
@@ -225,8 +178,142 @@
         </rootpe>
       </pes>
     </mach>
-  </grid>
-  <grid name="a%T62.+oi%gx1v6">
+    <mach name="izumi">
+      <pes pesize="any" compset="DATM.+CICE.+SWAV">
+        <comment>none</comment>
+        <ntasks>
+          <ntasks_atm>48</ntasks_atm>
+          <ntasks_rof>48</ntasks_rof>
+          <ntasks_cpl>48</ntasks_cpl>
+          <ntasks_ice>96</ntasks_ice>
+          <ntasks_ocn>144</ntasks_ocn>
+          <ntasks_lnd>1</ntasks_lnd>
+          <ntasks_wav>1</ntasks_wav>
+          <ntasks_glc>1</ntasks_glc>
+        </ntasks>
+        <nthrds>
+          <nthrds_atm>1</nthrds_atm>
+          <nthrds_lnd>1</nthrds_lnd>
+          <nthrds_rof>1</nthrds_rof>
+          <nthrds_ice>1</nthrds_ice>
+          <nthrds_ocn>1</nthrds_ocn>
+          <nthrds_glc>1</nthrds_glc>
+          <nthrds_wav>1</nthrds_wav>
+          <nthrds_cpl>1</nthrds_cpl>
+        </nthrds>
+        <rootpe>
+          <rootpe_atm>0</rootpe_atm>
+          <rootpe_rof>0</rootpe_rof>
+          <rootpe_cpl>0</rootpe_cpl>
+          <rootpe_ice>0</rootpe_ice>
+          <rootpe_ocn>96</rootpe_ocn>
+          <rootpe_lnd>0</rootpe_lnd>
+          <rootpe_wav>0</rootpe_wav>
+          <rootpe_glc>0</rootpe_glc>
+        </rootpe>
+      </pes>
+      <pes pesize="any" compset="DATM.+DICE.+SWAV">
+        <comment>none</comment>
+        <ntasks>
+          <ntasks_atm>48</ntasks_atm>
+          <ntasks_rof>48</ntasks_rof>
+          <ntasks_cpl>48</ntasks_cpl>
+          <ntasks_ice>48</ntasks_ice>
+          <ntasks_ocn>144</ntasks_ocn>
+          <ntasks_lnd>1</ntasks_lnd>
+          <ntasks_wav>1</ntasks_wav>
+          <ntasks_glc>1</ntasks_glc>
+        </ntasks>
+        <nthrds>
+          <nthrds_atm>1</nthrds_atm>
+          <nthrds_lnd>1</nthrds_lnd>
+          <nthrds_rof>1</nthrds_rof>
+          <nthrds_ice>1</nthrds_ice>
+          <nthrds_ocn>1</nthrds_ocn>
+          <nthrds_glc>1</nthrds_glc>
+          <nthrds_wav>1</nthrds_wav>
+          <nthrds_cpl>1</nthrds_cpl>
+        </nthrds>
+        <rootpe>
+          <rootpe_atm>0</rootpe_atm>
+          <rootpe_rof>0</rootpe_rof>
+          <rootpe_cpl>0</rootpe_cpl>
+          <rootpe_ice>0</rootpe_ice>
+          <rootpe_ocn>48</rootpe_ocn>
+          <rootpe_lnd>0</rootpe_lnd>
+          <rootpe_wav>0</rootpe_wav>
+          <rootpe_glc>0</rootpe_glc>
+        </rootpe>
+      </pes>
+    </mach>
+    <mach name="hobart">
+      <pes pesize="any" compset="DATM.+CICE.+SWAV">
+        <comment>none</comment>
+        <ntasks>
+          <ntasks_atm>48</ntasks_atm>
+          <ntasks_rof>48</ntasks_rof>
+          <ntasks_cpl>48</ntasks_cpl>
+          <ntasks_ice>96</ntasks_ice>
+          <ntasks_ocn>144</ntasks_ocn>
+          <ntasks_lnd>1</ntasks_lnd>
+          <ntasks_wav>1</ntasks_wav>
+          <ntasks_glc>1</ntasks_glc>
+        </ntasks>
+        <nthrds>
+          <nthrds_atm>1</nthrds_atm>
+          <nthrds_lnd>1</nthrds_lnd>
+          <nthrds_rof>1</nthrds_rof>
+          <nthrds_ice>1</nthrds_ice>
+          <nthrds_ocn>1</nthrds_ocn>
+          <nthrds_glc>1</nthrds_glc>
+          <nthrds_wav>1</nthrds_wav>
+          <nthrds_cpl>1</nthrds_cpl>
+        </nthrds>
+        <rootpe>
+          <rootpe_atm>0</rootpe_atm>
+          <rootpe_rof>0</rootpe_rof>
+          <rootpe_cpl>0</rootpe_cpl>
+          <rootpe_ice>0</rootpe_ice>
+          <rootpe_ocn>96</rootpe_ocn>
+          <rootpe_lnd>0</rootpe_lnd>
+          <rootpe_wav>0</rootpe_wav>
+          <rootpe_glc>0</rootpe_glc>
+        </rootpe>
+      </pes>
+      <pes pesize="any" compset="DATM.+DICE.+SWAV">
+        <comment>none</comment>
+        <ntasks>
+          <ntasks_atm>48</ntasks_atm>
+          <ntasks_rof>48</ntasks_rof>
+          <ntasks_cpl>48</ntasks_cpl>
+          <ntasks_ice>48</ntasks_ice>
+          <ntasks_ocn>144</ntasks_ocn>
+          <ntasks_lnd>1</ntasks_lnd>
+          <ntasks_wav>1</ntasks_wav>
+          <ntasks_glc>1</ntasks_glc>
+        </ntasks>
+        <nthrds>
+          <nthrds_atm>1</nthrds_atm>
+          <nthrds_lnd>1</nthrds_lnd>
+          <nthrds_rof>1</nthrds_rof>
+          <nthrds_ice>1</nthrds_ice>
+          <nthrds_ocn>1</nthrds_ocn>
+          <nthrds_glc>1</nthrds_glc>
+          <nthrds_wav>1</nthrds_wav>
+          <nthrds_cpl>1</nthrds_cpl>
+        </nthrds>
+        <rootpe>
+          <rootpe_atm>0</rootpe_atm>
+          <rootpe_rof>0</rootpe_rof>
+          <rootpe_cpl>0</rootpe_cpl>
+          <rootpe_ice>0</rootpe_ice>
+          <rootpe_ocn>48</rootpe_ocn>
+          <rootpe_lnd>0</rootpe_lnd>
+          <rootpe_wav>0</rootpe_wav>
+          <rootpe_glc>0</rootpe_glc>
+        </rootpe>
+      </pes>
+    </mach>
     <mach name="edison">
       <pes pesize="any" compset="any">
         <comment>none</comment>
@@ -262,8 +349,6 @@
         </rootpe>
       </pes>
     </mach>
-  </grid>
-  <grid name="a%T62.+oi%gx1v6">
     <mach name="stampede|titan">
       <pes pesize="any" compset="any">
         <comment>none</comment>
@@ -335,10 +420,6 @@
           <rootpe_glc>0</rootpe_glc>
         </rootpe>
       </pes>
-    </mach>
-  </grid>
-  <grid name="a%T62.+oi%tx0.66v1">
-    <mach name="any">
       <pes pesize="any" compset="DATM.+CICE.+SWAV">
         <comment>none</comment>
         <ntasks>
@@ -373,8 +454,6 @@
         </rootpe>
       </pes>
     </mach>
-  </grid>
-  <grid name="a%T62.+oi%tx0.66v1">
     <mach name="cheyenne">
       <pes pesize="any" compset="DATM.+CICE.+SWAV">
         <comment>none</comment>
@@ -409,10 +488,6 @@
           <rootpe_glc>0</rootpe_glc>
         </rootpe>
       </pes>
-    </mach>
-  </grid>
-  <grid name="a%T62.+oi%tx0.66v1">
-    <mach name="cheyenne">
       <pes pesize="any" compset="DATM.+DICE.+SWAV">
         <comment>none</comment>
         <ntasks>
@@ -441,6 +516,142 @@
           <rootpe_cpl>0</rootpe_cpl>
           <rootpe_ice>0</rootpe_ice>
           <rootpe_ocn>36</rootpe_ocn>
+          <rootpe_lnd>0</rootpe_lnd>
+          <rootpe_wav>0</rootpe_wav>
+          <rootpe_glc>0</rootpe_glc>
+        </rootpe>
+      </pes>
+    </mach>
+		<mach name="izumi">
+      <pes pesize="any" compset="DATM.+CICE.+SWAV">
+        <comment>none</comment>
+        <ntasks>
+          <ntasks_atm>48</ntasks_atm>
+          <ntasks_rof>48</ntasks_rof>
+          <ntasks_cpl>48</ntasks_cpl>
+          <ntasks_ice>96</ntasks_ice>
+          <ntasks_ocn>144</ntasks_ocn>
+          <ntasks_lnd>1</ntasks_lnd>
+          <ntasks_wav>1</ntasks_wav>
+          <ntasks_glc>1</ntasks_glc>
+        </ntasks>
+        <nthrds>
+          <nthrds_atm>1</nthrds_atm>
+          <nthrds_lnd>1</nthrds_lnd>
+          <nthrds_rof>1</nthrds_rof>
+          <nthrds_ice>1</nthrds_ice>
+          <nthrds_ocn>1</nthrds_ocn>
+          <nthrds_glc>1</nthrds_glc>
+          <nthrds_wav>1</nthrds_wav>
+          <nthrds_cpl>1</nthrds_cpl>
+        </nthrds>
+        <rootpe>
+          <rootpe_atm>0</rootpe_atm>
+          <rootpe_rof>0</rootpe_rof>
+          <rootpe_cpl>0</rootpe_cpl>
+          <rootpe_ice>0</rootpe_ice>
+          <rootpe_ocn>96</rootpe_ocn>
+          <rootpe_lnd>0</rootpe_lnd>
+          <rootpe_wav>0</rootpe_wav>
+          <rootpe_glc>0</rootpe_glc>
+        </rootpe>
+      </pes>
+      <pes pesize="any" compset="DATM.+DICE.+SWAV">
+        <comment>none</comment>
+        <ntasks>
+          <ntasks_atm>48</ntasks_atm>
+          <ntasks_rof>48</ntasks_rof>
+          <ntasks_cpl>48</ntasks_cpl>
+          <ntasks_ice>48</ntasks_ice>
+          <ntasks_ocn>144</ntasks_ocn>
+          <ntasks_lnd>1</ntasks_lnd>
+          <ntasks_wav>1</ntasks_wav>
+          <ntasks_glc>1</ntasks_glc>
+        </ntasks>
+        <nthrds>
+          <nthrds_atm>1</nthrds_atm>
+          <nthrds_lnd>1</nthrds_lnd>
+          <nthrds_rof>1</nthrds_rof>
+          <nthrds_ice>1</nthrds_ice>
+          <nthrds_ocn>1</nthrds_ocn>
+          <nthrds_glc>1</nthrds_glc>
+          <nthrds_wav>1</nthrds_wav>
+          <nthrds_cpl>1</nthrds_cpl>
+        </nthrds>
+        <rootpe>
+          <rootpe_atm>0</rootpe_atm>
+          <rootpe_rof>0</rootpe_rof>
+          <rootpe_cpl>0</rootpe_cpl>
+          <rootpe_ice>0</rootpe_ice>
+          <rootpe_ocn>48</rootpe_ocn>
+          <rootpe_lnd>0</rootpe_lnd>
+          <rootpe_wav>0</rootpe_wav>
+          <rootpe_glc>0</rootpe_glc>
+        </rootpe>
+      </pes>
+    </mach>
+		<mach name="hobart">
+      <pes pesize="any" compset="DATM.+CICE.+SWAV">
+        <comment>none</comment>
+        <ntasks>
+          <ntasks_atm>48</ntasks_atm>
+          <ntasks_rof>48</ntasks_rof>
+          <ntasks_cpl>48</ntasks_cpl>
+          <ntasks_ice>96</ntasks_ice>
+          <ntasks_ocn>144</ntasks_ocn>
+          <ntasks_lnd>1</ntasks_lnd>
+          <ntasks_wav>1</ntasks_wav>
+          <ntasks_glc>1</ntasks_glc>
+        </ntasks>
+        <nthrds>
+          <nthrds_atm>1</nthrds_atm>
+          <nthrds_lnd>1</nthrds_lnd>
+          <nthrds_rof>1</nthrds_rof>
+          <nthrds_ice>1</nthrds_ice>
+          <nthrds_ocn>1</nthrds_ocn>
+          <nthrds_glc>1</nthrds_glc>
+          <nthrds_wav>1</nthrds_wav>
+          <nthrds_cpl>1</nthrds_cpl>
+        </nthrds>
+        <rootpe>
+          <rootpe_atm>0</rootpe_atm>
+          <rootpe_rof>0</rootpe_rof>
+          <rootpe_cpl>0</rootpe_cpl>
+          <rootpe_ice>0</rootpe_ice>
+          <rootpe_ocn>96</rootpe_ocn>
+          <rootpe_lnd>0</rootpe_lnd>
+          <rootpe_wav>0</rootpe_wav>
+          <rootpe_glc>0</rootpe_glc>
+        </rootpe>
+      </pes>
+      <pes pesize="any" compset="DATM.+DICE.+SWAV">
+        <comment>none</comment>
+        <ntasks>
+          <ntasks_atm>48</ntasks_atm>
+          <ntasks_rof>48</ntasks_rof>
+          <ntasks_cpl>48</ntasks_cpl>
+          <ntasks_ice>48</ntasks_ice>
+          <ntasks_ocn>144</ntasks_ocn>
+          <ntasks_lnd>1</ntasks_lnd>
+          <ntasks_wav>1</ntasks_wav>
+          <ntasks_glc>1</ntasks_glc>
+        </ntasks>
+        <nthrds>
+          <nthrds_atm>1</nthrds_atm>
+          <nthrds_lnd>1</nthrds_lnd>
+          <nthrds_rof>1</nthrds_rof>
+          <nthrds_ice>1</nthrds_ice>
+          <nthrds_ocn>1</nthrds_ocn>
+          <nthrds_glc>1</nthrds_glc>
+          <nthrds_wav>1</nthrds_wav>
+          <nthrds_cpl>1</nthrds_cpl>
+        </nthrds>
+        <rootpe>
+          <rootpe_atm>0</rootpe_atm>
+          <rootpe_rof>0</rootpe_rof>
+          <rootpe_cpl>0</rootpe_cpl>
+          <rootpe_ice>0</rootpe_ice>
+          <rootpe_ocn>48</rootpe_ocn>
           <rootpe_lnd>0</rootpe_lnd>
           <rootpe_wav>0</rootpe_wav>
           <rootpe_glc>0</rootpe_glc>
@@ -485,18 +696,19 @@
       </pes>
     </mach>
   </grid>
-  <grid name="a%T62.+oi%gx1v6">
-    <mach name="hobart">
-      <pes pesize="any" compset="any">
+  <grid name="a%TL319.+oi%tx0.66v1">
+    <mach name="any">
+      <pes pesize="any" compset="DATM.+DICE.+SWAV">
+        <comment>none</comment>
         <ntasks>
           <ntasks_atm>48</ntasks_atm>
-          <ntasks_lnd>48</ntasks_lnd>
           <ntasks_rof>48</ntasks_rof>
-          <ntasks_ice>48</ntasks_ice>
-          <ntasks_ocn>48</ntasks_ocn>
           <ntasks_cpl>48</ntasks_cpl>
-          <ntasks_glc>48</ntasks_glc>
-          <ntasks_wav>48</ntasks_wav>
+          <ntasks_ice>48</ntasks_ice>
+          <ntasks_ocn>144</ntasks_ocn>
+          <ntasks_lnd>1</ntasks_lnd>
+          <ntasks_wav>1</ntasks_wav>
+          <ntasks_glc>1</ntasks_glc>
         </ntasks>
         <nthrds>
           <nthrds_atm>1</nthrds_atm>
@@ -510,19 +722,50 @@
         </nthrds>
         <rootpe>
           <rootpe_atm>0</rootpe_atm>
-          <rootpe_lnd>0</rootpe_lnd>
           <rootpe_rof>0</rootpe_rof>
-          <rootpe_ice>0</rootpe_ice>
-          <rootpe_ocn>0</rootpe_ocn>
-          <rootpe_glc>0</rootpe_glc>
-          <rootpe_wav>0</rootpe_wav>
           <rootpe_cpl>0</rootpe_cpl>
+          <rootpe_ice>0</rootpe_ice>
+          <rootpe_ocn>48</rootpe_ocn>
+          <rootpe_lnd>0</rootpe_lnd>
+          <rootpe_wav>0</rootpe_wav>
+          <rootpe_glc>0</rootpe_glc>
+        </rootpe>
+      </pes>
+      <pes pesize="any" compset="DATM.+CICE.+SWAV">
+        <comment>none</comment>
+        <ntasks>
+          <ntasks_atm>48</ntasks_atm>
+          <ntasks_rof>48</ntasks_rof>
+          <ntasks_cpl>48</ntasks_cpl>
+          <ntasks_ice>96</ntasks_ice>
+          <ntasks_ocn>144</ntasks_ocn>
+          <ntasks_lnd>1</ntasks_lnd>
+          <ntasks_wav>1</ntasks_wav>
+          <ntasks_glc>1</ntasks_glc>
+        </ntasks>
+        <nthrds>
+          <nthrds_atm>1</nthrds_atm>
+          <nthrds_lnd>1</nthrds_lnd>
+          <nthrds_rof>1</nthrds_rof>
+          <nthrds_ice>1</nthrds_ice>
+          <nthrds_ocn>1</nthrds_ocn>
+          <nthrds_glc>1</nthrds_glc>
+          <nthrds_wav>1</nthrds_wav>
+          <nthrds_cpl>1</nthrds_cpl>
+        </nthrds>
+        <rootpe>
+          <rootpe_atm>0</rootpe_atm>
+          <rootpe_rof>0</rootpe_rof>
+          <rootpe_cpl>0</rootpe_cpl>
+          <rootpe_ice>0</rootpe_ice>
+          <rootpe_ocn>72</rootpe_ocn>
+          <rootpe_lnd>0</rootpe_lnd>
+          <rootpe_wav>0</rootpe_wav>
+          <rootpe_glc>0</rootpe_glc>
         </rootpe>
       </pes>
     </mach>
-  </grid>
-  <grid name="a%TL319.+oi%tx0.66v1">
-    <mach name="any">
+    <mach name="cheyenne">
       <pes pesize="any" compset="DATM.+DICE.+SWAV">
         <comment>none</comment>
         <ntasks>

--- a/cime_config/testdefs/testlist_mom.xml
+++ b/cime_config/testdefs/testlist_mom.xml
@@ -8,7 +8,7 @@
         </options>
       </machine>
       <machine name="hobart" compiler="intel" category="aux_mom"/>
-			<machine name="izumi" compiler="intel" category="aux_mom"/>
+      <machine name="izumi" compiler="intel" category="aux_mom"/>
     </machines>
   </test>
   <test name="ERS_Vnuopc" grid="T62_g16" compset="CMOM_IAF">
@@ -19,7 +19,7 @@
         </options>
       </machine>
       <machine name="hobart" compiler="intel" category="aux_mom"/>
-			<machine name="izumi" compiler="intel" category="aux_mom"/>
+      <machine name="izumi" compiler="intel" category="aux_mom"/>
     </machines>
   </test>
   <test name="SMS_D_Ld2" grid="T62_g16" compset="CMOM">
@@ -30,7 +30,7 @@
         </options>
       </machine>
       <machine name="hobart" compiler="intel" category="aux_mom"/>
-			<machine name="izumi" compiler="intel" category="aux_mom"/>
+      <machine name="izumi" compiler="intel" category="aux_mom"/>
     </machines>
   </test>
   <test name="SMS" grid="T62_t061" compset="CMOM_IAF">
@@ -41,7 +41,7 @@
         </options>
       </machine>
       <machine name="hobart" compiler="intel" category="aux_mom"/>
-			<machine name="izumi" compiler="intel" category="aux_mom"/>
+      <machine name="izumi" compiler="intel" category="aux_mom"/>
     </machines>
   </test>
   <test name="SMS_Vnuopc" grid="T62_t061" compset="GMOM">
@@ -52,7 +52,7 @@
         </options>
       </machine>
       <machine name="hobart" compiler="intel" category="aux_mom"/>
-			<machine name="izumi" compiler="intel" category="aux_mom"/>
+      <machine name="izumi" compiler="intel" category="aux_mom"/>
     </machines>
   </test>
   <test name="ERI" grid="T62_t061" compset="GMOM">
@@ -63,7 +63,7 @@
         </options>
       </machine>
       <machine name="hobart" compiler="intel" category="aux_mom"/>
-			<machine name="izumi" compiler="intel" category="aux_mom"/>
+      <machine name="izumi" compiler="intel" category="aux_mom"/>
     </machines>
   </test>
   <test name="ERS" grid="TL319_t061" compset="CMOM_JRA">
@@ -83,7 +83,7 @@
         </options>
       </machine>
       <machine name="hobart" compiler="intel" category="aux_mom"/>
-			<machine name="izumi" compiler="intel" category="aux_mom"/>
+      <machine name="izumi" compiler="intel" category="aux_mom"/>
     </machines>
   </test>
 </testlist>

--- a/cime_config/testdefs/testlist_mom.xml
+++ b/cime_config/testdefs/testlist_mom.xml
@@ -7,11 +7,19 @@
           <option name="wallclock">00:30:00</option>
         </options>
       </machine>
-      <machine name="hobart" compiler="intel" category="aux_mom">
+      <machine name="hobart" compiler="intel" category="aux_mom"/>
+			<machine name="izumi" compiler="intel" category="aux_mom"/>
+    </machines>
+  </test>
+  <test name="ERS_Vnuopc" grid="T62_g16" compset="CMOM_IAF">
+    <machines>
+      <machine name="cheyenne" compiler="intel" category="aux_mom">
         <options>
           <option name="wallclock">00:30:00</option>
         </options>
       </machine>
+      <machine name="hobart" compiler="intel" category="aux_mom"/>
+			<machine name="izumi" compiler="intel" category="aux_mom"/>
     </machines>
   </test>
   <test name="SMS_D_Ld2" grid="T62_g16" compset="CMOM">
@@ -21,6 +29,8 @@
           <option name="wallclock">00:30:00</option>
         </options>
       </machine>
+      <machine name="hobart" compiler="intel" category="aux_mom"/>
+			<machine name="izumi" compiler="intel" category="aux_mom"/>
     </machines>
   </test>
   <test name="SMS" grid="T62_t061" compset="CMOM_IAF">
@@ -30,15 +40,30 @@
           <option name="wallclock">00:30:00</option>
         </options>
       </machine>
+      <machine name="hobart" compiler="intel" category="aux_mom"/>
+			<machine name="izumi" compiler="intel" category="aux_mom"/>
     </machines>
   </test>
-  <test name="SMS" grid="T62_t061" compset="GMOM">
+  <test name="SMS_Vnuopc" grid="T62_t061" compset="GMOM">
     <machines>
       <machine name="cheyenne" compiler="intel" category="aux_mom">
         <options>
           <option name="wallclock">00:30:00</option>
         </options>
       </machine>
+      <machine name="hobart" compiler="intel" category="aux_mom"/>
+			<machine name="izumi" compiler="intel" category="aux_mom"/>
+    </machines>
+  </test>
+  <test name="ERI" grid="T62_t061" compset="GMOM">
+    <machines>
+      <machine name="cheyenne" compiler="intel" category="aux_mom">
+        <options>
+          <option name="wallclock">00:30:00</option>
+        </options>
+      </machine>
+      <machine name="hobart" compiler="intel" category="aux_mom"/>
+			<machine name="izumi" compiler="intel" category="aux_mom"/>
     </machines>
   </test>
   <test name="ERS" grid="TL319_t061" compset="CMOM_JRA">
@@ -57,6 +82,8 @@
           <option name="wallclock">00:30:00</option>
         </options>
       </machine>
+      <machine name="hobart" compiler="intel" category="aux_mom"/>
+			<machine name="izumi" compiler="intel" category="aux_mom"/>
     </machines>
   </test>
 </testlist>

--- a/cime_config/testdefs/testlist_mom.xml
+++ b/cime_config/testdefs/testlist_mom.xml
@@ -63,7 +63,11 @@
         </options>
       </machine>
       <machine name="hobart" compiler="intel" category="aux_mom"/>
-      <machine name="izumi" compiler="intel" category="aux_mom"/>
+      <machine name="izumi" compiler="intel" category="aux_mom">
+        <options>
+          <option name="wallclock">99:00:00</option>
+        </options>
+      </machine>
     </machines>
   </test>
   <test name="ERS" grid="TL319_t061" compset="CMOM_JRA">


### PR DESCRIPTION
To run nuopc on izumi, we need to execute the following shell commands:

```
module purge

module load compiler/intel/19.0.1
module load mvapich2/2.3/intel-cluster-19.0.1
module load tool/hdf5/1.8.20/intel
module load tool/netcdf/4.6.1/intel

setenv ESMF_OS Linux
setenv ESMF_TESTMPMD OFF
setenv ESMF_TESTHARNESS_ARRAY RUN_ESMF_TestHarnessArrayUNI_default
setenv ESMF_TESTHARNESS_FIELD RUN_ESMF_TestHarnessFieldUNI_default
setenv ESMF_DIR /home/turuncu/progs/esmf-8.0.0b33
setenv ESMF_TESTWITHTHREADS OFF
setenv ESMF_INSTALL_PREFIX $ESMF_DIR/install_dir
setenv ESMF_COMM mvapich2
setenv ESMF_TESTEXHAUSTIVE ON
setenv ESMF_BOPT g
setenv ESMF_OPENMP OFF
setenv ESMF_SITE default
setenv ESMF_ABI 64
setenv ESMF_COMPILER intel
setenv ESMF_NETCDF "split"
setenv ESMF_NETCDF_INCLUDE /usr/local/netcdf-c-4.6.1-f-4.4.4-intel-cluster-18.0.3/include
setenv ESMF_NETCDF_LIBPATH /usr/local/netcdf-c-4.6.1-f-4.4.4-intel-cluster-18.0.3/lib
setenv ESMF_XERCES "standard"
setenv ESMF_XERCES_INCLUDE /home/turuncu/progs/xerces-c-3.2.2/intel/include
setenv ESMF_XERCES_LIBPATH /home/turuncu/progs/xerces-c-3.2.2/intel/lib
setenv ESMF_YAMLCPP "standard"
setenv ESMF_YAMLCPP_INCLUDE /home/turuncu/progs/yaml-cpp-0.6.2/intel/include
setenv ESMF_YAMLCPP_LIBPATH /home/turuncu/progs/yaml-cpp-0.6.2/intel/lib

setenv ESMFMKFILE /home/turuncu/progs/esmf-8.0.0b33/install_dir/lib/libg/Linux.intel.64.mvapich2.default/esmf.mk
setenv LD_LIBRARY_PATH /home/turuncu/progs/yaml-cpp-0.6.2/intel/lib:/home/turuncu/progs/xerces-c-3.2.2/intel/lib:$LD_LIBRARY_PATH
```