### PR TITLE
Removes MIN_Z_DIAG_INTERVAL

### DIFF
--- a/input_templates/tx0.66v1/B/MOM_input
+++ b/input_templates/tx0.66v1/B/MOM_input
@@ -111,11 +111,6 @@ HFREEZE = 10.0                  !   [m] default = -1.0
                                 ! over which melt potential is computed will be min(HFREEZE, OBLD),
                                 ! where OBLD is the boundary layer depth. If HFREEZE <= 0 (default),
                                 ! melt potential will not be computed.
-MIN_Z_DIAG_INTERVAL = 2.16E+04  !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between
-                                ! calculations of depth-space diagnostics. Making this
-                                ! larger than DT_THERM reduces the  performance penalty
-                                ! of regridding to depth online.
 DTBT_RESET_PERIOD = 7200.0      !   [s] default = 7200.0
                                 ! The period between recalculations of DTBT (if DTBT <= 0).
                                 ! If DTBT_RESET_PERIOD is negative, DTBT is set based

--- a/input_templates/tx0.66v1/C/MOM_input
+++ b/input_templates/tx0.66v1/C/MOM_input
@@ -111,11 +111,6 @@ HFREEZE = 10.0                  !   [m] default = -1.0
                                 ! over which melt potential is computed will be min(HFREEZE, OBLD),
                                 ! where OBLD is the boundary layer depth. If HFREEZE <= 0 (default),
                                 ! melt potential will not be computed.
-MIN_Z_DIAG_INTERVAL = 2.16E+04  !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between
-                                ! calculations of depth-space diagnostics. Making this
-                                ! larger than DT_THERM reduces the  performance penalty
-                                ! of regridding to depth online.
 DTBT_RESET_PERIOD = 7200.0      !   [s] default = 7200.0
                                 ! The period between recalculations of DTBT (if DTBT <= 0).
                                 ! If DTBT_RESET_PERIOD is negative, DTBT is set based

--- a/input_templates/tx0.66v1/G/MOM_input
+++ b/input_templates/tx0.66v1/G/MOM_input
@@ -111,11 +111,6 @@ HFREEZE = 10.0                  !   [m] default = -1.0
                                 ! over which melt potential is computed will be min(HFREEZE, OBLD),
                                 ! where OBLD is the boundary layer depth. If HFREEZE <= 0 (default),
                                 ! melt potential will not be computed.
-MIN_Z_DIAG_INTERVAL = 2.16E+04  !   [s] default = 0.0
-                                ! The minimum amount of time in seconds between
-                                ! calculations of depth-space diagnostics. Making this
-                                ! larger than DT_THERM reduces the  performance penalty
-                                ! of regridding to depth online.
 DTBT_RESET_PERIOD = 7200.0      !   [s] default = 7200.0
                                 ! The period between recalculations of DTBT (if DTBT <= 0).
                                 ! If DTBT_RESET_PERIOD is negative, DTBT is set based


### PR DESCRIPTION
This parameter has been obsoleted, see https://github.com/NOAA-GFDL/MOM6/pull/928.