### PR TITLE
Change option for background diffusivity

### DIFF
--- a/param_templates/MOM_input.yaml
+++ b/param_templates/MOM_input.yaml
@@ -1296,12 +1296,11 @@ Global:
             $OCN_GRID == "gx1v6": 0.1
             $OCN_GRID == "tx0.66v1": 0.1
             $OCN_GRID == "tx0.25v1": 0.1
-    HENYEY_IGW_BACKGROUND:
+    HORIZ_VARYING_BACKGROUND:
         description: |
             "[Boolean] default = False
-            If true, use a latitude-dependent scaling for the near
-            surface background diffusivity, as described in
-            Harrison & Hallberg, JPO 2008."
+             If true, apply vertically uniform, latitude-dependent background diffusivity,
+             as described in Danabasoglu et al., 2012."
         datatype: logical
         units: Boolean
         value:

--- a/param_templates/json/MOM_input.json
+++ b/param_templates/json/MOM_input.json
@@ -926,8 +926,8 @@
             "$OCN_GRID == \"tx0.25v1\"": 0.1
          }
       },
-      "HENYEY_IGW_BACKGROUND": {
-         "description": "\"[Boolean] default = False\nIf true, use a latitude-dependent scaling for the near\nsurface background diffusivity, as described in\nHarrison & Hallberg, JPO 2008.\"\n",
+      "HORIZ_VARYING_BACKGROUND": {
+         "description": "\"[Boolean] default = False\n If true, apply vertically uniform, latitude-dependent background diffusivity,\n as described in Danabasoglu et al., 2012.\"\n",
          "datatype": "logical",
          "units": "Boolean",
          "value": {


### PR DESCRIPTION
Previously we were using the latitude-dependent scaling for the near surface background diffusivity, as described in Harrison & Hallberg, JPO 2008. This commit disables this option and enables the latitude-dependent background diffusivity described in Danabasoglu et al., 2012.

Answers should change since this is applied to all ocean grids currently supported.