### PR TITLE
Sets DEPTH_SCALED_KHTH=True for tx0.66v1

### DIFF
--- a/param_templates/MOM_input.yaml
+++ b/param_templates/MOM_input.yaml
@@ -523,6 +523,20 @@ Global:
             $OCN_GRID == "gx1v6": True
             $OCN_GRID == "tx0.66v1": False
             $OCN_GRID == "tx0.25v1": True
+    DEPTH_SCALED_KHTH:
+        description: |
+            "[Boolean] default = False
+             If true,  KHTH is scaled away when the depth is shallower
+             than a reference depth: KHTH = MIN(1,H/H0)**N * KHTH,
+             where H0 is a reference depth, controlled via
+             DEPTH_SCALED_KHTH_H0, and theexponent (N) is
+             controlled via DEPTH_SCALED_KHTH_EXP."
+        datatype: logical
+        units: Boolean
+        value:
+            $OCN_GRID == "gx1v6": False
+            $OCN_GRID == "tx0.66v1": True
+            $OCN_GRID == "tx0.25v1": False
     KHTR_SLOPE_CFF:
         description: |
             "[nondim] default = 0.0

--- a/param_templates/json/MOM_input.json
+++ b/param_templates/json/MOM_input.json
@@ -370,6 +370,16 @@
             "$OCN_GRID == \"tx0.25v1\"": true
          }
       },
+      "DEPTH_SCALED_KHTH": {
+         "description": "\"[Boolean] default = False\n If true,  KHTH is scaled away when the depth is shallower\n than a reference depth: KHTH = MIN(1,H/H0)**N * KHTH,\n where H0 is a reference depth, controlled via\n DEPTH_SCALED_KHTH_H0, and theexponent (N) is\n controlled via DEPTH_SCALED_KHTH_EXP.\"\n",
+         "datatype": "logical",
+         "units": "Boolean",
+         "value": {
+            "$OCN_GRID == \"gx1v6\"": false,
+            "$OCN_GRID == \"tx0.66v1\"": true,
+            "$OCN_GRID == \"tx0.25v1\"": false
+         }
+      },
       "KHTR_SLOPE_CFF": {
          "description": "\"[nondim] default = 0.0\nThe nondimensional coefficient in the Visbeck formula\nfor the epipycnal tracer diffusivity\"\n",
          "datatype": "real",


### PR DESCRIPTION
Following https://github.com/NCAR/MOM6/pull/127, this PR sets DEPTH_SCALED_KHTH=True for ocean grid tx0.66v1. This will change answers for all compsets using this grid. 