### PR TITLE
build fms as subroutine instead of subprocess

### DIFF
--- a/cime_config/buildlib
+++ b/cime_config/buildlib
@@ -15,7 +15,7 @@ sys.path.append(_LIBDIR)
 from standard_script_setup import *
 from CIME.buildlib import parse_input
 from CIME.case import Case
-from CIME.utils import run_cmd, expect
+from CIME.utils import run_sub_or_cmd, run_cmd, expect
 from CIME.build import get_standard_makefile_args
 
 logger = logging.getLogger(__name__)
@@ -33,8 +33,8 @@ def buildlib(caseroot, libroot, bldroot):
             #todo: call checkout_externals to get this component
             expect(False, "FMS external not found")
         else:
-            stat, _, err = run_cmd("{} {} {} {}".format(fmsbuildlib, bldroot, fmsbuilddir, caseroot), verbose=True)
-            expect(stat==0, "FMS build Failed {}".format(err))
+            run_sub_or_cmd(fmsbuildlib, [bldroot, fmsbuilddir, caseroot], 'buildlib',
+                           [bldroot, fmsbuilddir, case], case=case)
 
         # CVMix source code is brought in as a git submodule (or my manage_externals)
         logger.info("Making sure CVMix code is available...")


### PR DESCRIPTION
Builds the fms as a subroutine call. 