### PR TITLE
Facilitate the control of input template variables via other input templates

### DIFF
--- a/cime_config/MOM_RPS/FType_input_data_list.py
+++ b/cime_config/MOM_RPS/FType_input_data_list.py
@@ -4,10 +4,10 @@ from MOM_RPS import MOM_RPS
 class FType_input_data_list(MOM_RPS):
     """Encapsulates data and read/write methods for MOM6 input_data_list file."""
 
-    def write(self, output_path, case):
+    def write(self, output_path, case, MOM_input_final=None):
 
         # Expand cime parameters in values of key:value pairs (e.g., $INPUTDIR)
-        self.expand_case_vars(case)
+        self.expand_case_vars(case, MOM_input_final)
 
         # Apply the guards on the general data to get the targeted values
         self.infer_values(case)

--- a/cime_config/MOM_RPS/rps_utils.py
+++ b/cime_config/MOM_RPS/rps_utils.py
@@ -190,6 +190,38 @@ def eval_formula(formula):
 
     return result
 
+def search_nested_dict(nested_dict, key):
+    """
+    Given a nested dictionary and a key to search for, returns all instances of values of that
+    particular key within the the nested dictionary
+
+    Parameters
+    ----------
+    nested_dict: dict or OrderedDict
+        The nested dictionary that may contain the "key".
+    key:
+        The key to search for
+
+    Returns
+    ------
+    A list of variables paired with all instances of "key".
+
+    >>> mydict = {"A":1, "B":2, "C":{"B":3}}
+    >>> search_nested_dict(mydict,"B")
+    [2, 3]
+    """
+
+    vals = []
+    def find_key_recursive(dict_obj):
+        for key_, val_ in dict_obj.items():
+            if key_ == key:
+                vals.append(dict_obj[key_])
+            if type(val_) in [dict, OrderedDict]:
+                find_key_recursive(val_)
+    find_key_recursive(nested_dict)
+    return(vals)
+
+
 if __name__ == "__main__":
     import doctest
     doctest.testmod()

--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -34,11 +34,15 @@ from FType_diag_table import FType_diag_table
 logger = logging.getLogger(__name__)
 
 def prep_input(case):
-    """ Stages MOM6 input files by calling the appropriate MOM_RPS functions. """
+    """ Generates out-of-the-box versions of MOM6 input files including MOM_input, MOM_override, diag_table
+    input.nml, and mom.input_data_list, inside the run directory. If any of these input files are provided
+    in SourceMods, those versions will be copied to run directory instead."""
 
-    Buildconf       = case.get_value("CASEBUILD")
-    rundir          = case.get_value("RUNDIR")
+    Buildconf = case.get_value("CASEBUILD")
+    rundir = case.get_value("RUNDIR")
     comp_root_dir_ocn = case.get_value("COMP_ROOT_DIR_OCN")
+    caseroot = case.get_value("CASEROOT")
+    SourceMods_dir = os.path.join(caseroot,"SourceMods","src.mom")
 
     # Make sure that rundir exists. If not, make it:
     if not os.path.exists(rundir):
@@ -47,30 +51,58 @@ def prep_input(case):
     # Parse json files and create MOM6 input files in rundir
     json_templates_dir = os.path.join(comp_root_dir_ocn,"param_templates","json")
 
-    # Create MOM_input:
-    MOM_input_src = os.path.join(json_templates_dir, "MOM_input.json")
-    MOM_input_dest = os.path.join(rundir,"MOM_input")
-    MOM_input = FType_MOM_params.from_json(MOM_input_src)
-    MOM_input.write(output_path=MOM_input_dest, output_format="MOM_input", case=case)
+    # 1. Create MOM_input:
+    if "MOM_input" in os.listdir(SourceMods_dir):
+        run_cmd("cp "+os.path.join(SourceMods_dir,"MOM_input")+" "+rundir)
+    else:
+        MOM_input_src = os.path.join(json_templates_dir, "MOM_input.json")
+        MOM_input_dest = os.path.join(rundir,"MOM_input")
+        MOM_input = FType_MOM_params.from_json(MOM_input_src)
+        MOM_input.write(output_path=MOM_input_dest, output_format="MOM_input", case=case)
 
-    # Create input.nml:
-    input_nml_src = os.path.join(json_templates_dir, "input_nml.json")
-    input_nml_dest = os.path.join(rundir,"input.nml")
-    input_nml = FType_input_nml.from_json(input_nml_src)
-    input_nml.write(input_nml_dest, case)
+    # 2. Create MOM_override:
+    user_nl_mom = FType_MOM_params.from_MOM_input(os.path.join(caseroot,"user_nl_mom"))
+    if "MOM_override" in os.listdir(SourceMods_dir):
+        assert len(user_nl_mom.data)==0, "Cannot provide parameter changes via both SourceMods and user_nl_mom!"
+        run_cmd("cp "+os.path.join(SourceMods_dir,"MOM_override")+" "+rundir)
+    else:
+        init_MOM_override(rundir)
+        process_user_nl_mom(case)
 
-    # Create mom.input_data_list:
-    input_data_list_src = os.path.join(json_templates_dir, "input_data_list.json")
-    input_data_list_dest = os.path.join(Buildconf,"mom.input_data_list")
-    input_data_list = FType_input_data_list.from_json(input_data_list_src)
-    input_data_list.write(input_data_list_dest, case)
+    # 3. Read in final versions of MOM_input and MOM_override, so as to use them when inferring
+    #    values of expandable variables in the templates of below MOM6 input files.
+    MOM_input_final = FType_MOM_params.from_MOM_input(os.path.join(rundir,"MOM_input"))
+    MOM_override_final = FType_MOM_params.from_MOM_input(os.path.join(rundir,"MOM_override"))
+    MOM_input_final.append(MOM_override_final)
 
-    # Create diag_table:
-    diag_table_src = os.path.join(json_templates_dir, "diag_table.json")
-    diag_table_dest = os.path.join(rundir,"diag_table")
-    diag_table = FType_diag_table.from_json(diag_table_src)
-    diag_table.write(diag_table_dest, case)
+    # 4. Create input.nml:
+    if "input.nml" in os.listdir(SourceMods_dir):
+        run_cmd("cp "+os.path.join(SourceMods_dir,"input.nml")+" "+rundir)
+    else:
+        input_nml_src = os.path.join(json_templates_dir, "input_nml.json")
+        input_nml_dest = os.path.join(rundir,"input.nml")
+        input_nml = FType_input_nml.from_json(input_nml_src)
+        input_nml.write(input_nml_dest, case)
 
+    # 5. Create mom.input_data_list:
+    if "mom.input_data_list" in os.listdir(SourceMods_dir):
+        run_cmd("cp "+os.path.join(SourceMods_dir,"input.nml")+" "+Buildconf)
+    else:
+        input_data_list_src = os.path.join(json_templates_dir, "input_data_list.json")
+        input_data_list_dest = os.path.join(Buildconf,"mom.input_data_list")
+        input_data_list = FType_input_data_list.from_json(input_data_list_src)
+        input_data_list.write(input_data_list_dest, case, MOM_input_final)
+
+    # 6. Create diag_table:
+    if "diag_table" in os.listdir(SourceMods_dir):
+        run_cmd("cp "+os.path.join(SourceMods_dir,"diag_table")+" "+rundir)
+    else:
+        diag_table_src = os.path.join(json_templates_dir, "diag_table.json")
+        diag_table_dest = os.path.join(rundir,"diag_table")
+        diag_table = FType_diag_table.from_json(diag_table_src)
+        diag_table.write(diag_table_dest, case)
+
+def init_MOM_override(rundir):
     # Create an empty MOM_override:
     with open(os.path.join(rundir,"MOM_override"), 'w') as MOM_override:
         MOM_override.write(\
@@ -78,23 +110,6 @@ def prep_input(case):
             '!          overriden. This file is automatically generated. MOM6 parameter\n'+\
             '!          changes may be made via SourceMods or user_nl_mom.\n'+\
             '!-------------------------------------------------------------------------\n\n')
-
-
-def process_SourceMods(case):
-    """ Copies MOM6 input files from CASEROOT/SourceMods/src.mom to RUNDIR."""
-
-    caseroot = case.get_value("CASEROOT")
-    rundir   = case.get_value("RUNDIR")
-    replaceable = ["diag_table", "input.nml", "MOM_input", "MOM_override"]
-
-    # If an input file normally copied from the templates directory is also provided by the user
-    # in SourceMods/src.mom/, copy the version provided by the user in SourceMods.src.mom into
-    # RUNDIR and so overwrite the default file.
-    SourceMods_dir = os.path.join(caseroot,"SourceMods","src.mom")
-    for filename in os.listdir(SourceMods_dir):
-        if filename in replaceable:
-            run_cmd("cp "+os.path.join(SourceMods_dir,filename)+" "+rundir)
-
 
 def process_user_nl_mom(case):
     """ Calls the appropriate MOM_RPS functions to parse user_nl_mom and create MOM_override."""
@@ -143,12 +158,6 @@ def buildnml(case, caseroot, compname):
 
     # prepare all input files
     prep_input(case)
-
-    # process the SourceMods
-    process_SourceMods(case)
-
-    # process user_nl_mom
-    process_user_nl_mom(case)
 
     # save copies of input files in momconf
     _copy_files_to_momconf(case)

--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -86,7 +86,7 @@ def prep_input(case):
 
     # 5. Create mom.input_data_list:
     if "mom.input_data_list" in os.listdir(SourceMods_dir):
-        run_cmd("cp "+os.path.join(SourceMods_dir,"input.nml")+" "+Buildconf)
+        run_cmd("cp "+os.path.join(SourceMods_dir,"mom.input_data_list")+" "+Buildconf)
     else:
         input_data_list_src = os.path.join(json_templates_dir, "input_data_list.json")
         input_data_list_dest = os.path.join(Buildconf,"mom.input_data_list")

--- a/param_templates/input_data_list.yaml
+++ b/param_templates/input_data_list.yaml
@@ -20,9 +20,9 @@ mom.input_data_list:
     ocean_topo_edit:
         $OCN_GRID == "tx0.25v1": "${DIN_LOC_ROOT}/ocn/mom/${OCN_GRID}/All_edits.nc"
     tempsalt:
-        $OCN_GRID == "gx1v6":    "${DIN_LOC_ROOT}/ocn/mom/${OCN_GRID}/WOA05_pottemp_salt.nc"
-        $OCN_GRID == "tx0.66v1": "${DIN_LOC_ROOT}/ocn/mom/${OCN_GRID}/WOA05_pottemp_salt_180829.nc"
-        $OCN_GRID == "tx0.25v1": "${DIN_LOC_ROOT}/ocn/mom/${OCN_GRID}/MOM6_IC_TS.nc"
+        $INIT_LAYERS_FROM_Z_FILE == "True" and $OCN_GRID == "gx1v6":    "${DIN_LOC_ROOT}/ocn/mom/${OCN_GRID}/WOA05_pottemp_salt.nc"
+        $INIT_LAYERS_FROM_Z_FILE == "True" and $OCN_GRID == "tx0.66v1": "${DIN_LOC_ROOT}/ocn/mom/${OCN_GRID}/WOA05_pottemp_salt_180829.nc"
+        $INIT_LAYERS_FROM_Z_FILE == "True" and $OCN_GRID == "tx0.25v1": "${DIN_LOC_ROOT}/ocn/mom/${OCN_GRID}/MOM6_IC_TS.nc"
     saltrestore:
         $OCN_GRID == "tx0.66v1": "${DIN_LOC_ROOT}/ocn/mom/${OCN_GRID}/salt_restore_tx0.66v1_180828.nc"
     tidal:

--- a/param_templates/input_data_list.yaml
+++ b/param_templates/input_data_list.yaml
@@ -20,9 +20,12 @@ mom.input_data_list:
     ocean_topo_edit:
         $OCN_GRID == "tx0.25v1": "${DIN_LOC_ROOT}/ocn/mom/${OCN_GRID}/All_edits.nc"
     tempsalt:
-        $INIT_LAYERS_FROM_Z_FILE == "True" and $OCN_GRID == "gx1v6":    "${DIN_LOC_ROOT}/ocn/mom/${OCN_GRID}/WOA05_pottemp_salt.nc"
-        $INIT_LAYERS_FROM_Z_FILE == "True" and $OCN_GRID == "tx0.66v1": "${DIN_LOC_ROOT}/ocn/mom/${OCN_GRID}/WOA05_pottemp_salt_180829.nc"
-        $INIT_LAYERS_FROM_Z_FILE == "True" and $OCN_GRID == "tx0.25v1": "${DIN_LOC_ROOT}/ocn/mom/${OCN_GRID}/MOM6_IC_TS.nc"
+        $INIT_LAYERS_FROM_Z_FILE == "True" and $OCN_GRID == "gx1v6":
+            "${DIN_LOC_ROOT}/ocn/mom/${OCN_GRID}/WOA05_pottemp_salt.nc"
+        $INIT_LAYERS_FROM_Z_FILE == "True" and $OCN_GRID == "tx0.66v1":
+            "${DIN_LOC_ROOT}/ocn/mom/${OCN_GRID}/WOA05_pottemp_salt_180829.nc"
+        $INIT_LAYERS_FROM_Z_FILE == "True" and $OCN_GRID == "tx0.25v1":
+            "${DIN_LOC_ROOT}/ocn/mom/${OCN_GRID}/MOM6_IC_TS.nc"
     saltrestore:
         $OCN_GRID == "tx0.66v1": "${DIN_LOC_ROOT}/ocn/mom/${OCN_GRID}/salt_restore_tx0.66v1_180828.nc"
     tidal:

--- a/param_templates/json/input_data_list.json
+++ b/param_templates/json/input_data_list.json
@@ -25,9 +25,9 @@
          "$OCN_GRID == \"tx0.25v1\"": "${DIN_LOC_ROOT}/ocn/mom/${OCN_GRID}/All_edits.nc"
       },
       "tempsalt": {
-         "$OCN_GRID == \"gx1v6\"": "${DIN_LOC_ROOT}/ocn/mom/${OCN_GRID}/WOA05_pottemp_salt.nc",
-         "$OCN_GRID == \"tx0.66v1\"": "${DIN_LOC_ROOT}/ocn/mom/${OCN_GRID}/WOA05_pottemp_salt_180829.nc",
-         "$OCN_GRID == \"tx0.25v1\"": "${DIN_LOC_ROOT}/ocn/mom/${OCN_GRID}/MOM6_IC_TS.nc"
+         "$INIT_LAYERS_FROM_Z_FILE == \"True\" and $OCN_GRID == \"gx1v6\"": "${DIN_LOC_ROOT}/ocn/mom/${OCN_GRID}/WOA05_pottemp_salt.nc",
+         "$INIT_LAYERS_FROM_Z_FILE == \"True\" and $OCN_GRID == \"tx0.66v1\"": "${DIN_LOC_ROOT}/ocn/mom/${OCN_GRID}/WOA05_pottemp_salt_180829.nc",
+         "$INIT_LAYERS_FROM_Z_FILE == \"True\" and $OCN_GRID == \"tx0.25v1\"": "${DIN_LOC_ROOT}/ocn/mom/${OCN_GRID}/MOM6_IC_TS.nc"
       },
       "saltrestore": {
          "$OCN_GRID == \"tx0.66v1\"": "${DIN_LOC_ROOT}/ocn/mom/${OCN_GRID}/salt_restore_tx0.66v1_180828.nc"


### PR DESCRIPTION
This PR brings in a new MOM_RPS capability: Conditionals in input file templates (yaml files) can now incorporate variables from other input template files. Prior to this PR, the conditionals and formulas could only incorporate CIME XML variables.

The PR also updates the conditional for the tempsalt file in mom.input_data_list, such that tempsalt is added only if the MOM_input variable `INIT_LAYERS_FROM_Z_FILE` is set to True. If the user sets `INIT_LAYERS_FROM_Z_FILE` to False via `user_nl_mom` or via `MOM_override`, tempsalt then gets omitted.