### PR TITLE
Add chl_a file to mom.input_data_list

### DIFF
--- a/cime_config/buildlib
+++ b/cime_config/buildlib
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 build mom library

--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """MOM6 namelist creator
 """

--- a/param_templates/input_data_list.yaml
+++ b/param_templates/input_data_list.yaml
@@ -35,4 +35,8 @@ mom.input_data_list:
         $OCN_GRID == "tx0.25v1": "${INPUTDIR}/geothermal_davies2013_v1.nc"
     ocean_seaw:
         $OCN_GRID == "tx0.25v1": "${INPUTDIR}/seawifs-clim-1997-2010.1440x1080.v20180328.nc"
+    chl_a:
+        $OCN_GRID == "tx0.66v1":
+            $VAR_PEN_SW == "True":
+                "${INPUTDIR}/${CHL_FILE}"
 ...

--- a/param_templates/json/input_data_list.json
+++ b/param_templates/json/input_data_list.json
@@ -45,6 +45,11 @@
       },
       "ocean_seaw": {
          "$OCN_GRID == \"tx0.25v1\"": "${INPUTDIR}/seawifs-clim-1997-2010.1440x1080.v20180328.nc"
+      },
+      "chl_a": {
+         "$OCN_GRID == \"tx0.66v1\"": {
+            "$VAR_PEN_SW == \"True\"": "${INPUTDIR}/${CHL_FILE}"
+         }
       }
    }
 }


### PR DESCRIPTION
This PR adds the chl_a file for tx.066v1 grid to mom.input_data_list. This ensures that the file is automatically downloaded when missing (in a new machine).