### PR TITLE
a cleaner import

### DIFF
--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -16,12 +16,20 @@ if CIMEROOT is None:
     raise SystemExit("ERROR: must set CIMEROOT environment variable")
 sys.path.append(os.path.join(CIMEROOT, "scripts", "Tools"))
 
+# The scope of the following path expansion is limited to this script only,
+# and is needed to import MOM6 input file classes:
+sys.path.append(os.path.join(os.path.dirname(os.path.abspath(__file__)),"MOM_RPS"))
+
 from standard_script_setup import *
 from CIME.case import Case
 from CIME.nmlgen import NamelistGenerator
 from CIME.utils import expect
 from CIME.buildnml import create_namelist_infile, parse_input
 from CIME.utils import run_cmd
+from FType_MOM_params import FType_MOM_params
+from FType_input_nml import FType_input_nml
+from FType_input_data_list import FType_input_data_list
+from FType_diag_table import FType_diag_table
 
 logger = logging.getLogger(__name__)
 
@@ -30,22 +38,14 @@ def prep_input(case):
 
     Buildconf       = case.get_value("CASEBUILD")
     rundir          = case.get_value("RUNDIR")
-    srcroot         = case.get_value("SRCROOT")
-
-    # The scope of the following path expansion is limited to this script only,
-    # and is needed to import MOM6 input file classes:
-    sys.path.append(os.path.join(srcroot,"components","mom","cime_config","MOM_RPS"))
-    from FType_MOM_params import FType_MOM_params
-    from FType_input_nml import FType_input_nml
-    from FType_input_data_list import FType_input_data_list
-    from FType_diag_table import FType_diag_table
+    comp_root_dir_ocn = case.get_value("COMP_ROOT_DIR_OCN")
 
     # Make sure that rundir exists. If not, make it:
     if not os.path.exists(rundir):
         os.makedirs(rundir)
 
     # Parse json files and create MOM6 input files in rundir
-    json_templates_dir = os.path.join(srcroot,"components","mom","param_templates","json")
+    json_templates_dir = os.path.join(comp_root_dir_ocn,"param_templates","json")
 
     # Create MOM_input:
     MOM_input_src = os.path.join(json_templates_dir, "MOM_input.json")
@@ -100,11 +100,7 @@ def process_user_nl_mom(case):
     """ Calls the appropriate MOM_RPS functions to parse user_nl_mom and create MOM_override."""
     caseroot = case.get_value("CASEROOT")
     rundir   = case.get_value("RUNDIR")
-    srcroot  = case.get_value("SRCROOT")
 
-    # parse the parameters in user_nl_mom:
-    sys.path.append(os.path.join(srcroot,"components","mom","cime_config","MOM_RPS"))
-    from FType_MOM_params import FType_MOM_params
     user_nl_mom = FType_MOM_params.from_MOM_input(os.path.join(caseroot,"user_nl_mom"))
 
     # copy the user_nl_mom parameters into MOM_override:


### PR DESCRIPTION
We can import the MOM_RPS modules earlier and without using the case object.  Also using COMP_ROOT_DIR_OCN is better than using SRCROOT since the location of the ocn component may change for different applications. 