### PR TITLE
Updates parameters in the MLE parameterization

### DIFF
--- a/param_templates/MOM_input.yaml
+++ b/param_templates/MOM_input.yaml
@@ -1200,7 +1200,7 @@ Global:
         datatype: real
         units: m
         value:
-            $OCN_GRID == "tx0.66v1": 200.0
+            $OCN_GRID == "tx0.66v1": 1000.0
             $OCN_GRID == "tx0.25v1": 500.0
     MLE_MLD_DECAY_TIME:
         description: |
@@ -1212,7 +1212,7 @@ Global:
         datatype: real
         units: s
         value:
-            $OCN_GRID == "tx0.66v1": 2.592E+06
+            $OCN_GRID == "tx0.66v1": 3.45600E+05
             $OCN_GRID == "tx0.25v1": 2.592E+06
     USE_CVMix_CONVECTION:
         description: |

--- a/param_templates/json/MOM_input.json
+++ b/param_templates/json/MOM_input.json
@@ -856,7 +856,7 @@
          "datatype": "real",
          "units": "m",
          "value": {
-            "$OCN_GRID == \"tx0.66v1\"": 200.0,
+            "$OCN_GRID == \"tx0.66v1\"": 1000.0,
             "$OCN_GRID == \"tx0.25v1\"": 500.0
          }
       },
@@ -865,7 +865,7 @@
          "datatype": "real",
          "units": "s",
          "value": {
-            "$OCN_GRID == \"tx0.66v1\"": 2592000.0,
+            "$OCN_GRID == \"tx0.66v1\"": 345600.0,
             "$OCN_GRID == \"tx0.25v1\"": 2592000.0
          }
       },


### PR DESCRIPTION
Previous values for the length scale (200 m) and decay time (30 days) in the MLE parameterization were giving extremely large (> 40 Sv) transport values, as shown below.

![image](https://user-images.githubusercontent.com/11339137/66058841-4ad4e780-e4f8-11e9-86fa-5d3777984f1a.png)

This PR sets these parameters to 1 km and 4 days in the tx0.66v1 grid,

```
MLE_FRONT_LENGTH = 1000.0
MLE_MLD_DECAY_TIME = 3.45600E+05
```
which leads to more reasonable transports. We actually do not know what these values should be but the results shown below are similar to those from POP. Weaker transports also reduced grid-scale noise in vhML.

![image](https://user-images.githubusercontent.com/11339137/66058881-5c1df400-e4f8-11e9-9fda-6c897c9d391d.png)

Answers will change for tx0.66v1
