### PR TITLE
Add option to compile MOM6 using dynamic_symmetric

### DIFF
--- a/cime_config/buildlib
+++ b/cime_config/buildlib
@@ -61,6 +61,7 @@ def buildlib(caseroot, libroot, bldroot):
         # create Filepath file for mom
         #-------------------------------------------------------
         sharedlibroot = case.get_value("SHAREDLIBROOT")
+        memory_mode =  case.get_value("MOM6_MEMORY_MODE")
 
         user_incldir = "\"-I{} -I{} -I{}\"".\
                         format(os.path.join(srcroot,"libraries","FMS","src","include"),
@@ -73,7 +74,7 @@ def buildlib(caseroot, libroot, bldroot):
             os.environ["CPPDEFS"] = " -Duse_libMPI -Duse_netCDF -DSPMD"
             paths = [os.path.join(caseroot,"SourceMods","src.mom"),
                      os.path.join(srcroot,"components","mom","MOM6","config_src",driver),
-                     os.path.join(srcroot,"components","mom","MOM6","config_src","dynamic"),
+                     os.path.join(srcroot,"components","mom","MOM6","config_src",memory_mode),
                      os.path.join(srcroot,"components","mom","MOM6","src","ALE"),
                      os.path.join(srcroot,"components","mom","MOM6","src","core"),
                      os.path.join(srcroot,"components","mom","MOM6","src","diagnostics"),

--- a/cime_config/config_component.xml
+++ b/cime_config/config_component.xml
@@ -17,6 +17,19 @@
     <desc>MOM6 ocean component</desc>
   </entry>
 
+  <entry id="MOM6_MEMORY_MODE">
+    <type>char</type>
+    <valid_values>dynamic,dynamic_symmetric</valid_values>
+    <default_value>dynamic</default_value>
+    <group>build_component_mom</group>
+    <file>env_build.xml</file>
+    <desc> This variable controls MOM6 memory mode. In non-symmetric mode (default), all arrays are
+           given the same shape. In symmetric mode, declarations are dependent on the variables
+           staggered location on the Arakawa C grid. This allows loops to be symmetric and stencils
+           to be applied more uniformly.
+    </desc>
+  </entry>
+
   <entry id="OCN_DIAG_MODE">
     <type>char</type>
     <valid_values>spinup,production,development,none</valid_values>


### PR DESCRIPTION
Adds a new xml variable ```MOM6_MEMORY_MODE``` that controls the MOM6 memory model, which is ```dynamic``` by default. The user can change it to ```dynamic_symmetric``` as follows:

```./xmlchange MOM6_MEMORY_MODE=dynamic_symmetric```

The variable description is as follows: MOM6_MEMORY_MODE: This variable controls MOM6 memory mode.  In non-symmetric mode (default), all arrays are given the same shape.  In symmetric mode, declarations are dependent on the variables staggered location on the Arakawa C grid.  This allows loops to be symmetric and stencils to be applied more uniformly.

Fixes: #63 
