### PR TITLE
Update input.nml for new FMS tag.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,19 @@
 ===============================================================================
 Tag Creator: altuntas
+Developers:  altuntas
+Tag Date:    15 Apr 2021
+Tag Name:    mi_20210415
+
+MOM_interface Updates Summary:
+- set use_mpp_io to .true. so as to keep using FMS1 io with the latest FMS version
+
+MOM6 Updates Summary:
+- none
+
+Testing: aux_mom on cheyenne
+
+===============================================================================
+Tag Creator: altuntas
 Developers:  jedwards
 Tag Date:    09 Apr 2021
 Tag Name:    mi_20210409

--- a/param_templates/input_nml.yaml
+++ b/param_templates/input_nml.yaml
@@ -23,4 +23,6 @@ fms_nml:
 diag_manager_nml:
     flush_nc_files:
         value: .true.
+    use_mpp_io:
+        value: .true.
 ...

--- a/param_templates/json/input_nml.json
+++ b/param_templates/json/input_nml.json
@@ -30,6 +30,9 @@
    "diag_manager_nml": {
       "flush_nc_files": {
          "value": ".true."
+      },
+      "use_mpp_io": {
+         "value": ".true."
       }
    }
 }


### PR DESCRIPTION
This PR sets `use_mpp_io` namelist var in `input.nml` to `.true.`. This is necessary to make sure that we are still using FMS1 io when switching to the new FMS tag (2020.04.03)

testing: cheyenne.aux_mom