### PR TITLE
add ChangeLog and update Externals.cfg for tagging

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,0 +1,22 @@
+===============================================================================
+Tag Creator: altuntas
+Developers:  altuntas
+Tag Date:    05 Aug 2019
+Tag Name:    mi_20190805
+
+MOM_interface Updates Summary:
+        - Added ChangeLog file.
+          ChangeLog is updated each time a new MOM_interface tag is created.
+          A new MOM_interface tag is created when new version(s) of NCAR/MOM6
+          and/or MOM_interface is to be incorporated in an upcoming CESM tag.
+        - Changed MOM6 entry in Externals.cfg to point to a tag instead of 
+          a branch.
+
+MOM6 Updates Summary: n/a
+
+Testing: aux_mom on cheyenne/intel
+
+Files Modified/Added/Removed:
+  new file:   ChangeLog
+  modified:   Externals.cfg
+

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -1,5 +1,5 @@
 [mom]
-branch = dev/ncar
+tag = dev/ncar_20190802
 protocol = git
 local_path = MOM6
 repo_url = https://github.com/NCAR/MOM6.git


### PR DESCRIPTION
- Added ChangeLog file:
  ChangeLog is updated each time a new MOM_interface tag is created.
  A new MOM_interface tag is created when new version(s) of NCAR/MOM6
  and/or MOM_interface is to be incorporated in an upcoming CESM tag.
- Changed MOM6 entry in Externals.cfg to point to a tag instead of a branch.

Once this PR gets merge, I will also create a MOM_interface mi_20190805