### PR TITLE
clean up buildlib and buildnml with cime pylint code_checker

### DIFF
--- a/cime_config/buildlib
+++ b/cime_config/buildlib
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 build mom library

--- a/cime_config/buildlib
+++ b/cime_config/buildlib
@@ -3,7 +3,7 @@
 """
 build mom library
 """
-import sys, os, time, filecmp, shutil, imp, glob
+import sys, os, shutil
 
 _CIMEROOT = os.environ.get("CIMEROOT")
 if _CIMEROOT is None:
@@ -45,6 +45,7 @@ def buildlib(caseroot, libroot, bldroot):
             expect(False, "CVMix external not found")
 
         # Current code base does not need to build MARBL yet
+        # pragma pylint: disable=using-constant-test
         if False:
             # MARBL source code is brought in as a git submodule (or my manage_externals)
             logger.info("Making sure MARBL code is available...")
@@ -56,12 +57,10 @@ def buildlib(caseroot, libroot, bldroot):
         casetools = case.get_value("CASETOOLS")
         gmake_j = case.get_value("GMAKE_J")
         gmake = case.get_value("GMAKE")
-        mach = case.get_value("MACH")
 
         #-------------------------------------------------------
         # create Filepath file for mom
         #-------------------------------------------------------
-        sharedlibroot = case.get_value("SHAREDLIBROOT")
         memory_mode =  case.get_value("MOM6_MEMORY_MODE")
 
         user_incldir = "\"-I{} -I{} -I{}\"".\

--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -9,7 +9,7 @@
 # Disable these because this is our standard setup
 # pylint: disable=wildcard-import,unused-wildcard-import,wrong-import-position
 
-import os, shutil, sys, glob, stat, filecmp, imp
+import os, shutil, sys
 
 CIMEROOT = os.environ.get("CIMEROOT")
 if CIMEROOT is None:
@@ -22,9 +22,7 @@ sys.path.append(os.path.join(os.path.dirname(os.path.abspath(__file__)),"MOM_RPS
 
 from standard_script_setup import *
 from CIME.case import Case
-from CIME.nmlgen import NamelistGenerator
-from CIME.utils import expect
-from CIME.buildnml import create_namelist_infile, parse_input
+from CIME.buildnml import parse_input
 from CIME.utils import run_cmd
 from FType_MOM_params import FType_MOM_params
 from FType_input_nml import FType_input_nml
@@ -143,7 +141,7 @@ def _copy_files_to_momconf(case):
         shutil.copy(os.path.join(rundir,filename), momconfdir)
 
 
-# pylint: disable=too-many-arguments,too-many-locals,too-many-branches,too-many-statements
+# pylint: disable=unused-argument
 ###############################################################################
 def buildnml(case, caseroot, compname):
 ###############################################################################

--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """MOM6 namelist creator
 """


### PR DESCRIPTION
Clean up using pylint - the imp module cannot be used with python3 so an error will occur with older tags. 