### PR TITLE
Remove unused parameters and provide CHLA dataset for SW absorption

### DIFF
--- a/param_templates/MOM_input.yaml
+++ b/param_templates/MOM_input.yaml
@@ -1958,7 +1958,7 @@ Global:
         units: truncations save_interval-1
         value:
             $OCN_GRID == "tx0.25v1": 100000
-            else: 5000
+            else: 0
     OCEAN_SURFACE_STAGGER:
         description: |
             "default = 'C'

--- a/param_templates/MOM_input.yaml
+++ b/param_templates/MOM_input.yaml
@@ -820,18 +820,6 @@ Global:
         units: Boolean
         value:
             $OCN_GRID == "gx1v6": True
-    TIDE_SAL_SCALAR_VALUE:
-        description: |
-            "[m m-1]
-            The constant of proportionality between sea surface
-            height (really it should be bottom pressure) anomalies
-            and bottom geopotential anomalies. This is only used if
-            TIDES and TIDE_USE_SAL_SCALAR are true."
-        datatype: real
-        units: m m-1
-        value:
-            $OCN_GRID == "gx1v6": 0.094
-            $OCN_GRID == "tx0.66v1": 0.094
     MASS_WEIGHT_IN_PRESSURE_GRADIENT:
         description: |
             "[Boolean] default = False
@@ -879,15 +867,6 @@ Global:
         units: m2 s-1
         value:
             $OCN_GRID == "tx0.66v1": 0.0
-    KH_PWR_OF_SINE:
-        description: |
-            "[nondim] default = 4.0
-            The power used to raise SIN(LAT) when using a latidutinally-
-            dependent background viscosity."
-        datatype: real
-        units: nondim
-        value:
-            $OCN_GRID == "tx0.66v1": 4.0
     BIHARMONIC:
         description: |
             "[Boolean] default = True
@@ -1432,18 +1411,6 @@ Global:
             $OCN_GRID == "gx1v6": True
             $OCN_GRID == "tx0.66v1": True
             $OCN_GRID == "tx0.25v1": True
-    N2_FLOOR_IOMEGA2:
-        description: |
-            "[nondim] default = 1.0
-            The floor applied to N2(k) scaled by Omega^2:
-            If =0., N2(k) is simply positive definite.
-            If =1., N2(k) > Omega^2 everywhere."
-        datatype: real
-        units: nondim
-        value:
-            $OCN_GRID == "gx1v6": 0.0
-            $OCN_GRID == "tx0.66v1": 0.0
-            $OCN_GRID == "tx0.25v1": 0.0
     KD:
         description: |
             "[m2 s-1]
@@ -1490,42 +1457,6 @@ Global:
         value:
             $OCN_GRID == "gx1v6": "300.3003003003003"
             $OCN_GRID == "tx0.25v1": "300.3003003003003"
-    KAPPA_ITIDES:
-        description: |
-            "[m-1] default = 6.283185307179586E-04
-            A topographic wavenumber used with INT_TIDE_DISSIPATION.
-            The default is 2pi/10 km, as in St.Laurent et al. 2002."
-        datatype: real
-        units: m-1
-        value:
-            $OCN_GRID == "gx1v6": 6.28319E-04
-            $OCN_GRID == "tx0.66v1": 6.28319E-04
-            $OCN_GRID == "tx0.25v1": 6.28319E-04
-    KAPPA_H2_FACTOR:
-        description: |
-            "[nondim] default = 1.0
-            A scaling factor for the roughness amplitude with nINT_TIDE_DISSIPATION."
-        datatype: real
-        units: nondim
-        value:
-            $OCN_GRID == "gx1v6": 0.75
-            $OCN_GRID == "tx0.66v1": 0.75
-            $OCN_GRID == "tx0.25v1": 0.84
-    TKE_ITIDE_MAX:
-        description: |
-            "[W m-2] default = 1000.0
-            The maximum internal tide energy source availble to mix
-            above the bottom boundary layer with INT_TIDE_DISSIPATION.
-            If true, read a file (given by TIDEAMP_FILE) containing
-            the tidal amplitude with INT_TIDE_DISSIPATION.
-            The path to the file containing the sub-grid-scale
-            topographic roughness amplitude with INT_TIDE_DISSIPATION."
-        datatype: real
-        units: W m-2
-        value:
-            $OCN_GRID == "gx1v6": 0.1
-            $OCN_GRID == "tx0.66v1": 0.1
-            $OCN_GRID == "tx0.25v1": 0.1
     READ_TIDEAMP:
         description: |
             "[Boolean] default = False
@@ -1680,17 +1611,6 @@ Global:
             $OCN_GRID == "gx1v6": 1.0E-05
             $OCN_GRID == "tx0.66v1": 1.0E-05
             $OCN_GRID == "MISOMIP": 1.0E-08
-    BULK_RI_ML:
-        description: |
-            "[nondim]
-            The efficiency with which mean kinetic energy released
-            by mechanically forced entrainment of the mixed layer
-            is converted to turbulent kinetic energy."
-        datatype: real
-        units: nondim
-        value:
-            $OCN_GRID == "gx1v6": 0.05
-            $OCN_GRID == "tx0.66v1": 0.05
     HMIX_MIN:
         description: |
             "[m] default = 0.0
@@ -2039,20 +1959,6 @@ Global:
         value:
             $OCN_GRID == "tx0.25v1": 100000
             else: 5000
-    MAXCPU:
-        description: |
-            "[wall-clock seconds] default = -1.0
-            The maximum amount of cpu time per processor for which
-            MOM should run before saving a restart file and
-            quitting with a return value that indicates that a
-            further run is required to complete the simulation.
-            If automatic restarts are not desired, use a negative
-            value for MAXCPU.  MAXCPU has units of wall-clock
-            seconds, so the actual CPU time used is larger by a
-            factor of the number of processors used."
-        datatype: real
-        units: wall-clock seconds
-        value: 2.88E+04
     OCEAN_SURFACE_STAGGER:
         description: |
             "default = 'C'
@@ -2159,8 +2065,6 @@ Global:
         units: days
         value:
             $OCN_GRID == "MISOMIP": 0.0
-            $OCN_GRID == "tx0.25v1": 0.0
-            else: 365.0
     ENERGYSAVEDAYS:
         description: |
             "[days] default = 1.0

--- a/param_templates/MOM_input.yaml
+++ b/param_templates/MOM_input.yaml
@@ -820,6 +820,17 @@ Global:
         units: Boolean
         value:
             $OCN_GRID == "gx1v6": True
+    TIDE_SAL_SCALAR_VALUE:
+        description: |
+            "[m m-1]
+            The constant of proportionality between sea surface
+            height (really it should be bottom pressure) anomalies
+            and bottom geopotential anomalies. This is only used if
+            TIDES and TIDE_USE_SAL_SCALAR are true."
+        datatype: real
+        units: m m-1
+        value:
+            $OCN_GRID == "gx1v6": 0.094
     MASS_WEIGHT_IN_PRESSURE_GRADIENT:
         description: |
             "[Boolean] default = False

--- a/param_templates/MOM_input.yaml
+++ b/param_templates/MOM_input.yaml
@@ -1642,7 +1642,6 @@ Global:
         units: m
         value:
             $OCN_GRID == "gx1v6": 15.0
-            $OCN_GRID == "tx0.66v1": 15.0
     PEN_SW_FRAC:
         description: |
             "[nondim] default = 0.0
@@ -1652,7 +1651,6 @@ Global:
         units: nondim
         value:
             $OCN_GRID == "gx1v6": 0.42
-            $OCN_GRID == "tx0.66v1": 0.42
     PRESSURE_DEPENDENT_FRAZIL:
         description: |
             "[Boolean] default = False

--- a/param_templates/MOM_input.yaml
+++ b/param_templates/MOM_input.yaml
@@ -1862,11 +1862,13 @@ Global:
         units: Boolean
         value:
             $OCN_GRID == "tx0.25v1": True
+            $OCN_GRID == "tx0.66v1": True
     CHL_FILE:
         description: |
         datatype: string
         value:
             $OCN_GRID == "tx0.25v1": "seawifs-clim-1997-2010.1440x1080.v20180328.nc"
+            $OCN_GRID == "tx0.66v1": "seawifs-clim-1997-2010-tx0.66v1.nc"
     CHL_VARNAME:
         description: |
             "default = 'CHL_A'"
@@ -1880,6 +1882,7 @@ Global:
         datatype: integer
         value:
             $OCN_GRID == "tx0.25v1": 3
+            $OCN_GRID == "tx0.66v1": 3
     TRACER_ADVECTION_SCHEME:
         description: |
             "default = 'PLM'

--- a/param_templates/json/MOM_input.json
+++ b/param_templates/json/MOM_input.json
@@ -585,6 +585,14 @@
             "$OCN_GRID == \"gx1v6\"": true
          }
       },
+      "TIDE_SAL_SCALAR_VALUE": {
+         "description": "\"[m m-1]\nThe constant of proportionality between sea surface\nheight (really it should be bottom pressure) anomalies\nand bottom geopotential anomalies. This is only used if\nTIDES and TIDE_USE_SAL_SCALAR are true.\"\n",
+         "datatype": "real",
+         "units": "m m-1",
+         "value": {
+            "$OCN_GRID == \"gx1v6\"": 0.094
+         }
+      },
       "MASS_WEIGHT_IN_PRESSURE_GRADIENT": {
          "description": "\"[Boolean] default = False\nIf true, use mass weighting when interpolation T/S for\ntop/bottom integrals in AFV pressure gradient calculation.\"\n",
          "datatype": "logical",

--- a/param_templates/json/MOM_input.json
+++ b/param_templates/json/MOM_input.json
@@ -1230,8 +1230,7 @@
          "datatype": "real",
          "units": "m",
          "value": {
-            "$OCN_GRID == \"gx1v6\"": 15.0,
-            "$OCN_GRID == \"tx0.66v1\"": 15.0
+            "$OCN_GRID == \"gx1v6\"": 15.0
          }
       },
       "PEN_SW_FRAC": {
@@ -1239,8 +1238,7 @@
          "datatype": "real",
          "units": "nondim",
          "value": {
-            "$OCN_GRID == \"gx1v6\"": 0.42,
-            "$OCN_GRID == \"tx0.66v1\"": 0.42
+            "$OCN_GRID == \"gx1v6\"": 0.42
          }
       },
       "PRESSURE_DEPENDENT_FRAZIL": {

--- a/param_templates/json/MOM_input.json
+++ b/param_templates/json/MOM_input.json
@@ -1417,14 +1417,16 @@
          "datatype": "logical",
          "units": "Boolean",
          "value": {
-            "$OCN_GRID == \"tx0.25v1\"": true
+            "$OCN_GRID == \"tx0.25v1\"": true,
+            "$OCN_GRID == \"tx0.66v1\"": true
          }
       },
       "CHL_FILE": {
          "description": "",
          "datatype": "string",
          "value": {
-            "$OCN_GRID == \"tx0.25v1\"": "seawifs-clim-1997-2010.1440x1080.v20180328.nc"
+            "$OCN_GRID == \"tx0.25v1\"": "seawifs-clim-1997-2010.1440x1080.v20180328.nc",
+            "$OCN_GRID == \"tx0.66v1\"": "seawifs-clim-1997-2010-tx0.66v1.nc"
          }
       },
       "CHL_VARNAME": {
@@ -1438,7 +1440,8 @@
          "description": "\"default = 1\nThe number of bands of penetrating shortwave radiation.\"\n",
          "datatype": "integer",
          "value": {
-            "$OCN_GRID == \"tx0.25v1\"": 3
+            "$OCN_GRID == \"tx0.25v1\"": 3,
+            "$OCN_GRID == \"tx0.66v1\"": 3
          }
       },
       "TRACER_ADVECTION_SCHEME": {

--- a/param_templates/json/MOM_input.json
+++ b/param_templates/json/MOM_input.json
@@ -585,15 +585,6 @@
             "$OCN_GRID == \"gx1v6\"": true
          }
       },
-      "TIDE_SAL_SCALAR_VALUE": {
-         "description": "\"[m m-1]\nThe constant of proportionality between sea surface\nheight (really it should be bottom pressure) anomalies\nand bottom geopotential anomalies. This is only used if\nTIDES and TIDE_USE_SAL_SCALAR are true.\"\n",
-         "datatype": "real",
-         "units": "m m-1",
-         "value": {
-            "$OCN_GRID == \"gx1v6\"": 0.094,
-            "$OCN_GRID == \"tx0.66v1\"": 0.094
-         }
-      },
       "MASS_WEIGHT_IN_PRESSURE_GRADIENT": {
          "description": "\"[Boolean] default = False\nIf true, use mass weighting when interpolation T/S for\ntop/bottom integrals in AFV pressure gradient calculation.\"\n",
          "datatype": "logical",
@@ -632,14 +623,6 @@
          "units": "m2 s-1",
          "value": {
             "$OCN_GRID == \"tx0.66v1\"": 0.0
-         }
-      },
-      "KH_PWR_OF_SINE": {
-         "description": "\"[nondim] default = 4.0\nThe power used to raise SIN(LAT) when using a latidutinally-\ndependent background viscosity.\"\n",
-         "datatype": "real",
-         "units": "nondim",
-         "value": {
-            "$OCN_GRID == \"tx0.66v1\"": 4.0
          }
       },
       "BIHARMONIC": {
@@ -1047,16 +1030,6 @@
             "$OCN_GRID == \"tx0.25v1\"": true
          }
       },
-      "N2_FLOOR_IOMEGA2": {
-         "description": "\"[nondim] default = 1.0\nThe floor applied to N2(k) scaled by Omega^2:\nIf =0., N2(k) is simply positive definite.\nIf =1., N2(k) > Omega^2 everywhere.\"\n",
-         "datatype": "real",
-         "units": "nondim",
-         "value": {
-            "$OCN_GRID == \"gx1v6\"": 0.0,
-            "$OCN_GRID == \"tx0.66v1\"": 0.0,
-            "$OCN_GRID == \"tx0.25v1\"": 0.0
-         }
-      },
       "KD": {
          "description": "\"[m2 s-1]\nThe background diapycnal diffusivity of density in the\ninterior. Zero or the molecular value, ~1e-7 m2 s-1,\nmay be used.\"\n",
          "datatype": "real",
@@ -1094,36 +1067,6 @@
          "value": {
             "$OCN_GRID == \"gx1v6\"": "300.3003003003003",
             "$OCN_GRID == \"tx0.25v1\"": "300.3003003003003"
-         }
-      },
-      "KAPPA_ITIDES": {
-         "description": "\"[m-1] default = 6.283185307179586E-04\nA topographic wavenumber used with INT_TIDE_DISSIPATION.\nThe default is 2pi/10 km, as in St.Laurent et al. 2002.\"\n",
-         "datatype": "real",
-         "units": "m-1",
-         "value": {
-            "$OCN_GRID == \"gx1v6\"": 0.000628319,
-            "$OCN_GRID == \"tx0.66v1\"": 0.000628319,
-            "$OCN_GRID == \"tx0.25v1\"": 0.000628319
-         }
-      },
-      "KAPPA_H2_FACTOR": {
-         "description": "\"[nondim] default = 1.0\nA scaling factor for the roughness amplitude with nINT_TIDE_DISSIPATION.\"\n",
-         "datatype": "real",
-         "units": "nondim",
-         "value": {
-            "$OCN_GRID == \"gx1v6\"": 0.75,
-            "$OCN_GRID == \"tx0.66v1\"": 0.75,
-            "$OCN_GRID == \"tx0.25v1\"": 0.84
-         }
-      },
-      "TKE_ITIDE_MAX": {
-         "description": "\"[W m-2] default = 1000.0\nThe maximum internal tide energy source availble to mix\nabove the bottom boundary layer with INT_TIDE_DISSIPATION.\nIf true, read a file (given by TIDEAMP_FILE) containing\nthe tidal amplitude with INT_TIDE_DISSIPATION.\nThe path to the file containing the sub-grid-scale\ntopographic roughness amplitude with INT_TIDE_DISSIPATION.\"\n",
-         "datatype": "real",
-         "units": "W m-2",
-         "value": {
-            "$OCN_GRID == \"gx1v6\"": 0.1,
-            "$OCN_GRID == \"tx0.66v1\"": 0.1,
-            "$OCN_GRID == \"tx0.25v1\"": 0.1
          }
       },
       "READ_TIDEAMP": {
@@ -1262,15 +1205,6 @@
             "$OCN_GRID == \"gx1v6\"": 1e-05,
             "$OCN_GRID == \"tx0.66v1\"": 1e-05,
             "$OCN_GRID == \"MISOMIP\"": 1e-08
-         }
-      },
-      "BULK_RI_ML": {
-         "description": "\"[nondim]\nThe efficiency with which mean kinetic energy released\nby mechanically forced entrainment of the mixed layer\nis converted to turbulent kinetic energy.\"\n",
-         "datatype": "real",
-         "units": "nondim",
-         "value": {
-            "$OCN_GRID == \"gx1v6\"": 0.05,
-            "$OCN_GRID == \"tx0.66v1\"": 0.05
          }
       },
       "HMIX_MIN": {
@@ -1575,12 +1509,6 @@
             "else": 5000
          }
       },
-      "MAXCPU": {
-         "description": "\"[wall-clock seconds] default = -1.0\nThe maximum amount of cpu time per processor for which\nMOM should run before saving a restart file and\nquitting with a return value that indicates that a\nfurther run is required to complete the simulation.\nIf automatic restarts are not desired, use a negative\nvalue for MAXCPU.  MAXCPU has units of wall-clock\nseconds, so the actual CPU time used is larger by a\nfactor of the number of processors used.\"\n",
-         "datatype": "real",
-         "units": "wall-clock seconds",
-         "value": 28800.0
-      },
       "OCEAN_SURFACE_STAGGER": {
          "description": "\"default = 'C'\nA case-insensitive character string to indicate the\nstaggering of the surface velocity field that is\nreturned to the coupler.  Valid values include\n'A', 'B', or 'C'.\"\n",
          "datatype": "string",
@@ -1666,9 +1594,7 @@
          "datatype": "real",
          "units": "days",
          "value": {
-            "$OCN_GRID == \"MISOMIP\"": 0.0,
-            "$OCN_GRID == \"tx0.25v1\"": 0.0,
-            "else": 365.0
+            "$OCN_GRID == \"MISOMIP\"": 0.0
          }
       },
       "ENERGYSAVEDAYS": {

--- a/param_templates/json/MOM_input.json
+++ b/param_templates/json/MOM_input.json
@@ -1506,7 +1506,7 @@
          "units": "truncations save_interval-1",
          "value": {
             "$OCN_GRID == \"tx0.25v1\"": 100000,
-            "else": 5000
+            "else": 0
          }
       },
       "OCEAN_SURFACE_STAGGER": {


### PR DESCRIPTION
Summary:

* Fixes https://github.com/ESCOMP/MOM_interface/issues/78
* Provides a CHLA climatology on the tx0.66v1 grid and updates options for SW absorption. This climatology (seawifs-clim-1997-2010-tx0.66v1.nc) has been copied to /glade/p/cesmdata/cseg/inputdata/ocn/mom/tx0.66v1 and instructions on how to reproduce it can be found at https://github.com/NCAR/SeaWIFS_MOM6.

This PR will change answers for all compsets using tx0.66v1. 