### PR TITLE
Add tx0.66v1 CHL_FILE to input_data_list

### DIFF
--- a/param_templates/input_data_list.yaml
+++ b/param_templates/input_data_list.yaml
@@ -35,4 +35,5 @@ mom.input_data_list:
         $OCN_GRID == "tx0.25v1": "${INPUTDIR}/geothermal_davies2013_v1.nc"
     ocean_seaw:
         $OCN_GRID == "tx0.25v1": "${INPUTDIR}/seawifs-clim-1997-2010.1440x1080.v20180328.nc"
+        $OCN_GRID == "tx0.66v1": "${INPUTDIR}/seawifs-clim-1997-2010-tx0.66v1.nc"
 ...

--- a/param_templates/json/input_data_list.json
+++ b/param_templates/json/input_data_list.json
@@ -44,7 +44,8 @@
          "$OCN_GRID == \"tx0.25v1\"": "${INPUTDIR}/geothermal_davies2013_v1.nc"
       },
       "ocean_seaw": {
-         "$OCN_GRID == \"tx0.25v1\"": "${INPUTDIR}/seawifs-clim-1997-2010.1440x1080.v20180328.nc"
+         "$OCN_GRID == \"tx0.25v1\"": "${INPUTDIR}/seawifs-clim-1997-2010.1440x1080.v20180328.nc",
+         "$OCN_GRID == \"tx0.66v1\"": "${INPUTDIR}/seawifs-clim-1997-2010-tx0.66v1.nc"
       }
    }
 }


### PR DESCRIPTION
I added `seawifs-clim-1997-2010-tx0.66v1.nc` to the inputdata repository and then
updated the `input_data_list.yaml` file (and corresponding json file); running a
`cesm2_3_alpha05a` case on izumi, I verified that this file was downloaded
(previous runs aborted because the file could not be found) and that CESM got
past the initialization stage.