### PR TITLE
Discard undetermined expandable vars to be dropped

### DIFF
--- a/param_templates/input_data_list.yaml
+++ b/param_templates/input_data_list.yaml
@@ -20,8 +20,9 @@ mom.input_data_list:
     ocean_topo_edit:
         $OCN_GRID == "tx0.25v1": "${INPUTDIR}/All_edits.nc"
     tempsalt:
-        $INIT_LAYERS_FROM_Z_FILE == "True" and $OCN_GRID in ["gx1v6", "tx0.66v1", "tx0.25v1"]:
-            "${INPUTDIR}/${TEMP_SALT_Z_INIT_FILE}"
+        $OCN_GRID in ["gx1v6", "tx0.66v1", "tx0.25v1"]:
+            $INIT_LAYERS_FROM_Z_FILE == "True":
+                "${INPUTDIR}/${TEMP_SALT_Z_INIT_FILE}"
     saltrestore:
         $OCN_GRID == "tx0.66v1": "${INPUTDIR}/state_restore_tx0.66v1_20200616.nc"
     tidal:

--- a/param_templates/json/input_data_list.json
+++ b/param_templates/json/input_data_list.json
@@ -25,7 +25,9 @@
          "$OCN_GRID == \"tx0.25v1\"": "${INPUTDIR}/All_edits.nc"
       },
       "tempsalt": {
-         "$INIT_LAYERS_FROM_Z_FILE == \"True\" and $OCN_GRID in [\"gx1v6\", \"tx0.66v1\", \"tx0.25v1\"]": "${INPUTDIR}/${TEMP_SALT_Z_INIT_FILE}"
+         "$OCN_GRID in [\"gx1v6\", \"tx0.66v1\", \"tx0.25v1\"]": {
+            "$INIT_LAYERS_FROM_Z_FILE == \"True\"": "${INPUTDIR}/${TEMP_SALT_Z_INIT_FILE}"
+         }
       },
       "saltrestore": {
          "$OCN_GRID == \"tx0.66v1\"": "${INPUTDIR}/state_restore_tx0.66v1_20200616.nc"


### PR DESCRIPTION
This PR allows MOM_RPS module to defer the expansion of undetermined expandable variables if they are to be dropped when guards are evaluated, i.e., if they are not necessary for a particular case configuration.

testing: aux_mom.cheyenne

@gustavo-marques can you confirm that this fixes your issue with the regional setup?