### PR TITLE
Improve reading in key=value from MOM_input/user_nl_mom files

### DIFF
--- a/cime_config/MOM_RPS/FType_MOM_params.py
+++ b/cime_config/MOM_RPS/FType_MOM_params.py
@@ -37,6 +37,7 @@ class FType_MOM_params(MOM_RPS):
             within_comment_block = False
             curr_module = "Global"
             for line in param_file:
+                line = line.strip()
                 if len(line)>1:
                     line_s = line.split()
 
@@ -61,7 +62,7 @@ class FType_MOM_params(MOM_RPS):
                             line_j = ' '.join(line_s)
 
                             # now parse the line:
-                            if re.search("^\s*\w*\s*=\s*.", line_j):
+                            if re.search("^\s*\w*\s*=\s*[^ \t\n\r\f\v!]+", line_j):
                                 eq_ix = line_j.index('=')
                                 varname = line_j[:eq_ix].strip()
                                 val_str = line_j[eq_ix+1:].strip()

--- a/cime_config/MOM_RPS/FType_MOM_params.py
+++ b/cime_config/MOM_RPS/FType_MOM_params.py
@@ -1,4 +1,5 @@
 import os
+import re
 from MOM_RPS import MOM_RPS
 from rps_utils import get_str_type
 from collections import OrderedDict
@@ -60,10 +61,10 @@ class FType_MOM_params(MOM_RPS):
                             line_j = ' '.join(line_s)
 
                             # now parse the line:
-                            if ("=" in line_j):
-                                line_ss     = line_j.split("=")
-                                param_str   = (line_ss[0]).strip()  # the first element is the parameter name
-                                val_str     = ' '.join(line_ss[1:]) # the rest is tha value string
+                            if re.search("^\s*\w*\s*=\s*.", line_j):
+                                eq_ix = line_j.index('=')
+                                varname = line_j[:eq_ix].strip()
+                                val_str = line_j[eq_ix+1:].strip()
                                 if '!' in val_str:
                                     val_str = val_str.split("!")[0] # discard the comment in val str, if there is
 
@@ -72,11 +73,11 @@ class FType_MOM_params(MOM_RPS):
                                     _data[curr_module] = dict()
 
                                 # check if param already provided:
-                                if param_str in _data[curr_module]:
-                                    raise SystemExit('ERROR: '+param_str+' listed more than once in '+input_path)
+                                if varname in _data[curr_module]:
+                                    raise SystemExit('ERROR: '+varname+' listed more than once in '+input_path)
 
                                 # enter the parameter in the dictionary:
-                                _data[curr_module][param_str] = {'value':val_str}
+                                _data[curr_module][varname] = {'value':val_str}
                             else:
                                 raise SystemExit('ERROR: Cannot parse the following line in user_nl_mom: '+line)
 

--- a/cime_config/testdefs/testlist_mom.xml
+++ b/cime_config/testdefs/testlist_mom.xml
@@ -30,7 +30,7 @@
       <option name="wallclock">00:30:00</option>
     </options>
   </test>
-  <test name="SMS" grid="T62_t061" compset="GMOM">
+  <test name="SMS" grid="T62_t061" compset="GMOM" testmods="mom/rps">
     <machines>
       <machine name="cheyenne" compiler="gnu" category="aux_mom"/>
       <machine name="cheyenne" compiler="intel" category="prealpha"/>

--- a/cime_config/testdefs/testmods_dirs/mom/rps/shell_commands
+++ b/cime_config/testdefs/testmods_dirs/mom/rps/shell_commands
@@ -1,0 +1,1 @@
+./xmlchange MOM6_MEMORY_MODE=dynamic_symmetric

--- a/cime_config/testdefs/testmods_dirs/mom/rps/user_nl_mom
+++ b/cime_config/testdefs/testmods_dirs/mom/rps/user_nl_mom
@@ -1,0 +1,9 @@
+! key = value !!! some comment
+
+MIN_THICKNESS = 1e-4  !! the default is 1e-3
+   
+KPP%
+  N_SMOOTH=2
+  USE_KPP_LT_VT2 = False  ! the default is false, so no change
+%KPP
+  


### PR DESCRIPTION
Use a regex expression to check whether a line in MOM_input|MOM_override|user_nl_file is a key=value pair, i.e., a variables assignment. Instead of split('=') and join, look for the first occurence of '=' to prevent disapperance of other '=' occurences in value strings.

Fixes: #93