### PR TITLE
CMORize variables and add missing diagnostic file

### DIFF
--- a/cime_config/MOM_RPS.py
+++ b/cime_config/MOM_RPS.py
@@ -312,7 +312,7 @@ class Diag_table(MOM_RPS):
                             time_axis_units = '"'+file_block['time_axis_units']+'",')
 
                 if 'new_file_freq' in file_block:
-                    file_descr_str += ', "'+str(file_block['new_file_freq'])+'", '
+                    file_descr_str += ', '+str(file_block['new_file_freq'])+', '
                     if 'time_axis_units' in file_block:
                         file_descr_str += '"'+str(file_block['new_file_freq_units'])+'"'
                 diag_table.write(file_descr_str+'\n')

--- a/param_templates/diag_table.yaml
+++ b/param_templates/diag_table.yaml
@@ -47,8 +47,8 @@ Files:
     # native grid
     hist:
         suffix: 
-            $OCN_DIAG_MODE == "spinup": "h%4yr"
-            else: "h%4yr-%2mo"
+            $OCN_DIAG_MODE == "spinup": "hm%4yr"
+            else: "hm%4yr-%2mo"
         output_freq: 1
         output_freq_units:
             $OCN_DIAG_MODE == "spinup": "years"

--- a/param_templates/diag_table.yaml
+++ b/param_templates/diag_table.yaml
@@ -4,32 +4,31 @@
 ###############################################################################
 
 FieldLists:
-    - &prognostic       ["u", "v", "h", "e", "temp", "salt", "rhoinsitu", "KE", "Rml", "Rv", "e_D"]
+    - &prognostic       ["uo", "vo", "h", "e", "thetao", "so", "rhoinsitu", "KE", "rhopot0"]
 
-    - &hist_additional  ["volcello", "thetao", "so", "vintage", "soga", "thetaoga"]
+    - &hist_additional  ["soga", "thetaoga", "umo", "vmo", "uh", "vh", "vhbt", "uhbt",
+                         "uhml", "vhml"]
 
-    - &tracers          ["age", "CFC11", "CFC12", "T_ady_2d", "T_adx_2d", "T_diffy_2d",
-                         "T_diffx_2d"]
+    - &tracers          ["agessc", "T_ady_2d", "T_adx_2d", "T_diffy_2d", "T_diffx_2d"]
 
-    - &surface_flds     ["SSH", "SST", "SSS", "SSU", "SSV", "mass_wt", "temp_int", 
-                         "salt_int", "Rd_dx", "speed", "MLD_003", "MLD_0125"]
+    - &surface_flds     ["SSH", "tos", "sos", "SSU", "SSV", "mass_wt", "opottempmint", 
+                         "somint", "Rd_dx", "speed", "mlotst"]
 
-    - &kpp_diags        ["KPP_OBLdepth"]
+    - &kpp_diags        ["oml"]
 
-    - &forcing_flds     ["taux", "tauy", "friver", "prsn", "precip", "evs", "hfsso", "rlntds",
-                         "hfsnthermds", "sfdsi", "salt_flux", "rsntds", "hfds", "ustar",
-                         "frazil", "PRCmE", "evap", "vprec", "lrunoff", "frunoff", "seaice_melt",
-                         "sensible", "latent", "SW", "LW", "p_surf"]
+    - &forcing_flds     ["tauuo", "tauvo", "friver", "prsn", "prlq", "evs", "hfsso", "rlntds",
+                         "hfsnthermds", "sfdsi", "rsntds", "hfds", "ustar",
+                         "hfsifrazil", "wfo", "vprec", "ficeberg", "fsitherm",
+                         "hflso", "pso", "seaice_melt_heat", "Heat_PmE", "salt_flux_added"]
 
-    - &forcing_flds_dev ["net_heat_coupler", "net_heat_surface", "seaice_melt_heat", "LwLatSens",
-                         "Heat_PmE", "heat_content_lrunoff", "heat_content_frunoff", 
-                         "heat_content_icemelt", "heat_content_lprec", "heat_content_fprec",
-                         "heat_content_vprec", "heat_content_cond", "heat_content_massout",
-                         "heat_content_massin", "heat_content_surfwater", "internal_heat",
-                         "heat_added", "vprec_global_adjustment", "net_fresh_water_global_adjustment",
+    - &forcing_flds_dev ["net_heat_coupler", "hfds", "LwLatSens", "heat_content_lrunoff",
+                         "heat_content_frunoff", "heat_content_icemelt", "heat_content_lprec", 
+                         "heat_content_fprec", "heat_content_vprec", "heat_content_cond", 
+                         "hfevapds", "heat_content_massin", "heat_content_surfwater", 
+                         "vprec_global_adjustment", "net_fresh_water_global_adjustment",
                          "salt_flux_global_restoring_adjustment", "net_massout", "net_massin"] 
 
-    - &visc_flds        ["KHTR_h", "KHTR_t", "Ahh", "Khh",]
+    - &visc_flds        ["diftrelo", "diftrblo", "difmxybo", "difmxylo", "vhGM", "uhGM"]
 
     - &static_flds      ["geolon", "geolat", "geolon_c", "geolat_c", "geolon_u", "geolat_u",
                          "geolon_v", "geolat_v", "area_t", "depth_ocean", "wet", "wet_c", "wet_u",
@@ -45,9 +44,43 @@ FieldLists:
 ###############################################################################
 
 Files:
-
+    # native grid
     hist:
-        suffix: "h%4yr-%2mo"
+        suffix: 
+            $OCN_DIAG_MODE == "spinup": "h%4yr"
+            else: "h%4yr-%2mo"
+        output_freq: 1
+        output_freq_units:
+            $OCN_DIAG_MODE == "spinup": "years"
+            else: "months"
+        time_axis_units: "days"
+        new_file_freq: 1
+        new_file_freq_units:
+            $OCN_DIAG_MODE == "spinup": "years"
+            else: "months"
+        reduction_method: "mean"    # time average
+        regional_section: "none"    # global
+        fields:
+            $OCN_DIAG_MODE == "spinup":
+                - module:   "ocean_model"   # z_space
+                  packing:  2                 # single precision
+                  lists:    [ *prognostic ]
+            else:
+                - module:   "ocean_model"   # z_space
+                  packing:  1                 # double precision
+                  lists:    [ *prognostic,
+                              *hist_additional,
+                              *kpp_diags,
+                              *forcing_flds,
+                              *surface_flds,
+                              *visc_flds,
+                              *tracers ]
+
+    # essential variable mapped to z_space
+    hist_z_space:
+        suffix:
+            $OCN_DIAG_MODE == "spinup": "h%4yr"
+            else: "h%4yr-%2mo"
         output_freq: 1
         output_freq_units:
             $OCN_DIAG_MODE == "spinup": "years"
@@ -67,13 +100,7 @@ Files:
             else:
                 - module:   "ocean_model_z"   # z_space
                   packing:  1                 # double precision
-                  lists:    [ *prognostic,
-                              *hist_additional,
-                              *kpp_diags,
-                              *forcing_flds,
-                              *surface_flds,
-                              *visc_flds,
-                              *tracers ]
+                  lists:    [ *prognostic ]
 
     surface_avg:
         suffix: "sfc%4yr"

--- a/param_templates/json/diag_table.json
+++ b/param_templates/json/diag_table.json
@@ -1,30 +1,30 @@
 {
    "FieldLists": [
       [
-         "u",
-         "v",
+         "uo",
+         "vo",
          "h",
          "e",
-         "temp",
-         "salt",
-         "rhoinsitu",
-         "KE",
-         "Rml",
-         "Rv",
-         "e_D"
-      ],
-      [
-         "volcello",
          "thetao",
          "so",
-         "vintage",
-         "soga",
-         "thetaoga"
+         "rhoinsitu",
+         "KE",
+         "rhopot0"
       ],
       [
-         "age",
-         "CFC11",
-         "CFC12",
+         "soga",
+         "thetaoga",
+         "umo",
+         "vmo",
+         "uh",
+         "vh",
+         "vhbt",
+         "uhbt",
+         "uhml",
+         "vhml"
+      ],
+      [
+         "agessc",
          "T_ady_2d",
          "T_adx_2d",
          "T_diffy_2d",
@@ -32,55 +32,49 @@
       ],
       [
          "SSH",
-         "SST",
-         "SSS",
+         "tos",
+         "sos",
          "SSU",
          "SSV",
          "mass_wt",
-         "temp_int",
-         "salt_int",
+         "opottempmint",
+         "somint",
          "Rd_dx",
          "speed",
-         "MLD_003",
-         "MLD_0125"
+         "mlotst"
       ],
       [
-         "KPP_OBLdepth"
+         "oml"
       ],
       [
-         "taux",
-         "tauy",
+         "tauuo",
+         "tauvo",
          "friver",
          "prsn",
-         "precip",
+         "prlq",
          "evs",
          "hfsso",
          "rlntds",
          "hfsnthermds",
          "sfdsi",
-         "salt_flux",
          "rsntds",
          "hfds",
          "ustar",
-         "frazil",
-         "PRCmE",
-         "evap",
+         "hfsifrazil",
+         "wfo",
          "vprec",
-         "lrunoff",
-         "frunoff",
-         "seaice_melt",
-         "sensible",
-         "latent",
-         "SW",
-         "LW",
-         "p_surf"
+         "ficeberg",
+         "fsitherm",
+         "hflso",
+         "pso",
+         "seaice_melt_heat",
+         "Heat_PmE",
+         "salt_flux_added"
       ],
       [
          "net_heat_coupler",
-         "net_heat_surface",
-         "seaice_melt_heat",
+         "hfds",
          "LwLatSens",
-         "Heat_PmE",
          "heat_content_lrunoff",
          "heat_content_frunoff",
          "heat_content_icemelt",
@@ -88,11 +82,9 @@
          "heat_content_fprec",
          "heat_content_vprec",
          "heat_content_cond",
-         "heat_content_massout",
+         "hfevapds",
          "heat_content_massin",
          "heat_content_surfwater",
-         "internal_heat",
-         "heat_added",
          "vprec_global_adjustment",
          "net_fresh_water_global_adjustment",
          "salt_flux_global_restoring_adjustment",
@@ -100,10 +92,12 @@
          "net_massin"
       ],
       [
-         "KHTR_h",
-         "KHTR_t",
-         "Ahh",
-         "Khh"
+         "diftrelo",
+         "diftrblo",
+         "difmxybo",
+         "difmxylo",
+         "vhGM",
+         "uhGM"
       ],
       [
          "geolon",
@@ -139,7 +133,137 @@
    ],
    "Files": {
       "hist": {
-         "suffix": "h%4yr-%2mo",
+         "suffix": {
+            "$OCN_DIAG_MODE == \"spinup\"": "hm%4yr",
+            "else": "hm%4yr-%2mo"
+         },
+         "output_freq": 1,
+         "output_freq_units": {
+            "$OCN_DIAG_MODE == \"spinup\"": "years",
+            "else": "months"
+         },
+         "time_axis_units": "days",
+         "new_file_freq": 1,
+         "new_file_freq_units": {
+            "$OCN_DIAG_MODE == \"spinup\"": "years",
+            "else": "months"
+         },
+         "reduction_method": "mean",
+         "regional_section": "none",
+         "fields": {
+            "$OCN_DIAG_MODE == \"spinup\"": [
+               {
+                  "module": "ocean_model",
+                  "packing": 2,
+                  "lists": [
+                     [
+                        "uo",
+                        "vo",
+                        "h",
+                        "e",
+                        "thetao",
+                        "so",
+                        "rhoinsitu",
+                        "KE",
+                        "rhopot0"
+                     ]
+                  ]
+               }
+            ],
+            "else": [
+               {
+                  "module": "ocean_model",
+                  "packing": 1,
+                  "lists": [
+                     [
+                        "uo",
+                        "vo",
+                        "h",
+                        "e",
+                        "thetao",
+                        "so",
+                        "rhoinsitu",
+                        "KE",
+                        "rhopot0"
+                     ],
+                     [
+                        "soga",
+                        "thetaoga",
+                        "umo",
+                        "vmo",
+                        "uh",
+                        "vh",
+                        "vhbt",
+                        "uhbt",
+                        "uhml",
+                        "vhml"
+                     ],
+                     [
+                        "oml"
+                     ],
+                     [
+                        "tauuo",
+                        "tauvo",
+                        "friver",
+                        "prsn",
+                        "prlq",
+                        "evs",
+                        "hfsso",
+                        "rlntds",
+                        "hfsnthermds",
+                        "sfdsi",
+                        "rsntds",
+                        "hfds",
+                        "ustar",
+                        "hfsifrazil",
+                        "wfo",
+                        "vprec",
+                        "ficeberg",
+                        "fsitherm",
+                        "hflso",
+                        "pso",
+                        "seaice_melt_heat",
+                        "Heat_PmE",
+                        "salt_flux_added"
+                     ],
+                     [
+                        "SSH",
+                        "tos",
+                        "sos",
+                        "SSU",
+                        "SSV",
+                        "mass_wt",
+                        "opottempmint",
+                        "somint",
+                        "Rd_dx",
+                        "speed",
+                        "mlotst"
+                     ],
+                     [
+                        "diftrelo",
+                        "diftrblo",
+                        "difmxybo",
+                        "difmxylo",
+                        "vhGM",
+                        "uhGM"
+                     ],
+                     [
+                        "agessc",
+                        "T_ady_2d",
+                        "T_adx_2d",
+                        "T_diffy_2d",
+                        "T_diffx_2d"
+                     ]
+                  ]
+               }
+            ]
+         }
+      },
+      "hist_z_space": {
+         "suffix": {
+            "$OCN_DIAG_MODE == \"spinup\"": "h%4yr",
+            "else": "h%4yr-%2mo"
+         },
          "output_freq": 1,
          "output_freq_units": {
             "$OCN_DIAG_MODE == \"spinup\"": "years",
@@ -160,17 +284,15 @@
                   "packing": 2,
                   "lists": [
                      [
-                        "u",
-                        "v",
+                        "uo",
+                        "vo",
                         "h",
                         "e",
-                        "temp",
-                        "salt",
+                        "thetao",
+                        "so",
                         "rhoinsitu",
                         "KE",
-                        "Rml",
-                        "Rv",
-                        "e_D"
+                        "rhopot0"
                      ]
                   ]
                }
@@ -181,85 +303,15 @@
                   "packing": 1,
                   "lists": [
                      [
-                        "u",
-                        "v",
+                        "uo",
+                        "vo",
                         "h",
                         "e",
-                        "temp",
-                        "salt",
-                        "rhoinsitu",
-                        "KE",
-                        "Rml",
-                        "Rv",
-                        "e_D"
-                     ],
-                     [
-                        "volcello",
                         "thetao",
                         "so",
-                        "vintage",
-                        "soga",
-                        "thetaoga"
-                     ],
-                     [
-                        "KPP_OBLdepth"
-                     ],
-                     [
-                        "taux",
-                        "tauy",
-                        "friver",
-                        "prsn",
-                        "precip",
-                        "evs",
-                        "hfsso",
-                        "rlntds",
-                        "hfsnthermds",
-                        "sfdsi",
-                        "salt_flux",
-                        "rsntds",
-                        "hfds",
-                        "ustar",
-                        "frazil",
-                        "PRCmE",
-                        "evap",
-                        "vprec",
-                        "lrunoff",
-                        "frunoff",
-                        "seaice_melt",
-                        "sensible",
-                        "latent",
-                        "SW",
-                        "LW",
-                        "p_surf"
-                     ],
-                     [
-                        "SSH",
-                        "SST",
-                        "SSS",
-                        "SSU",
-                        "SSV",
-                        "mass_wt",
-                        "temp_int",
-                        "salt_int",
-                        "Rd_dx",
-                        "speed",
-                        "MLD_003",
-                        "MLD_0125"
-                     ],
-                     [
-                        "KHTR_h",
-                        "KHTR_t",
-                        "Ahh",
-                        "Khh"
-                     ],
-                     [
-                        "age",
-                        "CFC11",
-                        "CFC12",
-                        "T_ady_2d",
-                        "T_adx_2d",
-                        "T_diffy_2d",
-                        "T_diffx_2d"
+                        "rhoinsitu",
+                        "KE",
+                        "rhopot0"
                      ]
                   ]
                }
@@ -283,17 +335,16 @@
                   "lists": [
                      [
                         "SSH",
-                        "SST",
-                        "SSS",
+                        "tos",
+                        "sos",
                         "SSU",
                         "SSV",
                         "mass_wt",
-                        "temp_int",
-                        "salt_int",
+                        "opottempmint",
+                        "somint",
                         "Rd_dx",
                         "speed",
-                        "MLD_003",
-                        "MLD_0125"
+                        "mlotst"
                      ]
                   ]
                }
@@ -316,39 +367,34 @@
                   "packing": 1,
                   "lists": [
                      [
-                        "taux",
-                        "tauy",
+                        "tauuo",
+                        "tauvo",
                         "friver",
                         "prsn",
-                        "precip",
+                        "prlq",
                         "evs",
                         "hfsso",
                         "rlntds",
                         "hfsnthermds",
                         "sfdsi",
-                        "salt_flux",
                         "rsntds",
                         "hfds",
                         "ustar",
-                        "frazil",
-                        "PRCmE",
-                        "evap",
+                        "hfsifrazil",
+                        "wfo",
                         "vprec",
-                        "lrunoff",
-                        "frunoff",
-                        "seaice_melt",
-                        "sensible",
-                        "latent",
-                        "SW",
-                        "LW",
-                        "p_surf"
+                        "ficeberg",
+                        "fsitherm",
+                        "hflso",
+                        "pso",
+                        "seaice_melt_heat",
+                        "Heat_PmE",
+                        "salt_flux_added"
                      ],
                      [
                         "net_heat_coupler",
-                        "net_heat_surface",
-                        "seaice_melt_heat",
+                        "hfds",
                         "LwLatSens",
-                        "Heat_PmE",
                         "heat_content_lrunoff",
                         "heat_content_frunoff",
                         "heat_content_icemelt",
@@ -356,11 +402,9 @@
                         "heat_content_fprec",
                         "heat_content_vprec",
                         "heat_content_cond",
-                        "heat_content_massout",
+                        "hfevapds",
                         "heat_content_massin",
                         "heat_content_surfwater",
-                        "internal_heat",
-                        "heat_added",
                         "vprec_global_adjustment",
                         "net_fresh_water_global_adjustment",
                         "salt_flux_global_restoring_adjustment",
@@ -388,10 +432,12 @@
                   "packing": 1,
                   "lists": [
                      [
-                        "KHTR_h",
-                        "KHTR_t",
-                        "Ahh",
-                        "Khh"
+                        "diftrelo",
+                        "diftrblo",
+                        "difmxybo",
+                        "difmxylo",
+                        "vhGM",
+                        "uhGM"
                      ]
                   ]
                }


### PR DESCRIPTION
This PR changes the name of the fields to the CMOR equivalent (when available). It also adds the following:
* removes quotes from file frequency when converting the YAML file (in MOM_RPS.py);
* ads new diagnostic file *hm* using the native vertical grid;
* adds new fields to the diag_table.
