### PR TITLE
the b compset definition is set at the cesm level

### DIFF
--- a/cime_config/config_compsets.xml
+++ b/cime_config/config_compsets.xml
@@ -84,10 +84,4 @@
     <lname>2000_SATM_SLND_SICE_MOM6_SROF_CISM2%EVOLVE_SWAV</lname>
   </compset>
 
-  <!-- fully coupled MOM6 runs -->
-  <compset>
-    <alias>BMOM</alias>
-    <lname>1850_CAM60_CLM50%BGC-CROP_CICE_MOM6_MOSART_CISM2%NOEVOLVE_SWAV_BGC%BDRD</lname>
-  </compset>
-
 </compsets>


### PR DESCRIPTION
Remove the BMOM compset here, it is defined in cesm as B1850MOM