### PR TITLE
Add the drifters module path to buildlib

### DIFF
--- a/cime_config/buildlib
+++ b/cime_config/buildlib
@@ -79,6 +79,7 @@ def buildlib(caseroot, libroot, bldroot):
                      os.path.join(comp_root_dir_ocn,"MOM6","config_src","external","GFDL_ocean_BGC"),
                      os.path.join(comp_root_dir_ocn,"MOM6","config_src","external","ODA_hooks"),
                      os.path.join(comp_root_dir_ocn,"MOM6","config_src","external","stochastic_physics"),
+                     os.path.join(comp_root_dir_ocn,"MOM6","config_src","external","drifters"),
                      os.path.join(comp_root_dir_ocn,"MOM6","src","ALE"),
                      os.path.join(comp_root_dir_ocn,"MOM6","src","core"),
                      os.path.join(comp_root_dir_ocn,"MOM6","src","diagnostics"),


### PR DESCRIPTION
This is to be evaluated and merged in conjunction with https://github.com/NCAR/MOM6/pull/211