### PR TITLE
add submodules for externals

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -1,5 +1,5 @@
 [mom]
-branch = dev/ncar
+branch = mvertens/validation_fixes
 protocol = git
 local_path = MOM6
 repo_url = https://github.com/NCAR/MOM6.git

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -1,5 +1,5 @@
 [mom]
-branch = mvertens/validation_fixes
+branch = dev/ncar
 protocol = git
 local_path = MOM6
 repo_url = https://github.com/NCAR/MOM6.git

--- a/Externals_MOM.cfg
+++ b/Externals_MOM.cfg
@@ -3,7 +3,7 @@ protocol = git
 from_submodule=True
 required = True
 
-[pgk/geoKdTree]
+[pkg/geoKdTree]
 protocol = git
 from_submodule=True
 required = True

--- a/Externals_MOM.cfg
+++ b/Externals_MOM.cfg
@@ -1,15 +1,11 @@
-[da_hooks]
-branch = master
+[pkg/MOM6_DA_hooks]
 protocol = git
-local_path = pkg/MOM6_DA_hooks
-repo_url = https://github.com/MJHarrison-GFDL/MOM6_DA_hooks.git
+from_submodule=True
 required = True
 
-[geoKdTree]
-tag = a4670b9
+[pgk/geoKdTree]
 protocol = git
-local_path = pkg/geoKdTree
-repo_url = https://github.com/travissluka/geoKdTree.git
+from_submodule=True
 required = True
 
 [externals_description]

--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -36,6 +36,7 @@ def prep_input(case):
     testcase        = case.get_value("TEST")
     hist_n          = case.get_value("HIST_N")
     hist_option     = case.get_value("HIST_OPTION")
+    ocn_ncpl        = case.get_value("OCN_NCPL")
     input_files     = ["diag_table", "input.nml", "MOM_input"]
 
     # determine input category (B,C, or G):

--- a/cime_config/config_archive.xml
+++ b/cime_config/config_archive.xml
@@ -1,10 +1,10 @@
 <components version="2.0">
   <comp_archive_spec compname="mom" compclass="ocn">
     <rest_file_extension>r</rest_file_extension>
-    <hist_file_extension>h[_\d+]+.nc$</hist_file_extension>
-    <hist_file_extension>hm[_\d+]+.nc$</hist_file_extension>
-    <hist_file_extension>frc[_\d+]+.nc$</hist_file_extension>
-    <hist_file_extension>sfc[_\d+]+.nc$</hist_file_extension>
+    <hist_file_extension>h.?[_\d+]+.nc$</hist_file_extension>
+    <hist_file_extension>hm.?[_\d+]+.nc$</hist_file_extension>
+    <hist_file_extension>frc.?[_\d+]+.nc$</hist_file_extension>
+    <hist_file_extension>sfc.?[_\d+]+.nc$</hist_file_extension>
     <hist_file_extension>static.nc$</hist_file_extension>
     <rpointer>
       <rpointer_file>rpointer.ocn$NINST_STRING</rpointer_file>


### PR DESCRIPTION
This needs to have the latest version of manage_externals when issuing checkout_externals to have the submodule tag in the Externals.cfg