### PR TITLE
Changes for CESM2.2

### DIFF
--- a/param_templates/MOM_input.yaml
+++ b/param_templates/MOM_input.yaml
@@ -430,7 +430,7 @@ Global:
         datatype: string
         value:
             $OCN_GRID == "gx1v6": "ocean_topog.nc"
-            $OCN_GRID == "tx0.66v1": "ocean_topog_190314.nc"
+            $OCN_GRID == "tx0.66v1": "ocean_topog_200701.nc"
             $OCN_GRID == "tx0.25v1": "ocean_topog.nc"
     MAXIMUM_DEPTH:
         description: |

--- a/param_templates/MOM_input.yaml
+++ b/param_templates/MOM_input.yaml
@@ -2206,6 +2206,26 @@ Global:
         units: nondim
         value:
             $OCN_GRID == "tx0.25v1": 1.0
+            $OCN_GRID == "tx0.66v1": 0.5
+    MEKE_VISCOSITY_COEFF_KU:
+        description: |
+            "[nondim] default = 0.0
+            If non-zero, is the scaling coefficient in the expression forviscosity used to
+            parameterize harmonic lateral momentum mixing byunresolved eddies represented
+            by MEKE. Can be negative torepresent backscatter from the unresolved eddies."
+        datatype: real
+        units: nondim
+        value:
+            $OCN_GRID == "tx0.66v1": 0.2
+    MEKE_MIN_LSCALE:
+        description: |
+            "[Boolean] default = False
+            If true, use a strict minimum of provided length scales rather than harmonic
+            mean."
+        datatype: logical
+        units: Boolean
+        value:
+            $OCN_GRID == "tx0.66v1": True
     MEKE_ALPHA_RHINES:
         description: |
             "[nondim] default = 0.05
@@ -2215,6 +2235,7 @@ Global:
         units: nondim
         value:
             $OCN_GRID == "tx0.25v1": 0.15
+            $OCN_GRID == "tx0.66v1": 1.0
     MEKE_ALPHA_EADY:
         description: |
             "[nondim] default = 0.05
@@ -2224,6 +2245,62 @@ Global:
         units: nondim
         value:
             $OCN_GRID == "tx0.25v1": 0.15
+            $OCN_GRID == "tx0.66v1": 1.0
+    MEKE_ALPHA_DEFORM:
+        description: |
+            "[nondim] default = 0.0
+            If positive, is a coefficient weighting the deformation scale in the
+            expression for mixing length used in MEKE-derived diffusivity."
+        datatype: real
+        units: nondim
+        value:
+            $OCN_GRID == "tx0.66v1": 1.0
+    MEKE_ALPHA_FRICT:
+        description: |
+            "[nondim] default = 0.0
+            If positive, is a coefficient weighting the frictional arrest scale in the
+            expression for mixing length used in MEKE-derived diffusivity."
+        datatype: real
+        units: nondim
+        value:
+            $OCN_GRID == "tx0.66v1": 1.0
+    MEKE_ALPHA_GRID:
+        description: |
+            "[nondim] default = 0.0
+            If positive, is a coefficient weighting the grid-spacing as a scale in the
+            expression for mixing length used in MEKE-derived diffusivity."
+        datatype: real
+        units: nondim
+        value:
+            $OCN_GRID == "tx0.66v1": 1.0
+    MEKE_FRCOEFF:
+        description: |
+            "[nondim] default = -1.0
+            If positive, is a coefficient weighting the grid-spacing as a scale in the
+            expression for mixing length used in MEKE-derived diffusivity."
+        datatype: real
+        units: nondim
+        value:
+            $OCN_GRID == "tx0.66v1": -1.0
+    KH_RES_SCALE_COEF:
+        description: |
+            "[nondim] default = 1.0
+            A coefficient that determines how KhTh is scaled away if RESOLN_SCALED_... is
+            true, as F = 1 / (1 + (KH_RES_SCALE_COEF*Rd/dx)^KH_RES_FN_POWER)."
+        datatype: real
+        units: nondim
+        value:
+            $OCN_GRID == "tx0.66v1": 0.4
+    VISC_RES_SCALE_COEF:
+        description: |
+            "[nondim] default = 1.0
+            A coefficient that determines how Kh is scaled away if RESOLN_SCALED_... is
+            true, as F = 1 / (1 + (KH_RES_SCALE_COEF*Rd/dx)^KH_RES_FN_POWER). This
+            function affects lateral viscosity, Kh, and not KhTh."
+        datatype: real
+        units: nondim
+        value:
+            $OCN_GRID == "tx0.66v1": 0.4
     MEKE_GEOMETRIC:
         description: |
             "[Boolean] default = False
@@ -2242,6 +2319,22 @@ Global:
         units: nondim
         value:
             $OCN_GRID == "tx0.66v1": 0.07
+    MEKE_KHTH_FAC:
+        description: |
+            "[nondim] default = 0.0
+            A factor that maps MEKE%Kh to KhTh."
+        datatype: real
+        units: nondim
+        value:
+            $OCN_GRID == "tx0.66v1": 1.0
+    MEKE_KHTR_FAC:
+        description: |
+            "[nondim] default = 0.0
+            A factor that maps MEKE%Kh to KhTr."
+        datatype: real
+        units: nondim
+        value:
+            $OCN_GRID == "tx0.66v1": 1.0
     MEKE_EQUILIBRIUM_ALT:
         description: |
             "[Boolean] default = False
@@ -2251,6 +2344,14 @@ Global:
         units: Boolean
         value:
             $OCN_GRID == "tx0.66v1": True
+    MEKE_VISC_DRAG:
+        description: |
+            "[Boolean] default = True
+            If true, use the vertvisc_type to calculate the bottom drag acting on MEKE."
+        datatype: logical
+        units: Boolean
+        value:
+            $OCN_GRID == "tx0.66v1": False
     MEKE_EQUILIBRIUM_RESTORING:
         description: |
             "[Boolean] default = False

--- a/param_templates/MOM_input.yaml
+++ b/param_templates/MOM_input.yaml
@@ -554,8 +554,17 @@ Global:
         units: Boolean
         value:
             $OCN_GRID == "gx1v6": True
-            $OCN_GRID == "tx0.66v1": False
+            $OCN_GRID == "tx0.66v1": True
             $OCN_GRID == "tx0.25v1": True
+    KHTH_SLOPE_CFF:
+        description: |
+            "[nondim] default = 0.0
+            The nondimensional coefficient in the Visbeck formula for the interface depth
+            diffusivity"
+        datatype: real
+        units: nondim
+        value:
+            $OCN_GRID == "tx0.66v1": 0.01
     DEPTH_SCALED_KHTH:
         description: |
             "[Boolean] default = False
@@ -570,6 +579,14 @@ Global:
             $OCN_GRID == "gx1v6": False
             $OCN_GRID == "tx0.66v1": True
             $OCN_GRID == "tx0.25v1": False
+    DEPTH_SCALED_KHTH_H0:
+        description: |
+            "[m] default = 1000.0
+            The depth above which KHTH is scaled away."
+        datatype: real
+        units: nondim
+        value:
+            $OCN_GRID == "tx0.66v1": 250.0
     KHTR_SLOPE_CFF:
         description: |
             "[nondim] default = 0.0
@@ -598,7 +615,7 @@ Global:
         units: Boolean
         value:
             $OCN_GRID == "gx1v6": True
-            $OCN_GRID == "tx0.66v1": False
+            $OCN_GRID == "tx0.66v1": True
             $OCN_GRID == "tx0.25v1": True
     USE_GM_WORK_BUG:
         description: |
@@ -618,7 +635,7 @@ Global:
         units: Boolean
         value:
             $OCN_GRID == "gx1v6": False
-            $OCN_GRID == "tx0.66v1": False
+            $OCN_GRID == "tx0.66v1": True
             $OCN_GRID == "tx0.25v1": True
     ETA_TOLERANCE:
         description: |
@@ -654,6 +671,32 @@ Global:
         units: Boolean
         value:
             $OCN_GRID == "gx1v6": True
+            $OCN_GRID == "tx0.66v1": True
+    NDIFF_INTERIOR_ONLY:
+        description: |
+            "[Boolean] default = False
+            If true, only applies neutral diffusion in the ocean interior. That is, the
+            algorithm will exclude the surface and bottomboundary layers."
+        datatype: logical
+        units: Boolean
+        value:
+            $OCN_GRID == "tx0.66v1": True
+    USE_LATERAL_BOUNDARY_DIFFUSION:
+        description: |
+            "[Boolean] default = False
+            If true, enables the lateral boundary tracer's diffusion module."
+        datatype: logical
+        units: Boolean
+        value:
+            $OCN_GRID == "tx0.66v1": True
+    LBD_LINEAR_TRANSITION:
+        description: |
+            "[Boolean] default = False
+            If True, apply a linear transition at the base/top of the boundary.
+            The flux will be fully applied at k=k_min and zero at k=k_max."
+        datatype: logical
+        units: Boolean
+        value:
             $OCN_GRID == "tx0.66v1": True
     SIMPLE_TKE_TO_KD:
         description: |
@@ -802,7 +845,6 @@ Global:
         datatype: real
         units: m2 s-1
         value:
-            $OCN_GRID == "tx0.66v1": 1000.0
             $OCN_GRID == "MISOMIP": 6.0
     KH_VEL_SCALE:
         description: |
@@ -816,6 +858,7 @@ Global:
         value:
             $OCN_GRID == "MISOMIP": 0.0
             $OCN_GRID == "tx0.25v1": 0.0
+            $OCN_GRID == "tx0.66v1": 0.0
             else: 0.01
     KH_SIN_LAT:
         description: |
@@ -845,6 +888,14 @@ Global:
         value:
             $OCN_GRID == "tx0.66v1": True
             $OCN_GRID == "MISOMIP": False
+    AH:
+        description: |
+            "[m4 s-1] default = 0.0
+            The background biharmonic horizontal viscosity."
+        datatype: real
+        units: m4 s-1
+        value:
+            $OCN_GRID == "tx0.66v1": 1.0E+12
     AH_VEL_SCALE:
         description: |
             "[m s-1] default = 0.0
@@ -856,9 +907,25 @@ Global:
         units: m s-1
         value:
             $OCN_GRID == "gx1v6": 0.05
-            $OCN_GRID == "tx0.66v1": 0.1
             $OCN_GRID == "tx0.25v1": 0.01
             $OCN_GRID == "MISOMIP": 0.001
+    LEITH_AH:
+        description: |
+            "[Boolean] default = False
+            If true, use a biharmonic Leith nonlinear eddy viscosity."
+        datatype: logical
+        units: Boolean
+        value:
+            $OCN_GRID == "tx0.66v1": True
+    LEITH_BI_CONST:
+        description: |
+            "[nondim] default = 0.0
+            The nondimensional biharmonic Leith constant, typical values are thus far
+            undetermined."
+        datatype: real
+        units: nondim
+        value:
+            $OCN_GRID == "tx0.66v1": 128.0
     USE_LAND_MASK_FOR_HVISC:
         description: |
             "[Boolean] default = False
@@ -1182,7 +1249,7 @@ Global:
         units: m2 s-1
         value:
             $OCN_GRID == "gx1v6": 600.0
-            $OCN_GRID == "tx0.66v1": 800.0
+            $OCN_GRID == "tx0.66v1": 0.0
             $OCN_GRID == "MISOMIP": 0.0
     KHTH_MAX:
         description: |
@@ -1192,7 +1259,6 @@ Global:
         units: m2 s-1
         value:
             $OCN_GRID == "gx1v6": 900.0
-            $OCN_GRID == "tx0.66v1": 900.0
     KHTH_MAX_CFL:
         description: |
             "[nondimensional] default = 0.8
@@ -1205,6 +1271,14 @@ Global:
         units: nondimensional
         value:
             $OCN_GRID == "tx0.25v1": 0.1
+    USE_KH_IN_MEKE:
+        description: |
+            "[Boolean] default = False
+            If true, uses the thickness diffusivity calculated here to diffuse MEKE."
+        datatype: logical
+        units: Boolean
+        value:
+            $OCN_GRID == "tx0.66v1": True
     KHTH_USE_FGNV_STREAMFUNCTION:
         description: |
             "[Boolean] default = False
@@ -1391,14 +1465,13 @@ Global:
             $OCN_GRID == "tx0.25v1": 2.0E-06
     INT_TIDE_DECAY_SCALE:
         description: |
-            "[m] default = 0.0
+            "[m] default = 500.0
             The decay scale away from the bottom for tidal TKE with
             the new coding when INT_TIDE_DISSIPATION is used."
         datatype: real
         units: m
         value:
             $OCN_GRID == "gx1v6": "300.3003003003003"
-            $OCN_GRID == "tx0.66v1": "300.3003003003003"
             $OCN_GRID == "tx0.25v1": "300.3003003003003"
     KAPPA_ITIDES:
         description: |
@@ -1882,7 +1955,6 @@ Global:
         units: m2 s-1
         value:
             $OCN_GRID == "gx1v6": 600.0
-            $OCN_GRID == "tx0.66v1": 800.0
             $OCN_GRID == "MISOMIP": 1.0
     KHTR_MIN:
         description: |
@@ -1901,7 +1973,6 @@ Global:
         units: m2 s-1
         value:
             $OCN_GRID == "gx1v6": 900.0
-            $OCN_GRID == "tx0.66v1": 900.0
     DEBUG:
         description: |
             "If true, write out verbose debugging data."
@@ -2105,6 +2176,7 @@ Global:
         value:
             $OCN_GRID == "gx1v6": True
             $OCN_GRID == "tx0.25v1": True
+            $OCN_GRID == "tx0.66v1": True
     MEKE_GMCOEFF:
         description: |
             "[nondim] default = -1.0
@@ -2117,6 +2189,7 @@ Global:
         value:
             $OCN_GRID == "gx1v6": 1.0
             $OCN_GRID == "tx0.25v1": 1.0
+            $OCN_GRID == "tx0.66v1": 0.0
     MEKE_BGSRC:
         description: |
             "[W kg-1] default = 0.0
@@ -2151,6 +2224,60 @@ Global:
         units: nondim
         value:
             $OCN_GRID == "tx0.25v1": 0.15
+    MEKE_GEOMETRIC:
+        description: |
+            "[Boolean] default = False
+            If MEKE_GEOMETRIC is true, uses the GM coefficient formulation from the
+            GEOMETRIC framework (Marshall et al., 2012)."
+        datatype: logical
+        units: Boolean
+        value:
+            $OCN_GRID == "tx0.66v1": True
+    MEKE_GEOMETRIC_ALPHA:
+        description: |
+            "[nondim] default = 0.05
+            The nondimensional coefficient governing the efficiency of the GEOMETRIC
+            thickness diffusion."
+        datatype: real
+        units: nondim
+        value:
+            $OCN_GRID == "tx0.66v1": 0.07
+    MEKE_EQUILIBRIUM_ALT:
+        description: |
+            "[Boolean] default = False
+            If true, use an alternative formula for computing the (equilibrium)initial
+            value of MEKE."
+        datatype: logical
+        units: Boolean
+        value:
+            $OCN_GRID == "tx0.66v1": True
+    MEKE_EQUILIBRIUM_RESTORING:
+        description: |
+            "[Boolean] default = False
+            If true, restore MEKE back to its equilibrium value, which is calculated
+            at each time step."
+        datatype: logical
+        units: Boolean
+        value:
+            $OCN_GRID == "tx0.66v1": True
+    MEKE_RESTORING_TIMESCALE:
+        description: |
+            "[s] default = 1.0E+06
+            The timescale used to nudge MEKE toward its equilibrium value."
+        datatype: real
+        units: nondim
+        value:
+            $OCN_GRID == "tx0.66v1": 1.0E+07
+    MEKE_ADVECTION_FACTOR:
+        description: |
+            "[nondim] default = 0.0
+            A scale factor in front of advection of eddy energy. Zero turns advection off.
+            Using unity would be normal but other values could accommodate a mismatch
+            between the advecting barotropic flow and the vertical structure of MEKE."
+        datatype: real
+        units: nondim
+        value:
+            $OCN_GRID == "tx0.66v1": 1.0
     DIAG_COORD_DEF_Z:
         description: |
             "default = WOA09
@@ -2302,7 +2429,7 @@ Global:
         datatype: real
         units: degC
         value:
-            $OCN_GRID == "tx0.66v1": -2.5
+            $OCN_GRID == "tx0.66v1": -3.0
             $OCN_GRID == "tx0.25v1": -3.0
     DEFAULT_2018_ANSWERS:
         description: |

--- a/param_templates/MOM_input.yaml
+++ b/param_templates/MOM_input.yaml
@@ -171,7 +171,7 @@ Global:
         value:
             $OCN_GRID == "gx1v6": 1800.0
             $OCN_GRID == "tx0.25v1": 900.0
-            $OCN_GRID == "tx0.66v1": 1200.0
+            $OCN_GRID == "tx0.66v1": 1800.0
             $OCN_GRID == "MISOMIP": 600.0
     DT_THERM:
         description: |

--- a/param_templates/MOM_input.yaml
+++ b/param_templates/MOM_input.yaml
@@ -2126,7 +2126,7 @@ Global:
              The background gustiness in the winds."
         datatype: real
         units: Pa
-        value: 0.0
+        value: 0.02
     FIX_USTAR_GUSTLESS_BUG:
         description: |
             "[Boolean] default = False

--- a/param_templates/MOM_input.yaml
+++ b/param_templates/MOM_input.yaml
@@ -106,7 +106,7 @@ Global:
         units: nondim
         value:
             $OCN_GRID == "gx1v6": 60
-            $OCN_GRID == "tx0.66v1": 63
+            $OCN_GRID == "tx0.66v1": 65
             $OCN_GRID == "tx0.25v1": 75
             $OCN_GRID == "MISOMIP": 36
     USE_LEGACY_DIABATIC_DRIVER:
@@ -501,7 +501,7 @@ Global:
         datatype: string
         value:
             $OCN_GRID == "gx1v6": "WOA05_pottemp_salt.nc"
-            $OCN_GRID == "tx0.66v1": "WOA05_pottemp_salt_180829.nc"
+            $OCN_GRID == "tx0.66v1": "woa18_04_initial_conditions.nc"
             $OCN_GRID == "tx0.25v1": "MOM6_IC_TS.nc"
     Z_INIT_FILE_PTEMP_VAR:
         description: |
@@ -511,7 +511,7 @@ Global:
         datatype: string
         value:
             $OCN_GRID == "gx1v6": "PTEMP"
-            $OCN_GRID == "tx0.66v1": "PTEMP"
+            $OCN_GRID == "tx0.66v1": "theta0"
             $OCN_GRID == "tx0.25v1": "temp"
     Z_INIT_FILE_SALT_VAR:
         description: |
@@ -521,7 +521,7 @@ Global:
         datatype: string
         value:
             $OCN_GRID == "gx1v6": "SALT"
-            $OCN_GRID == "tx0.66v1": "SALT"
+            $OCN_GRID == "tx0.66v1": "s_an"
     Z_INIT_REMAP_OLD_ALG:
         description: |
             "[Boolean] default = True
@@ -749,7 +749,7 @@ Global:
         datatype: string
         value:
             $OCN_GRID == "gx1v6": '"FILE:ocean_vgrid.nc,dz"'
-            $OCN_GRID == "tx0.66v1": '"FILE:ocean_vgrid_190320.nc,dz"'
+            $OCN_GRID == "tx0.66v1": '"FILE:vgrid_65L_20200626.nc,dz"'
             $OCN_GRID == "tx0.25v1": '"HYBRID:hycom1_75_800m.nc,sigma2,FNC1:2,4000,4.5,.01"'
     REGRID_COMPRESSIBILITY_FRACTION:
         description: |
@@ -2067,7 +2067,7 @@ Global:
             A file in which to find the surface salinity to use for restoring."
         datatype: string
         value:
-            $OCN_GRID == "tx0.66v1": "salt_restore_tx0.66v1_180828.nc"
+            $OCN_GRID == "tx0.66v1": "state_restore_tx0.66v1_20200616.nc"
     ADJUST_NET_FRESH_WATER_TO_ZERO:
         description: |
             "[Boolean] default = False
@@ -2326,6 +2326,7 @@ Global:
         value:
             $OCN_GRID == "gx1v6": "global_1deg"
             $OCN_GRID == "tx0.25v1": "list"
+            $OCN_GRID == "tx0.66v1": "list"
     CHANNEL_LIST_FILE:
         description: |
             "default = MOM_channel_list
@@ -2333,6 +2334,7 @@ Global:
         datatype: string
         value:
             $OCN_GRID == "tx0.25v1": "MOM_channels_global_025"
+            $OCN_GRID == "tx0.66v1": "MOM_channels_global_tx06v1"
     SMAG_BI_CONST:
         description: |
             "[nondim] default = 0.0

--- a/param_templates/MOM_input.yaml
+++ b/param_templates/MOM_input.yaml
@@ -118,6 +118,7 @@ Global:
         units: Boolean
         value:
             $OCN_GRID == "tx0.66v1": False
+            $OCN_GRID == "gx1v6": False
     DIABATIC_FIRST:
         description: |
             "[Boolean] default = False
@@ -203,6 +204,7 @@ Global:
         datatype: real
         units: m
         value:
+            $OCN_GRID == "gx1v6": 10.0
             $OCN_GRID == "tx0.66v1": 10.0
             $OCN_GRID == "tx0.25v1": 20.0
     DTBT_RESET_PERIOD:
@@ -257,7 +259,7 @@ Global:
         datatype: real
         units: J kg-1 K-1
         value:
-            $OCN_GRID == "gx1v6": 3925.0
+            $OCN_GRID == "gx1v6": 3992.0
             $OCN_GRID == "tx0.66v1": 3992.0
             $OCN_GRID == "tx0.25v1": 3992.0
             $OCN_GRID == "MISOMIP": 3974.0
@@ -296,6 +298,7 @@ Global:
         datatype: logical
         units: Boolean
         value:
+            $OCN_GRID == "gx1v6": False
             $OCN_GRID == "tx0.66v1": False
             $OCN_GRID == "tx0.25v1": False
     DTFREEZE_DP:
@@ -307,6 +310,7 @@ Global:
         datatype: real
         units: deg C Pa-1
         value:
+            $OCN_GRID == "gx1v6": -7.75E-08
             $OCN_GRID == "tx0.66v1": -7.75E-08
             $OCN_GRID == "tx0.25v1": -7.75E-08
             $OCN_GRID == "MISOMIP": -7.53E-08
@@ -565,6 +569,7 @@ Global:
         units: nondim
         value:
             $OCN_GRID == "tx0.66v1": 0.01
+            $OCN_GRID == "gx1v6": 0.01
     DEPTH_SCALED_KHTH:
         description: |
             "[Boolean] default = False
@@ -605,6 +610,7 @@ Global:
         units: Boolean
         value:
             $OCN_GRID == "tx0.66v1": True
+            $OCN_GRID == "gx1v6": True
     RESOLN_SCALED_KHTH:
         description: |
             "[Boolean] default = False
@@ -634,7 +640,7 @@ Global:
         datatype: logical
         units: Boolean
         value:
-            $OCN_GRID == "gx1v6": False
+            $OCN_GRID == "gx1v6": True
             $OCN_GRID == "tx0.66v1": True
             $OCN_GRID == "tx0.25v1": True
     ETA_TOLERANCE:
@@ -680,6 +686,7 @@ Global:
         datatype: logical
         units: Boolean
         value:
+            $OCN_GRID == "gx1v6": True
             $OCN_GRID == "tx0.66v1": True
     USE_LATERAL_BOUNDARY_DIFFUSION:
         description: |
@@ -688,6 +695,7 @@ Global:
         datatype: logical
         units: Boolean
         value:
+            $OCN_GRID == "gx1v6": True
             $OCN_GRID == "tx0.66v1": True
     LBD_LINEAR_TRANSITION:
         description: |
@@ -697,6 +705,7 @@ Global:
         datatype: logical
         units: Boolean
         value:
+            $OCN_GRID == "gx1v6": True
             $OCN_GRID == "tx0.66v1": True
     SIMPLE_TKE_TO_KD:
         description: |
@@ -859,6 +868,7 @@ Global:
             $OCN_GRID == "MISOMIP": 0.0
             $OCN_GRID == "tx0.25v1": 0.0
             $OCN_GRID == "tx0.66v1": 0.0
+            $OCN_GRID == "gx1v6": 0.0
             else: 0.01
     KH_SIN_LAT:
         description: |
@@ -896,6 +906,7 @@ Global:
         units: m4 s-1
         value:
             $OCN_GRID == "tx0.66v1": 1.0E+12
+            $OCN_GRID == "gx1v6": 1.0E+12
     AH_VEL_SCALE:
         description: |
             "[m s-1] default = 0.0
@@ -906,7 +917,7 @@ Global:
         datatype: real
         units: m s-1
         value:
-            $OCN_GRID == "gx1v6": 0.05
+            $OCN_GRID == "gx1v6": 0.0
             $OCN_GRID == "tx0.25v1": 0.01
             $OCN_GRID == "MISOMIP": 0.001
     LEITH_AH:
@@ -917,6 +928,7 @@ Global:
         units: Boolean
         value:
             $OCN_GRID == "tx0.66v1": True
+            $OCN_GRID == "gx1v6": True
     LEITH_BI_CONST:
         description: |
             "[nondim] default = 0.0
@@ -925,6 +937,7 @@ Global:
         datatype: real
         units: nondim
         value:
+            $OCN_GRID == "gx1v6": 128.0
             $OCN_GRID == "tx0.66v1": 128.0
     USE_LAND_MASK_FOR_HVISC:
         description: |
@@ -1248,7 +1261,7 @@ Global:
         datatype: real
         units: m2 s-1
         value:
-            $OCN_GRID == "gx1v6": 600.0
+            $OCN_GRID == "gx1v6": 0.0
             $OCN_GRID == "tx0.66v1": 0.0
             $OCN_GRID == "MISOMIP": 0.0
     KHTH_MAX:
@@ -1258,7 +1271,7 @@ Global:
         datatype: real
         units: m2 s-1
         value:
-            $OCN_GRID == "gx1v6": 900.0
+            $OCN_GRID == "gx1v6": 0.0
     KHTH_MAX_CFL:
         description: |
             "[nondimensional] default = 0.8
@@ -1279,6 +1292,7 @@ Global:
         units: Boolean
         value:
             $OCN_GRID == "tx0.66v1": True
+            $OCN_GRID == "gx1v6": True
     KHTH_USE_FGNV_STREAMFUNCTION:
         description: |
             "[Boolean] default = False
@@ -1330,7 +1344,7 @@ Global:
         datatype: real
         units: nondim
         value:
-            $OCN_GRID == "gx1v6": 20.0
+            $OCN_GRID == "gx1v6": 1.0
             $OCN_GRID == "tx0.66v1": 1.0
             $OCN_GRID == "tx0.25v1": 1.0
     MLE_FRONT_LENGTH:
@@ -1343,6 +1357,7 @@ Global:
         datatype: real
         units: m
         value:
+            $OCN_GRID == "gx1v6": 1000.0
             $OCN_GRID == "tx0.66v1": 1000.0
             $OCN_GRID == "tx0.25v1": 500.0
     MLE_MLD_DECAY_TIME:
@@ -1355,6 +1370,7 @@ Global:
         datatype: real
         units: s
         value:
+            $OCN_GRID == "gx1v6": 3.45600E+05
             $OCN_GRID == "tx0.66v1": 3.45600E+05
             $OCN_GRID == "tx0.25v1": 2.592E+06
     USE_CVMix_CONVECTION:
@@ -1367,6 +1383,7 @@ Global:
         datatype: logical
         units: Boolean
         value:
+            $OCN_GRID == "gx1v6": True
             $OCN_GRID == "tx0.66v1": True
     BBL_MIXING_AS_MAX:
         description: |
@@ -1567,6 +1584,7 @@ Global:
         datatype: logical
         units: Boolean
         value:
+            $OCN_GRID == "gx1v6": True
             $OCN_GRID == "tx0.66v1": True
     USE_CVMix_TIDAL:
         description: |
@@ -1621,6 +1639,7 @@ Global:
         datatype: logical
         units: Boolean
         value:
+            $OCN_GRID == "gx1v6": True
             $OCN_GRID == "tx0.66v1": True
     SMOOTH_RI:
         description: |
@@ -1629,6 +1648,7 @@ Global:
         datatype: logical
         units: Boolean
         value:
+            $OCN_GRID == "gx1v6": True
             $OCN_GRID == "tx0.66v1": True
     USE_CVMIX_DDIFF:
         description: |
@@ -1639,6 +1659,7 @@ Global:
         datatype: logical
         units: Boolean
         value:
+            $OCN_GRID == "gx1v6": True
             $OCN_GRID == "tx0.66v1": True
     MAX_ENT_IT:
         description: |
@@ -1689,6 +1710,7 @@ Global:
         datatype: real
         units: m
         value:
+            $OCN_GRID == "gx1v6": 15.0
             $OCN_GRID == "tx0.66v1": 15.0
     PEN_SW_FRAC:
         description: |
@@ -1698,6 +1720,7 @@ Global:
         datatype: real
         units: nondim
         value:
+            $OCN_GRID == "gx1v6": 0.42
             $OCN_GRID == "tx0.66v1": 0.42
     PRESSURE_DEPENDENT_FRAZIL:
         description: |
@@ -1708,6 +1731,7 @@ Global:
         datatype: logical
         units: Boolean
         value:
+            $OCN_GRID == "gx1v6": True
             $OCN_GRID == "tx0.66v1": True
     MSTAR_MODE:
         description: |
@@ -1954,7 +1978,6 @@ Global:
         datatype: real
         units: m2 s-1
         value:
-            $OCN_GRID == "gx1v6": 600.0
             $OCN_GRID == "MISOMIP": 1.0
     KHTR_MIN:
         description: |
@@ -1972,7 +1995,7 @@ Global:
         datatype: real
         units: m2 s-1
         value:
-            $OCN_GRID == "gx1v6": 900.0
+            $OCN_GRID == "gx1v6": 0.0
     DEBUG:
         description: |
             "If true, write out verbose debugging data."
@@ -1989,6 +2012,7 @@ Global:
         datatype: logical
         units: Boolean
         value:
+            $OCN_GRID == "gx1v6": True
             $OCN_GRID == "tx0.66v1": True
             $OCN_GRID == "tx0.25v1": True
     MAX_TR_DIFFUSION_CFL:
@@ -2001,6 +2025,7 @@ Global:
         datatype: real
         units: nondim
         value:
+            $OCN_GRID == "gx1v6": 2.0
             $OCN_GRID == "tx0.66v1": 2.0
     MAXTRUNC:
         description: |
@@ -2037,6 +2062,7 @@ Global:
             'A', 'B', or 'C'."
         datatype: string
         value:
+            $OCN_GRID == "gx1v6": "A"
             $OCN_GRID == "tx0.66v1": "A"
             $OCN_GRID == "tx0.25v1": "A"
     RESTORE_SALINITY:
@@ -2142,7 +2168,7 @@ Global:
         datatype: real
         units: days
         value:
-            $OCN_GRID == "gx1v6": 0.01
+            $OCN_GRID == "gx1v6": 1.0
             $OCN_GRID == "tx0.66v1": 1.0
             $OCN_GRID == "tx0.25v1": 0.25
             $OCN_GRID == "MISOMIP": 1.0
@@ -2155,7 +2181,6 @@ Global:
         datatype: logical
         units: Boolean
         value:
-            $OCN_GRID == "gx1v6": True
             $OCN_GRID == "tx0.25v1": True
             $OCN_GRID == "MISOMIP": True
     TIDES:
@@ -2187,7 +2212,7 @@ Global:
         datatype: real
         units: nondim
         value:
-            $OCN_GRID == "gx1v6": 1.0
+            $OCN_GRID == "gx1v6": 0.0
             $OCN_GRID == "tx0.25v1": 1.0
             $OCN_GRID == "tx0.66v1": 0.0
     MEKE_BGSRC:
@@ -2207,6 +2232,7 @@ Global:
         value:
             $OCN_GRID == "tx0.25v1": 1.0
             $OCN_GRID == "tx0.66v1": 0.5
+            $OCN_GRID == "gx1v6": 0.5
     MEKE_VISCOSITY_COEFF_KU:
         description: |
             "[nondim] default = 0.0
@@ -2217,6 +2243,7 @@ Global:
         units: nondim
         value:
             $OCN_GRID == "tx0.66v1": 0.2
+            $OCN_GRID == "gx1v6": 0.2
     MEKE_MIN_LSCALE:
         description: |
             "[Boolean] default = False
@@ -2226,6 +2253,7 @@ Global:
         units: Boolean
         value:
             $OCN_GRID == "tx0.66v1": True
+            $OCN_GRID == "gx1v6": True
     MEKE_ALPHA_RHINES:
         description: |
             "[nondim] default = 0.05
@@ -2236,6 +2264,7 @@ Global:
         value:
             $OCN_GRID == "tx0.25v1": 0.15
             $OCN_GRID == "tx0.66v1": 1.0
+            $OCN_GRID == "gx1v6": 1.0
     MEKE_ALPHA_EADY:
         description: |
             "[nondim] default = 0.05
@@ -2246,6 +2275,7 @@ Global:
         value:
             $OCN_GRID == "tx0.25v1": 0.15
             $OCN_GRID == "tx0.66v1": 1.0
+            $OCN_GRID == "gx1v6": 1.0
     MEKE_ALPHA_DEFORM:
         description: |
             "[nondim] default = 0.0
@@ -2255,6 +2285,7 @@ Global:
         units: nondim
         value:
             $OCN_GRID == "tx0.66v1": 1.0
+            $OCN_GRID == "gx1v6": 1.0
     MEKE_ALPHA_FRICT:
         description: |
             "[nondim] default = 0.0
@@ -2264,6 +2295,7 @@ Global:
         units: nondim
         value:
             $OCN_GRID == "tx0.66v1": 1.0
+            $OCN_GRID == "gx1v6": 1.0
     MEKE_ALPHA_GRID:
         description: |
             "[nondim] default = 0.0
@@ -2273,6 +2305,7 @@ Global:
         units: nondim
         value:
             $OCN_GRID == "tx0.66v1": 1.0
+            $OCN_GRID == "gx1v6": 1.0
     MEKE_FRCOEFF:
         description: |
             "[nondim] default = -1.0
@@ -2291,6 +2324,7 @@ Global:
         units: nondim
         value:
             $OCN_GRID == "tx0.66v1": 0.4
+            $OCN_GRID == "gx1v6": 0.4
     VISC_RES_SCALE_COEF:
         description: |
             "[nondim] default = 1.0
@@ -2301,6 +2335,7 @@ Global:
         units: nondim
         value:
             $OCN_GRID == "tx0.66v1": 0.4
+            $OCN_GRID == "gx1v6": 0.4
     MEKE_GEOMETRIC:
         description: |
             "[Boolean] default = False
@@ -2310,6 +2345,7 @@ Global:
         units: Boolean
         value:
             $OCN_GRID == "tx0.66v1": True
+            $OCN_GRID == "gx1v6": True
     MEKE_GEOMETRIC_ALPHA:
         description: |
             "[nondim] default = 0.05
@@ -2327,6 +2363,7 @@ Global:
         units: nondim
         value:
             $OCN_GRID == "tx0.66v1": 1.0
+            $OCN_GRID == "gx1v6": 1.0
     MEKE_KHTR_FAC:
         description: |
             "[nondim] default = 0.0
@@ -2335,6 +2372,7 @@ Global:
         units: nondim
         value:
             $OCN_GRID == "tx0.66v1": 1.0
+            $OCN_GRID == "gx1v6": 1.0
     MEKE_EQUILIBRIUM_ALT:
         description: |
             "[Boolean] default = False
@@ -2344,6 +2382,7 @@ Global:
         units: Boolean
         value:
             $OCN_GRID == "tx0.66v1": True
+            $OCN_GRID == "gx1v6": True
     MEKE_VISC_DRAG:
         description: |
             "[Boolean] default = True
@@ -2352,6 +2391,7 @@ Global:
         units: Boolean
         value:
             $OCN_GRID == "tx0.66v1": False
+            $OCN_GRID == "gx1v6": False
     MEKE_EQUILIBRIUM_RESTORING:
         description: |
             "[Boolean] default = False
@@ -2361,6 +2401,7 @@ Global:
         units: Boolean
         value:
             $OCN_GRID == "tx0.66v1": True
+            $OCN_GRID == "gx1v6": True
     MEKE_RESTORING_TIMESCALE:
         description: |
             "[s] default = 1.0E+06
@@ -2368,6 +2409,7 @@ Global:
         datatype: real
         units: nondim
         value:
+            $OCN_GRID == "gx1v6": 1.0E+07
             $OCN_GRID == "tx0.66v1": 1.0E+07
     MEKE_ADVECTION_FACTOR:
         description: |
@@ -2379,6 +2421,7 @@ Global:
         units: nondim
         value:
             $OCN_GRID == "tx0.66v1": 1.0
+            $OCN_GRID == "gx1v6": 1.0
     DIAG_COORD_DEF_Z:
         description: |
             "default = WOA09
@@ -2455,7 +2498,6 @@ Global:
         datatype: logical
         units: Boolean
         value:
-            $OCN_GRID == "gx1v6": True
             $OCN_GRID == "tx0.25v1": True
             $OCN_GRID == "MISOMIP": True
     KAPPA_SHEAR_ITER_BUG:
@@ -2494,7 +2536,6 @@ Global:
         datatype: logical
         units: Boolean
         value:
-            $OCN_GRID == "gx1v6": True
             $OCN_GRID == "tx0.25v1": True
     BAD_VAL_SSH_MAX:
         description: |
@@ -3327,6 +3368,7 @@ KPP:
             purely for diagnostic purposes."
         datatype: integer
         value:
+            $OCN_GRID == "gx1v6": 3
             $OCN_GRID == "tx0.66v1": 3
     MATCH_TECHNIQUE:
         description: |
@@ -3339,6 +3381,7 @@ KPP:
             ParabolicNonLocal = sigma*(1-sigma)^2 for diffusivity; (1-sigma)^2 for NLT"
         datatype: string
         value:
+            $OCN_GRID == "gx1v6": "MatchGradient"
             $OCN_GRID == "tx0.66v1": "MatchGradient"
     INTERP_TYPE2:
         description: |
@@ -3346,6 +3389,7 @@ KPP:
             Allowed types are: linear, quadratic, cubic or LMD94."
         datatype: string
         value:
+            $OCN_GRID == "gx1v6": "LMD94"
             $OCN_GRID == "tx0.66v1": "LMD94"
     KPP_IS_ADDITIVE:
         description: |
@@ -3355,6 +3399,7 @@ KPP:
         datatype: logical
         units: Boolean
         value:
+            $OCN_GRID == "gx1v6": False
             $OCN_GRID == "tx0.66v1": False
 
 ...

--- a/param_templates/MOM_input.yaml
+++ b/param_templates/MOM_input.yaml
@@ -939,17 +939,6 @@ Global:
         datatype: real
         units: m2 s-1
         value: 1.0E-04
-    HBBL:
-        description: |
-            "[m]
-            The thickness of a bottom boundary layer with a
-            viscosity of KVBBL if BOTTOMDRAGLAW is not defined, or
-            the thickness over which near-bottom velocities are
-            averaged for the drag law if BOTTOMDRAGLAW is defined
-            but LINEAR_DRAG is not."
-        datatype: real
-        units: m
-        value: 10.0
     MAXVEL:
         description: |
             "[m s-1] default = 3.0E+08
@@ -1472,14 +1461,6 @@ Global:
         units: nondim
         value:
             $OCN_GRID == "tx0.25v1": 0.0018
-    GUST_CONST:
-        description: |
-            "[Pa] default = 0.02
-            The background gustiness in the winds."
-        datatype: real
-        units: Pa
-        value:
-            $OCN_GRID == "tx0.25v1": 0.0
     USE_RIGID_SEA_ICE:
         description: |
             "[Boolean] default = False

--- a/param_templates/MOM_input.yaml
+++ b/param_templates/MOM_input.yaml
@@ -230,6 +230,14 @@ Global:
         datatype: logical
         units: Boolean
         value: True
+    MIN_SALINITY:
+        description: |
+            "[PPT] default = 0.01
+             The minimum value of salinity when BOUND_SALINITY=True. The default is 0.01
+             for backward compatibility but ideally should be 0."
+        datatype: real
+        units: PPT
+        value: 0.0
     BOUND_SALINITY:
         description: |
             "[Boolean] default = False
@@ -253,6 +261,14 @@ Global:
             $OCN_GRID == "tx0.66v1": 3992.0
             $OCN_GRID == "tx0.25v1": 3992.0
             $OCN_GRID == "MISOMIP": 3974.0
+    USE_PSURF_IN_EOS:
+        description: |
+            "[Boolean] default = True
+            If true, always include the surface pressure contributions in equation of
+            state calculations."
+        datatype: logical
+        units: Boolean
+        value: True
     CHECK_BAD_SURFACE_VALS:
         description: |
             "[Boolean] default = False
@@ -326,6 +342,15 @@ Global:
             $OCN_GRID == "tx0.66v1": "none"
             $OCN_GRID == "tx0.25v1": "file"
             $OCN_GRID == "MISOMIP": "linear"
+    REMAP_UV_USING_OLD_ALG:
+        description: |
+            "[Boolean] default = True
+            If true, uses the old remapping-via-a-delta-z method for remapping u and v. If
+            false, uses the new method that remaps between grids described by an old and
+            new thickness."
+        datatype: logical
+        units: Boolean
+        value: False
     COORD_FILE:
         description: |
             "The file from which the coordinate densities are read."
@@ -497,6 +522,14 @@ Global:
         value:
             $OCN_GRID == "gx1v6": "SALT"
             $OCN_GRID == "tx0.66v1": "SALT"
+    Z_INIT_REMAP_OLD_ALG:
+        description: |
+            "[Boolean] default = True
+            If false, uses the preferred remapping algorithm for initialization. If true,
+            use an older, less robust algorithm for remapping."
+        datatype: logical
+        units: Boolean
+        value: False
     USE_VARIABLE_MIXING:
         description: |
             "[Boolean] default = False
@@ -567,6 +600,14 @@ Global:
             $OCN_GRID == "gx1v6": True
             $OCN_GRID == "tx0.66v1": False
             $OCN_GRID == "tx0.25v1": True
+    USE_GM_WORK_BUG:
+        description: |
+            "[Boolean] default = True
+            If true, compute the top-layer work tendency on the u-grid with the incorrect
+            sign, for legacy reproducibility."
+        datatype: logical
+        units: Boolean
+        value: False
     USE_STORED_SLOPES:
         description: |
             "[Boolean] default = False
@@ -828,8 +869,7 @@ Global:
             for new experiments."
         datatype: logical
         units: Boolean
-        value:
-            $OCN_GRID == "tx0.66v1": True
+        value: True
     HMIX_FIXED:
         description: |
             "[m]
@@ -846,14 +886,22 @@ Global:
             "[Boolean] default = False
             If true, the bottom drag is exerted directly on each
             layer proportional to the fraction of the bottom it
-            overlies.
-            If true, use a bulk Richardson number criterion to
-            determine the mixed layer thickness for viscosity."
+            overlies."
         datatype: logical
         units: Boolean
         value:
             $OCN_GRID == "MISOMIP": False
             else: True
+    HBBL:
+        description: |
+            "[m]
+             The thickness of a bottom boundary layer with a viscosity of KVBBL if
+             BOTTOMDRAGLAW is not defined, or the thickness over which near-bottom
+             velocities are averaged for the drag law if BOTTOMDRAGLAW is defined but
+             LINEAR_DRAG is not."
+        datatype: real
+        units: m
+        value: 10.0
     PRANDTL_TURB:
         description: |
             "[nondim] default = 0.0
@@ -983,10 +1031,7 @@ Global:
             function independently at each point."
         datatype: logical
         units: Boolean
-        value:
-            $OCN_GRID == "gx1v6": False
-            $OCN_GRID == "tx0.66v1": False
-            $OCN_GRID == "tx0.25v1": False
+        value: False
     GILL_EQUATORIAL_LD:
         description: |
             "[Boolean] default = False
@@ -1997,6 +2042,21 @@ Global:
         units: Boolean
         value:
             $OCN_GRID == "tx0.66v1": True
+    GUST_CONST:
+        description: |
+            "[Pa] default = 0.02
+             The background gustiness in the winds."
+        datatype: real
+        units: Pa
+        value: 0.0
+    FIX_USTAR_GUSTLESS_BUG:
+        description: |
+            "[Boolean] default = False
+            If true correct a bug in the time-averaging of the gustless wind
+            friction velocity."
+        datatype: logical
+        units: Boolean
+        value: True
     RESTART_CONTROL:
         description: |
             "default = 1
@@ -2187,6 +2247,24 @@ Global:
             $OCN_GRID == "gx1v6": True
             $OCN_GRID == "tx0.25v1": True
             $OCN_GRID == "MISOMIP": True
+    KAPPA_SHEAR_ITER_BUG:
+        description:
+            "[Boolean] default = True
+            If true, use an older, dimensionally inconsistent estimate of the derivative
+            of diffusivity with energy in the Newton's method iteration.  The bug causes
+            undercorrections when dz > 1 m."
+        datatype: logical
+        units: Boolean
+        value: False
+    KAPPA_SHEAR_ALL_LAYER_TKE_BUG:
+        description:
+            "[Boolean] default = True
+            If true, report back the latest estimate of TKE instead of the time average
+            TKE when there is mass in all layers.  Otherwise always report the time
+            averaged TKE, as is currently done when there are some massless layers."
+        datatype: logical
+        units: Boolean
+        value: False
     VELOCITY_TOLERANCE:
         description: |
             "[m s-1] default = 3.0E+08
@@ -2245,6 +2323,13 @@ Global:
         value:
             $OCN_GRID == "tx0.66v1": -2.5
             $OCN_GRID == "tx0.25v1": -3.0
+    DEFAULT_2018_ANSWERS:
+        description: |
+            "[Boolean] default = True
+            This sets the default value for the various _2018_ANSWERS parameters."
+        datatype: logical
+        units: Boolean
+        value: False
     VERTEX_SHEAR:
         description: |
             "[Boolean] default = False

--- a/param_templates/json/MOM_input.json
+++ b/param_templates/json/MOM_input.json
@@ -390,8 +390,16 @@
          "units": "Boolean",
          "value": {
             "$OCN_GRID == \"gx1v6\"": true,
-            "$OCN_GRID == \"tx0.66v1\"": false,
+            "$OCN_GRID == \"tx0.66v1\"": true,
             "$OCN_GRID == \"tx0.25v1\"": true
+         }
+      },
+      "KHTH_SLOPE_CFF": {
+         "description": "\"[nondim] default = 0.0\nThe nondimensional coefficient in the Visbeck formula for the interface depth\ndiffusivity\"\n",
+         "datatype": "real",
+         "units": "nondim",
+         "value": {
+            "$OCN_GRID == \"tx0.66v1\"": 0.01
          }
       },
       "DEPTH_SCALED_KHTH": {
@@ -402,6 +410,14 @@
             "$OCN_GRID == \"gx1v6\"": false,
             "$OCN_GRID == \"tx0.66v1\"": true,
             "$OCN_GRID == \"tx0.25v1\"": false
+         }
+      },
+      "DEPTH_SCALED_KHTH_H0": {
+         "description": "\"[m] default = 1000.0\nThe depth above which KHTH is scaled away.\"\n",
+         "datatype": "real",
+         "units": "nondim",
+         "value": {
+            "$OCN_GRID == \"tx0.66v1\"": 250.0
          }
       },
       "KHTR_SLOPE_CFF": {
@@ -426,7 +442,7 @@
          "units": "Boolean",
          "value": {
             "$OCN_GRID == \"gx1v6\"": true,
-            "$OCN_GRID == \"tx0.66v1\"": false,
+            "$OCN_GRID == \"tx0.66v1\"": true,
             "$OCN_GRID == \"tx0.25v1\"": true
          }
       },
@@ -442,7 +458,7 @@
          "units": "Boolean",
          "value": {
             "$OCN_GRID == \"gx1v6\"": false,
-            "$OCN_GRID == \"tx0.66v1\"": false,
+            "$OCN_GRID == \"tx0.66v1\"": true,
             "$OCN_GRID == \"tx0.25v1\"": true
          }
       },
@@ -469,6 +485,30 @@
          "units": "Boolean",
          "value": {
             "$OCN_GRID == \"gx1v6\"": true,
+            "$OCN_GRID == \"tx0.66v1\"": true
+         }
+      },
+      "NDIFF_INTERIOR_ONLY": {
+         "description": "\"[Boolean] default = False\nIf true, only applies neutral diffusion in the ocean interior. That is, the\nalgorithm will exclude the surface and bottomboundary layers.\"\n",
+         "datatype": "logical",
+         "units": "Boolean",
+         "value": {
+            "$OCN_GRID == \"tx0.66v1\"": true
+         }
+      },
+      "USE_LATERAL_BOUNDARY_DIFFUSION": {
+         "description": "\"[Boolean] default = False\nIf true, enables the lateral boundary tracer's diffusion module.\"\n",
+         "datatype": "logical",
+         "units": "Boolean",
+         "value": {
+            "$OCN_GRID == \"tx0.66v1\"": true
+         }
+      },
+      "LBD_LINEAR_TRANSITION": {
+         "description": "\"[Boolean] default = False\nIf True, apply a linear transition at the base/top of the boundary.\nThe flux will be fully applied at k=k_min and zero at k=k_max.\"\n",
+         "datatype": "logical",
+         "units": "Boolean",
+         "value": {
             "$OCN_GRID == \"tx0.66v1\"": true
          }
       },
@@ -562,7 +602,6 @@
          "datatype": "real",
          "units": "m2 s-1",
          "value": {
-            "$OCN_GRID == \"tx0.66v1\"": 1000.0,
             "$OCN_GRID == \"MISOMIP\"": 6.0
          }
       },
@@ -573,6 +612,7 @@
          "value": {
             "$OCN_GRID == \"MISOMIP\"": 0.0,
             "$OCN_GRID == \"tx0.25v1\"": 0.0,
+            "$OCN_GRID == \"tx0.66v1\"": 0.0,
             "else": 0.01
          }
       },
@@ -601,15 +641,38 @@
             "$OCN_GRID == \"MISOMIP\"": false
          }
       },
+      "AH": {
+         "description": "\"[m4 s-1] default = 0.0\nThe background biharmonic horizontal viscosity.\"\n",
+         "datatype": "real",
+         "units": "m4 s-1",
+         "value": {
+            "$OCN_GRID == \"tx0.66v1\"": 1000000000000.0
+         }
+      },
       "AH_VEL_SCALE": {
          "description": "\"[m s-1] default = 0.0\nThe velocity scale which is multiplied by the cube of\nthe grid spacing to calculate the biharmonic viscosity.\nThe final viscosity is the largest of this scaled\nviscosity, the Smagorinsky and Leith viscosities, and AH.\"\n",
          "datatype": "real",
          "units": "m s-1",
          "value": {
             "$OCN_GRID == \"gx1v6\"": 0.05,
-            "$OCN_GRID == \"tx0.66v1\"": 0.1,
             "$OCN_GRID == \"tx0.25v1\"": 0.01,
             "$OCN_GRID == \"MISOMIP\"": 0.001
+         }
+      },
+      "LEITH_AH": {
+         "description": "\"[Boolean] default = False\nIf true, use a biharmonic Leith nonlinear eddy viscosity.\"\n",
+         "datatype": "logical",
+         "units": "Boolean",
+         "value": {
+            "$OCN_GRID == \"tx0.66v1\"": true
+         }
+      },
+      "LEITH_BI_CONST": {
+         "description": "\"[nondim] default = 0.0\nThe nondimensional biharmonic Leith constant, typical values are thus far\nundetermined.\"\n",
+         "datatype": "real",
+         "units": "nondim",
+         "value": {
+            "$OCN_GRID == \"tx0.66v1\"": 128.0
          }
       },
       "USE_LAND_MASK_FOR_HVISC": {
@@ -836,7 +899,7 @@
          "units": "m2 s-1",
          "value": {
             "$OCN_GRID == \"gx1v6\"": 600.0,
-            "$OCN_GRID == \"tx0.66v1\"": 800.0,
+            "$OCN_GRID == \"tx0.66v1\"": 0.0,
             "$OCN_GRID == \"MISOMIP\"": 0.0
          }
       },
@@ -845,8 +908,7 @@
          "datatype": "real",
          "units": "m2 s-1",
          "value": {
-            "$OCN_GRID == \"gx1v6\"": 900.0,
-            "$OCN_GRID == \"tx0.66v1\"": 900.0
+            "$OCN_GRID == \"gx1v6\"": 900.0
          }
       },
       "KHTH_MAX_CFL": {
@@ -855,6 +917,14 @@
          "units": "nondimensional",
          "value": {
             "$OCN_GRID == \"tx0.25v1\"": 0.1
+         }
+      },
+      "USE_KH_IN_MEKE": {
+         "description": "\"[Boolean] default = False\nIf true, uses the thickness diffusivity calculated here to diffuse MEKE.\"\n",
+         "datatype": "logical",
+         "units": "Boolean",
+         "value": {
+            "$OCN_GRID == \"tx0.66v1\"": true
          }
       },
       "KHTH_USE_FGNV_STREAMFUNCTION": {
@@ -1001,12 +1071,11 @@
          }
       },
       "INT_TIDE_DECAY_SCALE": {
-         "description": "\"[m] default = 0.0\nThe decay scale away from the bottom for tidal TKE with\nthe new coding when INT_TIDE_DISSIPATION is used.\"\n",
+         "description": "\"[m] default = 500.0\nThe decay scale away from the bottom for tidal TKE with\nthe new coding when INT_TIDE_DISSIPATION is used.\"\n",
          "datatype": "real",
          "units": "m",
          "value": {
             "$OCN_GRID == \"gx1v6\"": "300.3003003003003",
-            "$OCN_GRID == \"tx0.66v1\"": "300.3003003003003",
             "$OCN_GRID == \"tx0.25v1\"": "300.3003003003003"
          }
       },
@@ -1429,7 +1498,6 @@
          "units": "m2 s-1",
          "value": {
             "$OCN_GRID == \"gx1v6\"": 600.0,
-            "$OCN_GRID == \"tx0.66v1\"": 800.0,
             "$OCN_GRID == \"MISOMIP\"": 1.0
          }
       },
@@ -1447,8 +1515,7 @@
          "datatype": "real",
          "units": "m2 s-1",
          "value": {
-            "$OCN_GRID == \"gx1v6\"": 900.0,
-            "$OCN_GRID == \"tx0.66v1\"": 900.0
+            "$OCN_GRID == \"gx1v6\"": 900.0
          }
       },
       "DEBUG": {
@@ -1612,7 +1679,8 @@
          "units": "Boolean",
          "value": {
             "$OCN_GRID == \"gx1v6\"": true,
-            "$OCN_GRID == \"tx0.25v1\"": true
+            "$OCN_GRID == \"tx0.25v1\"": true,
+            "$OCN_GRID == \"tx0.66v1\"": true
          }
       },
       "MEKE_GMCOEFF": {
@@ -1621,7 +1689,8 @@
          "units": "nondim",
          "value": {
             "$OCN_GRID == \"gx1v6\"": 1.0,
-            "$OCN_GRID == \"tx0.25v1\"": 1.0
+            "$OCN_GRID == \"tx0.25v1\"": 1.0,
+            "$OCN_GRID == \"tx0.66v1\"": 0.0
          }
       },
       "MEKE_BGSRC": {
@@ -1654,6 +1723,54 @@
          "units": "nondim",
          "value": {
             "$OCN_GRID == \"tx0.25v1\"": 0.15
+         }
+      },
+      "MEKE_GEOMETRIC": {
+         "description": "\"[Boolean] default = False\nIf MEKE_GEOMETRIC is true, uses the GM coefficient formulation from the\nGEOMETRIC framework (Marshall et al., 2012).\"\n",
+         "datatype": "logical",
+         "units": "Boolean",
+         "value": {
+            "$OCN_GRID == \"tx0.66v1\"": true
+         }
+      },
+      "MEKE_GEOMETRIC_ALPHA": {
+         "description": "\"[nondim] default = 0.05\nThe nondimensional coefficient governing the efficiency of the GEOMETRIC\nthickness diffusion.\"\n",
+         "datatype": "real",
+         "units": "nondim",
+         "value": {
+            "$OCN_GRID == \"tx0.66v1\"": 0.07
+         }
+      },
+      "MEKE_EQUILIBRIUM_ALT": {
+         "description": "\"[Boolean] default = False\nIf true, use an alternative formula for computing the (equilibrium)initial\nvalue of MEKE.\"\n",
+         "datatype": "logical",
+         "units": "Boolean",
+         "value": {
+            "$OCN_GRID == \"tx0.66v1\"": true
+         }
+      },
+      "MEKE_EQUILIBRIUM_RESTORING": {
+         "description": "\"[Boolean] default = False\nIf true, restore MEKE back to its equilibrium value, which is calculated\nat each time step.\"\n",
+         "datatype": "logical",
+         "units": "Boolean",
+         "value": {
+            "$OCN_GRID == \"tx0.66v1\"": true
+         }
+      },
+      "MEKE_RESTORING_TIMESCALE": {
+         "description": "\"[s] default = 1.0E+06\nThe timescale used to nudge MEKE toward its equilibrium value.\"\n",
+         "datatype": "real",
+         "units": "nondim",
+         "value": {
+            "$OCN_GRID == \"tx0.66v1\"": 10000000.0
+         }
+      },
+      "MEKE_ADVECTION_FACTOR": {
+         "description": "\"[nondim] default = 0.0\nA scale factor in front of advection of eddy energy. Zero turns advection off.\nUsing unity would be normal but other values could accommodate a mismatch\nbetween the advecting barotropic flow and the vertical structure of MEKE.\"\n",
+         "datatype": "real",
+         "units": "nondim",
+         "value": {
+            "$OCN_GRID == \"tx0.66v1\"": 1.0
          }
       },
       "DIAG_COORD_DEF_Z": {
@@ -1767,7 +1884,7 @@
          "datatype": "real",
          "units": "degC",
          "value": {
-            "$OCN_GRID == \"tx0.66v1\"": -2.5,
+            "$OCN_GRID == \"tx0.66v1\"": -3.0,
             "$OCN_GRID == \"tx0.25v1\"": -3.0
          }
       },

--- a/param_templates/json/MOM_input.json
+++ b/param_templates/json/MOM_input.json
@@ -1706,7 +1706,24 @@
          "datatype": "real",
          "units": "nondim",
          "value": {
-            "$OCN_GRID == \"tx0.25v1\"": 1.0
+            "$OCN_GRID == \"tx0.25v1\"": 1.0,
+            "$OCN_GRID == \"tx0.66v1\"": 0.5
+         }
+      },
+      "MEKE_VISCOSITY_COEFF_KU": {
+         "description": "\"[nondim] default = 0.0\nIf non-zero, is the scaling coefficient in the expression forviscosity used to\nparameterize harmonic lateral momentum mixing byunresolved eddies represented\nby MEKE. Can be negative torepresent backscatter from the unresolved eddies.\"\n",
+         "datatype": "real",
+         "units": "nondim",
+         "value": {
+            "$OCN_GRID == \"tx0.66v1\"": 0.2
+         }
+      },
+      "MEKE_MIN_LSCALE": {
+         "description": "\"[Boolean] default = False\nIf true, use a strict minimum of provided length scales rather than harmonic\nmean.\"\n",
+         "datatype": "logical",
+         "units": "Boolean",
+         "value": {
+            "$OCN_GRID == \"tx0.66v1\"": true
          }
       },
       "MEKE_ALPHA_RHINES": {
@@ -1714,7 +1731,8 @@
          "datatype": "real",
          "units": "nondim",
          "value": {
-            "$OCN_GRID == \"tx0.25v1\"": 0.15
+            "$OCN_GRID == \"tx0.25v1\"": 0.15,
+            "$OCN_GRID == \"tx0.66v1\"": 1.0
          }
       },
       "MEKE_ALPHA_EADY": {
@@ -1722,7 +1740,56 @@
          "datatype": "real",
          "units": "nondim",
          "value": {
-            "$OCN_GRID == \"tx0.25v1\"": 0.15
+            "$OCN_GRID == \"tx0.25v1\"": 0.15,
+            "$OCN_GRID == \"tx0.66v1\"": 1.0
+         }
+      },
+      "MEKE_ALPHA_DEFORM": {
+         "description": "\"[nondim] default = 0.0\nIf positive, is a coefficient weighting the deformation scale in the\nexpression for mixing length used in MEKE-derived diffusivity.\"\n",
+         "datatype": "real",
+         "units": "nondim",
+         "value": {
+            "$OCN_GRID == \"tx0.66v1\"": 1.0
+         }
+      },
+      "MEKE_ALPHA_FRICT": {
+         "description": "\"[nondim] default = 0.0\nIf positive, is a coefficient weighting the frictional arrest scale in the\nexpression for mixing length used in MEKE-derived diffusivity.\"\n",
+         "datatype": "real",
+         "units": "nondim",
+         "value": {
+            "$OCN_GRID == \"tx0.66v1\"": 1.0
+         }
+      },
+      "MEKE_ALPHA_GRID": {
+         "description": "\"[nondim] default = 0.0\nIf positive, is a coefficient weighting the grid-spacing as a scale in the\nexpression for mixing length used in MEKE-derived diffusivity.\"\n",
+         "datatype": "real",
+         "units": "nondim",
+         "value": {
+            "$OCN_GRID == \"tx0.66v1\"": 1.0
+         }
+      },
+      "MEKE_FRCOEFF": {
+         "description": "\"[nondim] default = -1.0\nIf positive, is a coefficient weighting the grid-spacing as a scale in the\nexpression for mixing length used in MEKE-derived diffusivity.\"\n",
+         "datatype": "real",
+         "units": "nondim",
+         "value": {
+            "$OCN_GRID == \"tx0.66v1\"": -1.0
+         }
+      },
+      "KH_RES_SCALE_COEF": {
+         "description": "\"[nondim] default = 1.0\nA coefficient that determines how KhTh is scaled away if RESOLN_SCALED_... is\ntrue, as F = 1 / (1 + (KH_RES_SCALE_COEF*Rd/dx)^KH_RES_FN_POWER).\"\n",
+         "datatype": "real",
+         "units": "nondim",
+         "value": {
+            "$OCN_GRID == \"tx0.66v1\"": 0.4
+         }
+      },
+      "VISC_RES_SCALE_COEF": {
+         "description": "\"[nondim] default = 1.0\nA coefficient that determines how Kh is scaled away if RESOLN_SCALED_... is\ntrue, as F = 1 / (1 + (KH_RES_SCALE_COEF*Rd/dx)^KH_RES_FN_POWER). This\nfunction affects lateral viscosity, Kh, and not KhTh.\"\n",
+         "datatype": "real",
+         "units": "nondim",
+         "value": {
+            "$OCN_GRID == \"tx0.66v1\"": 0.4
          }
       },
       "MEKE_GEOMETRIC": {
@@ -1741,12 +1808,36 @@
             "$OCN_GRID == \"tx0.66v1\"": 0.07
          }
       },
+      "MEKE_KHTH_FAC": {
+         "description": "\"[nondim] default = 0.0\nA factor that maps MEKE%Kh to KhTh.\"\n",
+         "datatype": "real",
+         "units": "nondim",
+         "value": {
+            "$OCN_GRID == \"tx0.66v1\"": 1.0
+         }
+      },
+      "MEKE_KHTR_FAC": {
+         "description": "\"[nondim] default = 0.0\nA factor that maps MEKE%Kh to KhTr.\"\n",
+         "datatype": "real",
+         "units": "nondim",
+         "value": {
+            "$OCN_GRID == \"tx0.66v1\"": 1.0
+         }
+      },
       "MEKE_EQUILIBRIUM_ALT": {
          "description": "\"[Boolean] default = False\nIf true, use an alternative formula for computing the (equilibrium)initial\nvalue of MEKE.\"\n",
          "datatype": "logical",
          "units": "Boolean",
          "value": {
             "$OCN_GRID == \"tx0.66v1\"": true
+         }
+      },
+      "MEKE_VISC_DRAG": {
+         "description": "\"[Boolean] default = True\nIf true, use the vertvisc_type to calculate the bottom drag acting on MEKE.\"\n",
+         "datatype": "logical",
+         "units": "Boolean",
+         "value": {
+            "$OCN_GRID == \"tx0.66v1\"": false
          }
       },
       "MEKE_EQUILIBRIUM_RESTORING": {

--- a/param_templates/json/MOM_input.json
+++ b/param_templates/json/MOM_input.json
@@ -293,7 +293,7 @@
          "datatype": "string",
          "value": {
             "$OCN_GRID == \"gx1v6\"": "ocean_topog.nc",
-            "$OCN_GRID == \"tx0.66v1\"": "ocean_topog_190314.nc",
+            "$OCN_GRID == \"tx0.66v1\"": "ocean_topog_200701.nc",
             "$OCN_GRID == \"tx0.25v1\"": "ocean_topog.nc"
          }
       },

--- a/param_templates/json/MOM_input.json
+++ b/param_templates/json/MOM_input.json
@@ -111,7 +111,7 @@
          "value": {
             "$OCN_GRID == \"gx1v6\"": 1800.0,
             "$OCN_GRID == \"tx0.25v1\"": 900.0,
-            "$OCN_GRID == \"tx0.66v1\"": 1200.0,
+            "$OCN_GRID == \"tx0.66v1\"": 1800.0,
             "$OCN_GRID == \"MISOMIP\"": 600.0
          }
       },

--- a/param_templates/json/MOM_input.json
+++ b/param_templates/json/MOM_input.json
@@ -66,7 +66,8 @@
          "datatype": "logical",
          "units": "Boolean",
          "value": {
-            "$OCN_GRID == \"tx0.66v1\"": false
+            "$OCN_GRID == \"tx0.66v1\"": false,
+            "$OCN_GRID == \"gx1v6\"": false
          }
       },
       "DIABATIC_FIRST": {
@@ -129,6 +130,7 @@
          "datatype": "real",
          "units": "m",
          "value": {
+            "$OCN_GRID == \"gx1v6\"": 10.0,
             "$OCN_GRID == \"tx0.66v1\"": 10.0,
             "$OCN_GRID == \"tx0.25v1\"": 20.0
          }
@@ -166,7 +168,7 @@
          "datatype": "real",
          "units": "J kg-1 K-1",
          "value": {
-            "$OCN_GRID == \"gx1v6\"": 3925.0,
+            "$OCN_GRID == \"gx1v6\"": 3992.0,
             "$OCN_GRID == \"tx0.66v1\"": 3992.0,
             "$OCN_GRID == \"tx0.25v1\"": 3992.0,
             "$OCN_GRID == \"MISOMIP\"": 3974.0
@@ -199,6 +201,7 @@
          "datatype": "logical",
          "units": "Boolean",
          "value": {
+            "$OCN_GRID == \"gx1v6\"": false,
             "$OCN_GRID == \"tx0.66v1\"": false,
             "$OCN_GRID == \"tx0.25v1\"": false
          }
@@ -208,6 +211,7 @@
          "datatype": "real",
          "units": "deg C Pa-1",
          "value": {
+            "$OCN_GRID == \"gx1v6\"": -7.75e-08,
             "$OCN_GRID == \"tx0.66v1\"": -7.75e-08,
             "$OCN_GRID == \"tx0.25v1\"": -7.75e-08,
             "$OCN_GRID == \"MISOMIP\"": -7.53e-08
@@ -399,7 +403,8 @@
          "datatype": "real",
          "units": "nondim",
          "value": {
-            "$OCN_GRID == \"tx0.66v1\"": 0.01
+            "$OCN_GRID == \"tx0.66v1\"": 0.01,
+            "$OCN_GRID == \"gx1v6\"": 0.01
          }
       },
       "DEPTH_SCALED_KHTH": {
@@ -433,7 +438,8 @@
          "datatype": "logical",
          "units": "Boolean",
          "value": {
-            "$OCN_GRID == \"tx0.66v1\"": true
+            "$OCN_GRID == \"tx0.66v1\"": true,
+            "$OCN_GRID == \"gx1v6\"": true
          }
       },
       "RESOLN_SCALED_KHTH": {
@@ -457,7 +463,7 @@
          "datatype": "logical",
          "units": "Boolean",
          "value": {
-            "$OCN_GRID == \"gx1v6\"": false,
+            "$OCN_GRID == \"gx1v6\"": true,
             "$OCN_GRID == \"tx0.66v1\"": true,
             "$OCN_GRID == \"tx0.25v1\"": true
          }
@@ -493,6 +499,7 @@
          "datatype": "logical",
          "units": "Boolean",
          "value": {
+            "$OCN_GRID == \"gx1v6\"": true,
             "$OCN_GRID == \"tx0.66v1\"": true
          }
       },
@@ -501,6 +508,7 @@
          "datatype": "logical",
          "units": "Boolean",
          "value": {
+            "$OCN_GRID == \"gx1v6\"": true,
             "$OCN_GRID == \"tx0.66v1\"": true
          }
       },
@@ -509,6 +517,7 @@
          "datatype": "logical",
          "units": "Boolean",
          "value": {
+            "$OCN_GRID == \"gx1v6\"": true,
             "$OCN_GRID == \"tx0.66v1\"": true
          }
       },
@@ -613,6 +622,7 @@
             "$OCN_GRID == \"MISOMIP\"": 0.0,
             "$OCN_GRID == \"tx0.25v1\"": 0.0,
             "$OCN_GRID == \"tx0.66v1\"": 0.0,
+            "$OCN_GRID == \"gx1v6\"": 0.0,
             "else": 0.01
          }
       },
@@ -646,7 +656,8 @@
          "datatype": "real",
          "units": "m4 s-1",
          "value": {
-            "$OCN_GRID == \"tx0.66v1\"": 1000000000000.0
+            "$OCN_GRID == \"tx0.66v1\"": 1000000000000.0,
+            "$OCN_GRID == \"gx1v6\"": 1000000000000.0
          }
       },
       "AH_VEL_SCALE": {
@@ -654,7 +665,7 @@
          "datatype": "real",
          "units": "m s-1",
          "value": {
-            "$OCN_GRID == \"gx1v6\"": 0.05,
+            "$OCN_GRID == \"gx1v6\"": 0.0,
             "$OCN_GRID == \"tx0.25v1\"": 0.01,
             "$OCN_GRID == \"MISOMIP\"": 0.001
          }
@@ -664,7 +675,8 @@
          "datatype": "logical",
          "units": "Boolean",
          "value": {
-            "$OCN_GRID == \"tx0.66v1\"": true
+            "$OCN_GRID == \"tx0.66v1\"": true,
+            "$OCN_GRID == \"gx1v6\"": true
          }
       },
       "LEITH_BI_CONST": {
@@ -672,6 +684,7 @@
          "datatype": "real",
          "units": "nondim",
          "value": {
+            "$OCN_GRID == \"gx1v6\"": 128.0,
             "$OCN_GRID == \"tx0.66v1\"": 128.0
          }
       },
@@ -898,7 +911,7 @@
          "datatype": "real",
          "units": "m2 s-1",
          "value": {
-            "$OCN_GRID == \"gx1v6\"": 600.0,
+            "$OCN_GRID == \"gx1v6\"": 0.0,
             "$OCN_GRID == \"tx0.66v1\"": 0.0,
             "$OCN_GRID == \"MISOMIP\"": 0.0
          }
@@ -908,7 +921,7 @@
          "datatype": "real",
          "units": "m2 s-1",
          "value": {
-            "$OCN_GRID == \"gx1v6\"": 900.0
+            "$OCN_GRID == \"gx1v6\"": 0.0
          }
       },
       "KHTH_MAX_CFL": {
@@ -924,7 +937,8 @@
          "datatype": "logical",
          "units": "Boolean",
          "value": {
-            "$OCN_GRID == \"tx0.66v1\"": true
+            "$OCN_GRID == \"tx0.66v1\"": true,
+            "$OCN_GRID == \"gx1v6\"": true
          }
       },
       "KHTH_USE_FGNV_STREAMFUNCTION": {
@@ -959,7 +973,7 @@
          "datatype": "real",
          "units": "nondim",
          "value": {
-            "$OCN_GRID == \"gx1v6\"": 20.0,
+            "$OCN_GRID == \"gx1v6\"": 1.0,
             "$OCN_GRID == \"tx0.66v1\"": 1.0,
             "$OCN_GRID == \"tx0.25v1\"": 1.0
          }
@@ -969,6 +983,7 @@
          "datatype": "real",
          "units": "m",
          "value": {
+            "$OCN_GRID == \"gx1v6\"": 1000.0,
             "$OCN_GRID == \"tx0.66v1\"": 1000.0,
             "$OCN_GRID == \"tx0.25v1\"": 500.0
          }
@@ -978,6 +993,7 @@
          "datatype": "real",
          "units": "s",
          "value": {
+            "$OCN_GRID == \"gx1v6\"": 345600.0,
             "$OCN_GRID == \"tx0.66v1\"": 345600.0,
             "$OCN_GRID == \"tx0.25v1\"": 2592000.0
          }
@@ -987,6 +1003,7 @@
          "datatype": "logical",
          "units": "Boolean",
          "value": {
+            "$OCN_GRID == \"gx1v6\"": true,
             "$OCN_GRID == \"tx0.66v1\"": true
          }
       },
@@ -1160,6 +1177,7 @@
          "datatype": "logical",
          "units": "Boolean",
          "value": {
+            "$OCN_GRID == \"gx1v6\"": true,
             "$OCN_GRID == \"tx0.66v1\"": true
          }
       },
@@ -1206,6 +1224,7 @@
          "datatype": "logical",
          "units": "Boolean",
          "value": {
+            "$OCN_GRID == \"gx1v6\"": true,
             "$OCN_GRID == \"tx0.66v1\"": true
          }
       },
@@ -1214,6 +1233,7 @@
          "datatype": "logical",
          "units": "Boolean",
          "value": {
+            "$OCN_GRID == \"gx1v6\"": true,
             "$OCN_GRID == \"tx0.66v1\"": true
          }
       },
@@ -1222,6 +1242,7 @@
          "datatype": "logical",
          "units": "Boolean",
          "value": {
+            "$OCN_GRID == \"gx1v6\"": true,
             "$OCN_GRID == \"tx0.66v1\"": true
          }
       },
@@ -1267,6 +1288,7 @@
          "datatype": "real",
          "units": "m",
          "value": {
+            "$OCN_GRID == \"gx1v6\"": 15.0,
             "$OCN_GRID == \"tx0.66v1\"": 15.0
          }
       },
@@ -1275,6 +1297,7 @@
          "datatype": "real",
          "units": "nondim",
          "value": {
+            "$OCN_GRID == \"gx1v6\"": 0.42,
             "$OCN_GRID == \"tx0.66v1\"": 0.42
          }
       },
@@ -1283,6 +1306,7 @@
          "datatype": "logical",
          "units": "Boolean",
          "value": {
+            "$OCN_GRID == \"gx1v6\"": true,
             "$OCN_GRID == \"tx0.66v1\"": true
          }
       },
@@ -1497,7 +1521,6 @@
          "datatype": "real",
          "units": "m2 s-1",
          "value": {
-            "$OCN_GRID == \"gx1v6\"": 600.0,
             "$OCN_GRID == \"MISOMIP\"": 1.0
          }
       },
@@ -1515,7 +1538,7 @@
          "datatype": "real",
          "units": "m2 s-1",
          "value": {
-            "$OCN_GRID == \"gx1v6\"": 900.0
+            "$OCN_GRID == \"gx1v6\"": 0.0
          }
       },
       "DEBUG": {
@@ -1529,6 +1552,7 @@
          "datatype": "logical",
          "units": "Boolean",
          "value": {
+            "$OCN_GRID == \"gx1v6\"": true,
             "$OCN_GRID == \"tx0.66v1\"": true,
             "$OCN_GRID == \"tx0.25v1\"": true
          }
@@ -1538,6 +1562,7 @@
          "datatype": "real",
          "units": "nondim",
          "value": {
+            "$OCN_GRID == \"gx1v6\"": 2.0,
             "$OCN_GRID == \"tx0.66v1\"": 2.0
          }
       },
@@ -1560,6 +1585,7 @@
          "description": "\"default = 'C'\nA case-insensitive character string to indicate the\nstaggering of the surface velocity field that is\nreturned to the coupler.  Valid values include\n'A', 'B', or 'C'.\"\n",
          "datatype": "string",
          "value": {
+            "$OCN_GRID == \"gx1v6\"": "A",
             "$OCN_GRID == \"tx0.66v1\"": "A",
             "$OCN_GRID == \"tx0.25v1\"": "A"
          }
@@ -1649,7 +1675,7 @@
          "datatype": "real",
          "units": "days",
          "value": {
-            "$OCN_GRID == \"gx1v6\"": 0.01,
+            "$OCN_GRID == \"gx1v6\"": 1.0,
             "$OCN_GRID == \"tx0.66v1\"": 1.0,
             "$OCN_GRID == \"tx0.25v1\"": 0.25,
             "$OCN_GRID == \"MISOMIP\"": 1.0
@@ -1660,7 +1686,6 @@
          "datatype": "logical",
          "units": "Boolean",
          "value": {
-            "$OCN_GRID == \"gx1v6\"": true,
             "$OCN_GRID == \"tx0.25v1\"": true,
             "$OCN_GRID == \"MISOMIP\"": true
          }
@@ -1688,7 +1713,7 @@
          "datatype": "real",
          "units": "nondim",
          "value": {
-            "$OCN_GRID == \"gx1v6\"": 1.0,
+            "$OCN_GRID == \"gx1v6\"": 0.0,
             "$OCN_GRID == \"tx0.25v1\"": 1.0,
             "$OCN_GRID == \"tx0.66v1\"": 0.0
          }
@@ -1707,7 +1732,8 @@
          "units": "nondim",
          "value": {
             "$OCN_GRID == \"tx0.25v1\"": 1.0,
-            "$OCN_GRID == \"tx0.66v1\"": 0.5
+            "$OCN_GRID == \"tx0.66v1\"": 0.5,
+            "$OCN_GRID == \"gx1v6\"": 0.5
          }
       },
       "MEKE_VISCOSITY_COEFF_KU": {
@@ -1715,7 +1741,8 @@
          "datatype": "real",
          "units": "nondim",
          "value": {
-            "$OCN_GRID == \"tx0.66v1\"": 0.2
+            "$OCN_GRID == \"tx0.66v1\"": 0.2,
+            "$OCN_GRID == \"gx1v6\"": 0.2
          }
       },
       "MEKE_MIN_LSCALE": {
@@ -1723,7 +1750,8 @@
          "datatype": "logical",
          "units": "Boolean",
          "value": {
-            "$OCN_GRID == \"tx0.66v1\"": true
+            "$OCN_GRID == \"tx0.66v1\"": true,
+            "$OCN_GRID == \"gx1v6\"": true
          }
       },
       "MEKE_ALPHA_RHINES": {
@@ -1732,7 +1760,8 @@
          "units": "nondim",
          "value": {
             "$OCN_GRID == \"tx0.25v1\"": 0.15,
-            "$OCN_GRID == \"tx0.66v1\"": 1.0
+            "$OCN_GRID == \"tx0.66v1\"": 1.0,
+            "$OCN_GRID == \"gx1v6\"": 1.0
          }
       },
       "MEKE_ALPHA_EADY": {
@@ -1741,7 +1770,8 @@
          "units": "nondim",
          "value": {
             "$OCN_GRID == \"tx0.25v1\"": 0.15,
-            "$OCN_GRID == \"tx0.66v1\"": 1.0
+            "$OCN_GRID == \"tx0.66v1\"": 1.0,
+            "$OCN_GRID == \"gx1v6\"": 1.0
          }
       },
       "MEKE_ALPHA_DEFORM": {
@@ -1749,7 +1779,8 @@
          "datatype": "real",
          "units": "nondim",
          "value": {
-            "$OCN_GRID == \"tx0.66v1\"": 1.0
+            "$OCN_GRID == \"tx0.66v1\"": 1.0,
+            "$OCN_GRID == \"gx1v6\"": 1.0
          }
       },
       "MEKE_ALPHA_FRICT": {
@@ -1757,7 +1788,8 @@
          "datatype": "real",
          "units": "nondim",
          "value": {
-            "$OCN_GRID == \"tx0.66v1\"": 1.0
+            "$OCN_GRID == \"tx0.66v1\"": 1.0,
+            "$OCN_GRID == \"gx1v6\"": 1.0
          }
       },
       "MEKE_ALPHA_GRID": {
@@ -1765,7 +1797,8 @@
          "datatype": "real",
          "units": "nondim",
          "value": {
-            "$OCN_GRID == \"tx0.66v1\"": 1.0
+            "$OCN_GRID == \"tx0.66v1\"": 1.0,
+            "$OCN_GRID == \"gx1v6\"": 1.0
          }
       },
       "MEKE_FRCOEFF": {
@@ -1781,7 +1814,8 @@
          "datatype": "real",
          "units": "nondim",
          "value": {
-            "$OCN_GRID == \"tx0.66v1\"": 0.4
+            "$OCN_GRID == \"tx0.66v1\"": 0.4,
+            "$OCN_GRID == \"gx1v6\"": 0.4
          }
       },
       "VISC_RES_SCALE_COEF": {
@@ -1789,7 +1823,8 @@
          "datatype": "real",
          "units": "nondim",
          "value": {
-            "$OCN_GRID == \"tx0.66v1\"": 0.4
+            "$OCN_GRID == \"tx0.66v1\"": 0.4,
+            "$OCN_GRID == \"gx1v6\"": 0.4
          }
       },
       "MEKE_GEOMETRIC": {
@@ -1797,7 +1832,8 @@
          "datatype": "logical",
          "units": "Boolean",
          "value": {
-            "$OCN_GRID == \"tx0.66v1\"": true
+            "$OCN_GRID == \"tx0.66v1\"": true,
+            "$OCN_GRID == \"gx1v6\"": true
          }
       },
       "MEKE_GEOMETRIC_ALPHA": {
@@ -1813,7 +1849,8 @@
          "datatype": "real",
          "units": "nondim",
          "value": {
-            "$OCN_GRID == \"tx0.66v1\"": 1.0
+            "$OCN_GRID == \"tx0.66v1\"": 1.0,
+            "$OCN_GRID == \"gx1v6\"": 1.0
          }
       },
       "MEKE_KHTR_FAC": {
@@ -1821,7 +1858,8 @@
          "datatype": "real",
          "units": "nondim",
          "value": {
-            "$OCN_GRID == \"tx0.66v1\"": 1.0
+            "$OCN_GRID == \"tx0.66v1\"": 1.0,
+            "$OCN_GRID == \"gx1v6\"": 1.0
          }
       },
       "MEKE_EQUILIBRIUM_ALT": {
@@ -1829,7 +1867,8 @@
          "datatype": "logical",
          "units": "Boolean",
          "value": {
-            "$OCN_GRID == \"tx0.66v1\"": true
+            "$OCN_GRID == \"tx0.66v1\"": true,
+            "$OCN_GRID == \"gx1v6\"": true
          }
       },
       "MEKE_VISC_DRAG": {
@@ -1837,7 +1876,8 @@
          "datatype": "logical",
          "units": "Boolean",
          "value": {
-            "$OCN_GRID == \"tx0.66v1\"": false
+            "$OCN_GRID == \"tx0.66v1\"": false,
+            "$OCN_GRID == \"gx1v6\"": false
          }
       },
       "MEKE_EQUILIBRIUM_RESTORING": {
@@ -1845,7 +1885,8 @@
          "datatype": "logical",
          "units": "Boolean",
          "value": {
-            "$OCN_GRID == \"tx0.66v1\"": true
+            "$OCN_GRID == \"tx0.66v1\"": true,
+            "$OCN_GRID == \"gx1v6\"": true
          }
       },
       "MEKE_RESTORING_TIMESCALE": {
@@ -1853,6 +1894,7 @@
          "datatype": "real",
          "units": "nondim",
          "value": {
+            "$OCN_GRID == \"gx1v6\"": 10000000.0,
             "$OCN_GRID == \"tx0.66v1\"": 10000000.0
          }
       },
@@ -1861,7 +1903,8 @@
          "datatype": "real",
          "units": "nondim",
          "value": {
-            "$OCN_GRID == \"tx0.66v1\"": 1.0
+            "$OCN_GRID == \"tx0.66v1\"": 1.0,
+            "$OCN_GRID == \"gx1v6\"": 1.0
          }
       },
       "DIAG_COORD_DEF_Z": {
@@ -1913,7 +1956,6 @@
          "datatype": "logical",
          "units": "Boolean",
          "value": {
-            "$OCN_GRID == \"gx1v6\"": true,
             "$OCN_GRID == \"tx0.25v1\"": true,
             "$OCN_GRID == \"MISOMIP\"": true
          }
@@ -1943,7 +1985,6 @@
          "datatype": "logical",
          "units": "Boolean",
          "value": {
-            "$OCN_GRID == \"gx1v6\"": true,
             "$OCN_GRID == \"tx0.25v1\"": true
          }
       },
@@ -2649,6 +2690,7 @@
          "description": "\"default = 0\nThe number of times the 1-1-4-1-1 Laplacian filter is applied on\nOBL depth.\npurely for diagnostic purposes.\"\n",
          "datatype": "integer",
          "value": {
+            "$OCN_GRID == \"gx1v6\"": 3,
             "$OCN_GRID == \"tx0.66v1\"": 3
          }
       },
@@ -2656,6 +2698,7 @@
          "description": "\"default = 'SimpleShapes'\nCVMix method to set profile function for diffusivity and NLT,\nas well as matching across OBL base. Allowed values are:\nSimpleShapes      = sigma*(1-sigma)^2 for both diffusivity and NLT\nMatchGradient     = sigma*(1-sigma)^2 for NLT; diffusivity profile from matching\nMatchBoth         = match gradient for both diffusivity and NLT\nParabolicNonLocal = sigma*(1-sigma)^2 for diffusivity; (1-sigma)^2 for NLT\"\n",
          "datatype": "string",
          "value": {
+            "$OCN_GRID == \"gx1v6\"": "MatchGradient",
             "$OCN_GRID == \"tx0.66v1\"": "MatchGradient"
          }
       },
@@ -2663,6 +2706,7 @@
          "description": "\"Type of interpolation to compute diff and visc at OBL_depth\nAllowed types are: linear, quadratic, cubic or LMD94.\"\n",
          "datatype": "string",
          "value": {
+            "$OCN_GRID == \"gx1v6\"": "LMD94",
             "$OCN_GRID == \"tx0.66v1\"": "LMD94"
          }
       },
@@ -2671,6 +2715,7 @@
          "datatype": "logical",
          "units": "Boolean",
          "value": {
+            "$OCN_GRID == \"gx1v6\"": false,
             "$OCN_GRID == \"tx0.66v1\"": false
          }
       }

--- a/param_templates/json/MOM_input.json
+++ b/param_templates/json/MOM_input.json
@@ -56,7 +56,7 @@
          "units": "nondim",
          "value": {
             "$OCN_GRID == \"gx1v6\"": 60,
-            "$OCN_GRID == \"tx0.66v1\"": 63,
+            "$OCN_GRID == \"tx0.66v1\"": 65,
             "$OCN_GRID == \"tx0.25v1\"": 75,
             "$OCN_GRID == \"MISOMIP\"": 36
          }
@@ -347,7 +347,7 @@
          "datatype": "string",
          "value": {
             "$OCN_GRID == \"gx1v6\"": "WOA05_pottemp_salt.nc",
-            "$OCN_GRID == \"tx0.66v1\"": "WOA05_pottemp_salt_180829.nc",
+            "$OCN_GRID == \"tx0.66v1\"": "woa18_04_initial_conditions.nc",
             "$OCN_GRID == \"tx0.25v1\"": "MOM6_IC_TS.nc"
          }
       },
@@ -356,7 +356,7 @@
          "datatype": "string",
          "value": {
             "$OCN_GRID == \"gx1v6\"": "PTEMP",
-            "$OCN_GRID == \"tx0.66v1\"": "PTEMP",
+            "$OCN_GRID == \"tx0.66v1\"": "theta0",
             "$OCN_GRID == \"tx0.25v1\"": "temp"
          }
       },
@@ -365,7 +365,7 @@
          "datatype": "string",
          "value": {
             "$OCN_GRID == \"gx1v6\"": "SALT",
-            "$OCN_GRID == \"tx0.66v1\"": "SALT"
+            "$OCN_GRID == \"tx0.66v1\"": "s_an"
          }
       },
       "Z_INIT_REMAP_OLD_ALG": {
@@ -536,7 +536,7 @@
          "datatype": "string",
          "value": {
             "$OCN_GRID == \"gx1v6\"": "\"FILE:ocean_vgrid.nc,dz\"",
-            "$OCN_GRID == \"tx0.66v1\"": "\"FILE:ocean_vgrid_190320.nc,dz\"",
+            "$OCN_GRID == \"tx0.66v1\"": "\"FILE:vgrid_65L_20200626.nc,dz\"",
             "$OCN_GRID == \"tx0.25v1\"": "\"HYBRID:hycom1_75_800m.nc,sigma2,FNC1:2,4000,4.5,.01\""
          }
       },
@@ -1586,7 +1586,7 @@
          "description": "\"default = 'salt_restore.nc'\nA file in which to find the surface salinity to use for restoring.\"\n",
          "datatype": "string",
          "value": {
-            "$OCN_GRID == \"tx0.66v1\"": "salt_restore_tx0.66v1_180828.nc"
+            "$OCN_GRID == \"tx0.66v1\"": "state_restore_tx0.66v1_20200616.nc"
          }
       },
       "ADJUST_NET_FRESH_WATER_TO_ZERO": {
@@ -1795,14 +1795,16 @@
          "datatype": "string",
          "value": {
             "$OCN_GRID == \"gx1v6\"": "global_1deg",
-            "$OCN_GRID == \"tx0.25v1\"": "list"
+            "$OCN_GRID == \"tx0.25v1\"": "list",
+            "$OCN_GRID == \"tx0.66v1\"": "list"
          }
       },
       "CHANNEL_LIST_FILE": {
          "description": "\"default = MOM_channel_list\nThe file from which the list of narrowed channels is read.\"\n",
          "datatype": "string",
          "value": {
-            "$OCN_GRID == \"tx0.25v1\"": "MOM_channels_global_025"
+            "$OCN_GRID == \"tx0.25v1\"": "MOM_channels_global_025",
+            "$OCN_GRID == \"tx0.66v1\"": "MOM_channels_global_tx06v1"
          }
       },
       "SMAG_BI_CONST": {

--- a/param_templates/json/MOM_input.json
+++ b/param_templates/json/MOM_input.json
@@ -1643,7 +1643,7 @@
          "description": "\"[Pa] default = 0.02\n The background gustiness in the winds.\"\n",
          "datatype": "real",
          "units": "Pa",
-         "value": 0.0
+         "value": 0.02
       },
       "FIX_USTAR_GUSTLESS_BUG": {
          "description": "\"[Boolean] default = False\nIf true correct a bug in the time-averaging of the gustless wind\nfriction velocity.\"\n",

--- a/param_templates/json/MOM_input.json
+++ b/param_templates/json/MOM_input.json
@@ -149,6 +149,12 @@
          "units": "Boolean",
          "value": true
       },
+      "MIN_SALINITY": {
+         "description": "\"[PPT] default = 0.01\n The minimum value of salinity when BOUND_SALINITY=True. The default is 0.01\n for backward compatibility but ideally should be 0.\"\n",
+         "datatype": "real",
+         "units": "PPT",
+         "value": 0.0
+      },
       "BOUND_SALINITY": {
          "description": "\"[Boolean] default = False\nIf true, limit salinity to being positive. (The sea-ice\nmodel may ask for more salt than is available and\ndrive the salinity negative otherwise.)\"\n",
          "datatype": "logical",
@@ -165,6 +171,12 @@
             "$OCN_GRID == \"tx0.25v1\"": 3992.0,
             "$OCN_GRID == \"MISOMIP\"": 3974.0
          }
+      },
+      "USE_PSURF_IN_EOS": {
+         "description": "\"[Boolean] default = True\nIf true, always include the surface pressure contributions in equation of\nstate calculations.\"\n",
+         "datatype": "logical",
+         "units": "Boolean",
+         "value": true
       },
       "CHECK_BAD_SURFACE_VALS": {
          "description": "\"[Boolean] default = False\nIf true, check the surface state for ridiculous values.\"\n",
@@ -220,6 +232,12 @@
             "$OCN_GRID == \"tx0.25v1\"": "file",
             "$OCN_GRID == \"MISOMIP\"": "linear"
          }
+      },
+      "REMAP_UV_USING_OLD_ALG": {
+         "description": "\"[Boolean] default = True\nIf true, uses the old remapping-via-a-delta-z method for remapping u and v. If\nfalse, uses the new method that remaps between grids described by an old and\nnew thickness.\"\n",
+         "datatype": "logical",
+         "units": "Boolean",
+         "value": false
       },
       "COORD_FILE": {
          "description": "\"The file from which the coordinate densities are read.\"\n",
@@ -350,6 +368,12 @@
             "$OCN_GRID == \"tx0.66v1\"": "SALT"
          }
       },
+      "Z_INIT_REMAP_OLD_ALG": {
+         "description": "\"[Boolean] default = True\nIf false, uses the preferred remapping algorithm for initialization. If true,\nuse an older, less robust algorithm for remapping.\"\n",
+         "datatype": "logical",
+         "units": "Boolean",
+         "value": false
+      },
       "USE_VARIABLE_MIXING": {
          "description": "\"[Boolean] default = False\nIf true, the variable mixing code will be called.  This\nallows diagnostics to be created even if the scheme is\nnot used.  If KHTR_SLOPE_CFF>0 or  KhTh_Slope_Cff>0,\nthis is set to true regardless of what is in the\nparameter file.\"\n",
          "datatype": "logical",
@@ -405,6 +429,12 @@
             "$OCN_GRID == \"tx0.66v1\"": false,
             "$OCN_GRID == \"tx0.25v1\"": true
          }
+      },
+      "USE_GM_WORK_BUG": {
+         "description": "\"[Boolean] default = True\nIf true, compute the top-layer work tendency on the u-grid with the incorrect\nsign, for legacy reproducibility.\"\n",
+         "datatype": "logical",
+         "units": "Boolean",
+         "value": false
       },
       "USE_STORED_SLOPES": {
          "description": "\"[Boolean] default = False\nIf true, the isopycnal slopes are calculated once and\nstored for re-use. This uses more memory but avoids calling\nthe equation of state more times than should be necessary.\"\n",
@@ -586,9 +616,7 @@
          "description": "\"[Boolean] default = False\nIf true, use Use the land mask for the computation of thicknesses\nat velocity locations. This eliminates the dependence on arbitrary\nvalues over land or outside of the domain. Default is False in order to\nmaintain answers with legacy experiments but should be changed to True\nfor new experiments.\"\n",
          "datatype": "logical",
          "units": "Boolean",
-         "value": {
-            "$OCN_GRID == \"tx0.66v1\"": true
-         }
+         "value": true
       },
       "HMIX_FIXED": {
          "description": "\"[m]\nThe prescribed depth over which the near-surface\nviscosity and diffusivity are elevated when the bulk\nmixed layer is not used.\"\n",
@@ -600,13 +628,19 @@
          }
       },
       "CHANNEL_DRAG": {
-         "description": "\"[Boolean] default = False\nIf true, the bottom drag is exerted directly on each\nlayer proportional to the fraction of the bottom it\noverlies.\nIf true, use a bulk Richardson number criterion to\ndetermine the mixed layer thickness for viscosity.\"\n",
+         "description": "\"[Boolean] default = False\nIf true, the bottom drag is exerted directly on each\nlayer proportional to the fraction of the bottom it\noverlies.\"\n",
          "datatype": "logical",
          "units": "Boolean",
          "value": {
             "$OCN_GRID == \"MISOMIP\"": false,
             "else": true
          }
+      },
+      "HBBL": {
+         "description": "\"[m]\nThe thickness of a bottom boundary layer with a\nviscosity of KVBBL if BOTTOMDRAGLAW is not defined, or\nthe thickness over which near-bottom velocities are\naveraged for the drag law if BOTTOMDRAGLAW is defined\nbut LINEAR_DRAG is not.\"\n",
+         "datatype": "real",
+         "units": "m",
+         "value": 10.0
       },
       "PRANDTL_TURB": {
          "description": "\"[nondim] default = 0.0\nThe turbulent Prandtl number applied to shear\ninstability.\"\n",
@@ -633,12 +667,6 @@
          "datatype": "real",
          "units": "m2 s-1",
          "value": 0.0001
-      },
-      "HBBL": {
-         "description": "\"[m]\nThe thickness of a bottom boundary layer with a\nviscosity of KVBBL if BOTTOMDRAGLAW is not defined, or\nthe thickness over which near-bottom velocities are\naveraged for the drag law if BOTTOMDRAGLAW is defined\nbut LINEAR_DRAG is not.\"\n",
-         "datatype": "real",
-         "units": "m",
-         "value": 10.0
       },
       "MAXVEL": {
          "description": "\"[m s-1] default = 3.0E+08\nThe maximum velocity allowed before the velocity\ncomponents are truncated.\"\n",
@@ -702,11 +730,7 @@
          "description": "\"[Boolean] default = True\nIf true, interpolate the resolution function to the\nvelocity points from the thickness points; otherwise\ninterpolate the wave speed and calculate the resolution\nfunction independently at each point.\"\n",
          "datatype": "logical",
          "units": "Boolean",
-         "value": {
-            "$OCN_GRID == \"gx1v6\"": false,
-            "$OCN_GRID == \"tx0.66v1\"": false,
-            "$OCN_GRID == \"tx0.25v1\"": false
-         }
+         "value": false
       },
       "GILL_EQUATORIAL_LD": {
          "description": "\"[Boolean] default = False\nIf true, uses Gill's definition of the baroclinic\nequatorial deformation radius, otherwise, if false, use\nPedlosky's definition. These definitions differ by a factor\nof 2 infront of the beta term in the denominator. Gill'sis the more appropriate definition.\"\n",
@@ -1040,12 +1064,10 @@
          }
       },
       "GUST_CONST": {
-         "description": "\"[Pa] default = 0.02\nThe background gustiness in the winds.\"\n",
+         "description": "\"[Pa] default = 0.02\n The background gustiness in the winds.\"\n",
          "datatype": "real",
          "units": "Pa",
-         "value": {
-            "$OCN_GRID == \"tx0.25v1\"": 0.0
-         }
+         "value": 0.0
       },
       "USE_RIGID_SEA_ICE": {
          "description": "\"[Boolean] default = False\nIf true, sea-ice is rigid enough to exert a\nnonhydrostatic pressure that resist vertical motion.\"\n",
@@ -1530,6 +1552,12 @@
             "$OCN_GRID == \"tx0.66v1\"": true
          }
       },
+      "FIX_USTAR_GUSTLESS_BUG": {
+         "description": "\"[Boolean] default = False\nIf true correct a bug in the time-averaging of the gustless wind\nfriction velocity.\"\n",
+         "datatype": "logical",
+         "units": "Boolean",
+         "value": true
+      },
       "RESTART_CONTROL": {
          "description": "\"default = 1\nAn integer whose bits encode which restart files are\nwritten. Add 2 (bit 1) for a time-stamped file, and odd\n(bit 0) for a non-time-stamped file. A non-time-stamped\nrestart file is saved at the end of the run segment\nfor any non-negative value.\"\n",
          "datatype": "integer",
@@ -1680,6 +1708,18 @@
             "$OCN_GRID == \"MISOMIP\"": true
          }
       },
+      "KAPPA_SHEAR_ITER_BUG": {
+         "description": "[Boolean] default = True If true, use an older, dimensionally inconsistent estimate of the derivative of diffusivity with energy in the Newton's method iteration.  The bug causes undercorrections when dz > 1 m.",
+         "datatype": "logical",
+         "units": "Boolean",
+         "value": false
+      },
+      "KAPPA_SHEAR_ALL_LAYER_TKE_BUG": {
+         "description": "[Boolean] default = True If true, report back the latest estimate of TKE instead of the time average TKE when there is mass in all layers.  Otherwise always report the time averaged TKE, as is currently done when there are some massless layers.",
+         "datatype": "logical",
+         "units": "Boolean",
+         "value": false
+      },
       "VELOCITY_TOLERANCE": {
          "description": "\"[m s-1] default = 3.0E+08\nThe tolerance for barotropic velocity discrepancies\nbetween the barotropic solution and  the sum of the\nlayer thicknesses.\"\n",
          "datatype": "real",
@@ -1730,6 +1770,12 @@
             "$OCN_GRID == \"tx0.66v1\"": -2.5,
             "$OCN_GRID == \"tx0.25v1\"": -3.0
          }
+      },
+      "DEFAULT_2018_ANSWERS": {
+         "description": "\"[Boolean] default = True\nThis sets the default value for the various _2018_ANSWERS parameters.\"\n",
+         "datatype": "logical",
+         "units": "Boolean",
+         "value": false
       },
       "VERTEX_SHEAR": {
          "description": "\"[Boolean] default = False\nIf true, do the calculations of the shear-driven mixing\nat the cell vertices (i.e., the vorticity points).\"\n",

--- a/param_templates/json/MOM_input.json
+++ b/param_templates/json/MOM_input.json
@@ -637,7 +637,7 @@
          }
       },
       "HBBL": {
-         "description": "\"[m]\nThe thickness of a bottom boundary layer with a\nviscosity of KVBBL if BOTTOMDRAGLAW is not defined, or\nthe thickness over which near-bottom velocities are\naveraged for the drag law if BOTTOMDRAGLAW is defined\nbut LINEAR_DRAG is not.\"\n",
+         "description": "\"[m]\n The thickness of a bottom boundary layer with a viscosity of KVBBL if\n BOTTOMDRAGLAW is not defined, or the thickness over which near-bottom\n velocities are averaged for the drag law if BOTTOMDRAGLAW is defined but\n LINEAR_DRAG is not.\"\n",
          "datatype": "real",
          "units": "m",
          "value": 10.0
@@ -1062,12 +1062,6 @@
          "value": {
             "$OCN_GRID == \"tx0.25v1\"": 0.0018
          }
-      },
-      "GUST_CONST": {
-         "description": "\"[Pa] default = 0.02\n The background gustiness in the winds.\"\n",
-         "datatype": "real",
-         "units": "Pa",
-         "value": 0.0
       },
       "USE_RIGID_SEA_ICE": {
          "description": "\"[Boolean] default = False\nIf true, sea-ice is rigid enough to exert a\nnonhydrostatic pressure that resist vertical motion.\"\n",
@@ -1551,6 +1545,12 @@
          "value": {
             "$OCN_GRID == \"tx0.66v1\"": true
          }
+      },
+      "GUST_CONST": {
+         "description": "\"[Pa] default = 0.02\n The background gustiness in the winds.\"\n",
+         "datatype": "real",
+         "units": "Pa",
+         "value": 0.0
       },
       "FIX_USTAR_GUSTLESS_BUG": {
          "description": "\"[Boolean] default = False\nIf true correct a bug in the time-averaging of the gustless wind\nfriction velocity.\"\n",


### PR DESCRIPTION
This PR adds all the changes needed for the CESM2.2/MOM6 tag. All the new files introduced here have been placed in the appropriate directory (/glade/p/cesmdata/cseg/inputdata/ocn/mom/tx0.66v1) and instructions for reproducing them are included in their metadata.

All tests that use OCN_GRID = gx1v6 or tx0.66v1 will change answers. 

Below is a summary of the parameters that are being changed for tx0.66v1:

**1) Change defaults agreed during dev call**

| Parameter   |      OLD      |  NEW |
|----------|:-------------:|------:|
| MIN_SALINITY |  0.01 | 0.0 |
|USE_PSURF_IN_EOS | False | True |
| DEFAULT_2018_ANSWERS | True | False|
| SURFACE_2018_ANSWERS | True | False |
| REMAP_UV_USING_OLD_ALG | True | False |
| REMAPPING_2018_ANSWERS | True | False |
| Z_INIT_REMAP_OLD_ALG | True | False |
| HOR_REGRID_2018_ANSWERS | True | False |
| SET_VISC_2018_ANSWERS |  True | False |
| USE_GM_WORK_BUG | True | False |
| HOR_VISC_2018_ANSWERS  | True | False |
| VERT_FRICTION_2018_ANSWERS | True | False |
| BAROTROPIC_2018_ANSWERS | True | False |
|TIDAL_MIXING_2018_ANSWERS | True | False |
| SET_DIFF_2018_ANSWERS | True | False |
| KAPPA_SHEAR_ITER_BUG | True | False |
| KAPPA_SHEAR_ALL_LAYER_TKE_BUG | True | False |
| OPTICS_2018_ANSWERS | True | False |
| PEN_SW_ABSORB_MINTHICK |  0.001 | 1.0 |
| GUST_CONST | 0.02 | 0.0 |
|FIX_USTAR_GUSTLESS_BUG | False | True |

**2) Add MEKE/GEOMETRIC, LBD and other parameters used in G74**

The table below *does not* show parameters that have been introduced with default values.

| Parameter   |      OLD      |  NEW |
|----------|:-------------:|------:|
| BAD_VAL_SST_MIN |  -2.5 | -3.0 |
| USE_MEKE | False | True |
| MEKE_GMCOEFF| - | 0.0 |
| MEKE_GEOMETRIC| False | True |
| MEKE_GEOMETRIC_ALPHA| 0.05 | 0.07|
|MEKE_EQUILIBRIUM_ALT | False | True |
|MEKE_EQUILIBRIUM_RESTORING | False | True |
| MEKE_RESTORING_TIMESCALE |1.0E+06  | 1.0E+07|
| RESOLN_SCALED_KH| False | True |
| RESOLN_SCALED_KHTH| False | True |
| KHTH_SLOPE_CFF| 0.0 | 0.01 |
|USE_STORED_SLOPES | False | True |
|INTERPOLATE_RES_FN | - | False |
|GILL_EQUATORIAL_LD | -  | True |
| DEPTH_SCALED_KHTH_H0| 1000 | 250 |
|KHTH | 800 | 0.0 |
| KHTH_MAX| 900 | 0.0 |
| USE_KH_IN_MEKE| - | True |
| KH | 1000 | 0.0 |
| KH_VEL_SCALE| 0.01 | 0.0 |
| AH| 0.0 | 1.0E12|
| AH_VEL_SCALE| 0.1 | 0.0|
|LEITH_AH | False | True|
|LEITH_BI_CONST | - | 128|
|INT_TIDE_DECAY_SCALE | 300.3003| 500.0 |
| KHTR| 800 | 0.0 |
| KHTR_MAX| 900 | 0.0 |
| NDIFF_INTERIOR_ONLY | False | True |
| USE_LATERAL_BOUNDARY_DIFFUSION| False | True|
|LBD_LINEAR_TRANSITION |- | True |

**3) Initial conditions, SSS restoring, vertical grid and channel list**

| Parameter   |      OLD      |  NEW |
|----------|:-------------:|------:|
| CHANNEL_CONFIG | none | list |
| CHANNEL_LIST_FILE | - | MOM_channels_global_tx06v1 |
| CHANNEL_LIST_360_LON_CHECK | - | True |
| NK | 63 | 65 |
| ALE_COORDINATE_CONFIG | FILE:ocean_vgrid_190320.nc,dz | FILE:vgrid_65L_20200626.nc,dz |
| TEMP_SALT_Z_INIT_FILE | WOA05_pottemp_salt_180829.nc | woa18_04_initial_conditions.nc |
| Z_INIT_FILE_PTEMP_VAR | PTEMP | theta0 |
| Z_INIT_FILE_SALT_VAR | SALT| s_an |
| SALT_RESTORE_FILE |salt_restore_tx0.66v1_180828.nc | state_restore_tx0.66v1_20200616.nc|

**4) topography**
The new topography is identical to the one used in experiment g.c2b6.GJRA.TL319_t061.long_JRA_mct.074. 

| Parameter   |      OLD      |  NEW |
|----------|:-------------:|------:|
| TOPO_FILE | ocean_topog_200701.nc | ocean_topog_190314.nc |



