### PR TITLE
Add the option of turning off diagnostics

### DIFF
--- a/cime_config/MOM_RPS/FType_MOM_params.py
+++ b/cime_config/MOM_RPS/FType_MOM_params.py
@@ -73,7 +73,7 @@ class FType_MOM_params(MOM_RPS):
 
                                 # check if param already provided:
                                 if param_str in _data[curr_module]:
-                                    raise SystemExit('ERROR: '+param_str+' listed more than once in '+file_name)
+                                    raise SystemExit('ERROR: '+param_str+' listed more than once in '+input_path)
 
                                 # enter the parameter in the dictionary:
                                 _data[curr_module][param_str] = {'value':val_str}

--- a/cime_config/MOM_RPS/MOM_RPS.py
+++ b/cime_config/MOM_RPS/MOM_RPS.py
@@ -5,6 +5,7 @@ import abc
 import re
 from rps_utils import get_str_type, is_logical_expr, has_expandable_var, eval_formula
 from rps_utils import is_formula, eval_formula
+import copy
 
 ### MOM Runtime Parameter System Module =======================================
 
@@ -38,7 +39,7 @@ class MOM_RPS(object,):
     def __init__(self, data_dict):
         assert type(data_dict) in [dict, OrderedDict], \
             "MOM_RPS class requires a dict or OrderedDict as the initial data."
-        self._data = data_dict
+        self._data = copy.deepcopy(data_dict)
 
     @property
     def data(self):

--- a/cime_config/config_component.xml
+++ b/cime_config/config_component.xml
@@ -19,7 +19,7 @@
 
   <entry id="OCN_DIAG_MODE">
     <type>char</type>
-    <valid_values>spinup,production,development</valid_values>
+    <valid_values>spinup,production,development,none</valid_values>
     <default_value>production</default_value>
     <group>case_comp</group>
     <file>env_run.xml</file>

--- a/param_templates/diag_table.yaml
+++ b/param_templates/diag_table.yaml
@@ -64,9 +64,10 @@ Files:
         reduction_method: "mean"    # time average
         regional_section: "none"    # global
         fields:
-            - module:   "ocean_model_rho2"
-              packing:  2                 # single precision
-              lists:    [ *transports ]
+            $OCN_DIAG_MODE != "none":
+                - module:   "ocean_model_rho2"
+                  packing:  2                 # single precision
+                  lists:    [ *transports ]
 
     # native grid
     hist:
@@ -94,7 +95,7 @@ Files:
                               *tracers,
                               *visc_flds,
                               *transports ]
-            else:
+            $OCN_DIAG_MODE not in ["spinup", "none"]:
                 - module:   "ocean_model"
                   packing:  1                 # double precision
                   lists:    [ *prognostic,
@@ -129,7 +130,7 @@ Files:
                 - module:   "ocean_model_z"   # z_space
                   packing:  2                 # single precision
                   lists:    [ *prognostic ]
-            else:
+            $OCN_DIAG_MODE not in ["spinup", "none"]:
                 - module:   "ocean_model_z"   # z_space
                   packing:  1                 # double precision
                   lists:    [ *prognostic ]

--- a/param_templates/json/diag_table.json
+++ b/param_templates/json/diag_table.json
@@ -155,23 +155,25 @@
          },
          "reduction_method": "mean",
          "regional_section": "none",
-         "fields": [
-            {
-               "module": "ocean_model_rho2",
-               "packing": 2,
-               "lists": [
-                  [
-                     "volcello",
-                     "vmo",
-                     "vhGM",
-                     "vhml",
-                     "umo",
-                     "uhGM",
-                     "uhml"
+         "fields": {
+            "$OCN_DIAG_MODE != \"none\"": [
+               {
+                  "module": "ocean_model_rho2",
+                  "packing": 2,
+                  "lists": [
+                     [
+                        "volcello",
+                        "vmo",
+                        "vhGM",
+                        "vhml",
+                        "umo",
+                        "uhGM",
+                        "uhml"
+                     ]
                   ]
-               ]
-            }
-         ]
+               }
+            ]
+         }
       },
       "hist": {
          "suffix": {
@@ -232,7 +234,7 @@
                   ]
                }
             ],
-            "else": [
+            "$OCN_DIAG_MODE not in [\"spinup\", \"none\"]": [
                {
                   "module": "ocean_model",
                   "packing": 1,
@@ -364,7 +366,7 @@
                   ]
                }
             ],
-            "else": [
+            "$OCN_DIAG_MODE not in [\"spinup\", \"none\"]": [
                {
                   "module": "ocean_model_z",
                   "packing": 1,


### PR DESCRIPTION
This PR adds the option of turning off diagnostics fully. This option will be useful for benchmarking and profiling studies.

With this change, one can turn off diagnostics with the following two XML changes:

```
./xmlchange OCN_DIAG_MODE=none
./xmlchange OCN_DIAG_SECTIONS=False
```

testing: pr_mom/cheyenne/b4b
