### PR TITLE
Set ENERGYSAVEDAYS_GEOMETRIC=0.0 for all cases

### DIFF
--- a/param_templates/MOM_input.yaml
+++ b/param_templates/MOM_input.yaml
@@ -1496,8 +1496,7 @@ Global:
             The interval increases by a factor of 2. after each call to write_energy."
         datatype: real
         units: days
-        value:
-            $OCN_GRID == "tx0.66v1": 0.25
+        value: 0.0
     ENERGETICS_SFC_PBL:
         description: |
           "[Boolean] default = False

--- a/param_templates/MOM_input.yaml
+++ b/param_templates/MOM_input.yaml
@@ -1488,15 +1488,6 @@ Global:
             $OCN_GRID == "gx1v6": 0.01
             $OCN_GRID == "tx0.66v1": 1.0
             $OCN_GRID == "MISOMIP": 1.0
-    ENERGYSAVEDAYS_GEOMETRIC:
-        description: |
-            "[days] default = 0.0
-            The starting interval in units of TIMEUNIT for the first call
-            to save the energies of the run and other globally summed diagnostics.
-            The interval increases by a factor of 2. after each call to write_energy."
-        datatype: real
-        units: days
-        value: 0.0
     ENERGETICS_SFC_PBL:
         description: |
           "[Boolean] default = False

--- a/param_templates/json/MOM_input.json
+++ b/param_templates/json/MOM_input.json
@@ -1109,9 +1109,7 @@
          "description": "\"[days] default = 0.0\nThe starting interval in units of TIMEUNIT for the first call\nto save the energies of the run and other globally summed diagnostics.\nThe interval increases by a factor of 2. after each call to write_energy.\"\n",
          "datatype": "real",
          "units": "days",
-         "value": {
-            "$OCN_GRID == \"tx0.66v1\"": 0.25
-         }
+         "value": 0.0
       },
       "ENERGETICS_SFC_PBL": {
          "description": "\"[Boolean] default = False\nIf true, use an implied energetics planetary boundary\nlayer scheme to determine the diffusivity and viscosity\nin the surface boundary layer.\"\n",

--- a/param_templates/json/MOM_input.json
+++ b/param_templates/json/MOM_input.json
@@ -1105,12 +1105,6 @@
             "$OCN_GRID == \"MISOMIP\"": 1.0
          }
       },
-      "ENERGYSAVEDAYS_GEOMETRIC": {
-         "description": "\"[days] default = 0.0\nThe starting interval in units of TIMEUNIT for the first call\nto save the energies of the run and other globally summed diagnostics.\nThe interval increases by a factor of 2. after each call to write_energy.\"\n",
-         "datatype": "real",
-         "units": "days",
-         "value": 0.0
-      },
       "ENERGETICS_SFC_PBL": {
          "description": "\"[Boolean] default = False\nIf true, use an implied energetics planetary boundary\nlayer scheme to determine the diffusivity and viscosity\nin the surface boundary layer.\"\n",
          "datatype": "logical",


### PR DESCRIPTION
Having ENERGYSAVEDAYS_GEOMETRIC != 0.0 affects the last three columns in ocean.stats (*Err), which is not ideal when checking if answers change across restarts.