### PR TITLE
Set USE_STORED_SLOPES = False for tx0.66v1 and gx1v6

### DIFF
--- a/param_templates/MOM_input.yaml
+++ b/param_templates/MOM_input.yaml
@@ -562,8 +562,8 @@ Global:
         datatype: logical
         units: Boolean
         value:
-            $OCN_GRID == "gx1v6": True
-            $OCN_GRID == "tx0.66v1": True
+            $OCN_GRID == "gx1v6": False
+            $OCN_GRID == "tx0.66v1": False
             $OCN_GRID == "tx0.25v1": True
     ETA_TOLERANCE:
         description: |

--- a/param_templates/json/MOM_input.json
+++ b/param_templates/json/MOM_input.json
@@ -401,8 +401,8 @@
          "datatype": "logical",
          "units": "Boolean",
          "value": {
-            "$OCN_GRID == \"gx1v6\"": true,
-            "$OCN_GRID == \"tx0.66v1\"": true,
+            "$OCN_GRID == \"gx1v6\"": false,
+            "$OCN_GRID == \"tx0.66v1\"": false,
             "$OCN_GRID == \"tx0.25v1\"": true
          }
       },


### PR DESCRIPTION
In the current configuration for tx0.66v1 and gx1v6, GM is not
applied since setting USE_STORED_SLOPES=True does not guarantee
slopes will be computed (either KHTH_SLOPE_CFF or KHTR_SLOPE_CFF
must also be > 0). By setting USE_STORED_SLOPES = False
and THICKNESSDIFFUSE = True slopes are always calculated in
thickness_diffuse, which is the only place they are used.

This will change answers for compsets using these grids.