### PR TITLE
diag_table.yaml changes to improve flexibility and brevity

### DIFF
--- a/param_templates/diag_table.yaml
+++ b/param_templates/diag_table.yaml
@@ -70,7 +70,7 @@ Files:
         fields:
             $OCN_DIAG_MODE != "none":
                 module:   "ocean_model_rho2"
-                packing: = 1 if $TEST else 2
+                packing: = 2
                 lists:    [ *transports ]
 
     # native grid
@@ -150,7 +150,7 @@ Files:
         reduction_method: "mean"    # time average
         regional_section: "none"    # global
         fields:
-            $OCN_DIAG_MODE != "none":
+            $OCN_DIAG_MODE != "none" and $TEST is not True :
                 module:   "ocean_model"    # native
                 packing: = 1 if $TEST else 2
                 lists:    [ *surface_flds,

--- a/param_templates/diag_table.yaml
+++ b/param_templates/diag_table.yaml
@@ -69,9 +69,9 @@ Files:
         regional_section: "none"    # global
         fields:
             $OCN_DIAG_MODE != "none":
-                - module:   "ocean_model_rho2"
-                  packing:  2                 # single precision
-                  lists:    [ *transports ]
+                module:   "ocean_model_rho2"
+                packing: = 1 if $TEST else 2
+                lists:    [ *transports ]
 
     # native grid
     hist:
@@ -92,37 +92,23 @@ Files:
         reduction_method: "mean"    # time average
         regional_section: "none"    # global
         fields:
-            $OCN_DIAG_MODE == "spinup":
-                - module:   "ocean_model"
-                  packing:  2                 # single precision
-                  lists:    [ *hist_additional,
-                              *tracers,
-                              *visc_flds,
-                              *transports ]
-            $OCN_DIAG_MODE not in ["spinup", "none"]:
-                $USE_CFC_CAP == "True":
-                    - module:   "ocean_model"
-                      packing:  1                 # double precision
-                      lists:    [ *prognostic,
-                                  *hist_additional,
-                                  *kpp_diags,
-                                  *forcing_flds,
-                                  *surface_flds,
-                                  *visc_flds,
-                                  *transports,
-                                  *tracers,
-                                  *cfc_2d ]
-                else:
-                    - module:   "ocean_model"
-                      packing:  1                 # double precision
-                      lists:    [ *prognostic,
-                                  *hist_additional,
-                                  *kpp_diags,
-                                  *forcing_flds,
-                                  *surface_flds,
-                                  *visc_flds,
-                                  *transports,
-                                  *tracers ]
+            $OCN_DIAG_MODE != "none":
+                module:   "ocean_model"
+                packing: = 1 if $TEST else 2
+                lists:
+                        [ *hist_additional,
+                          *tracers,
+                          *visc_flds,
+                          *transports ]
+                lists2:
+                    $OCN_DIAG_MODE not in ["spinup", "none"]:
+                        [ *prognostic,
+                          *kpp_diags,
+                          *forcing_flds,
+                          *surface_flds]
+                lists3:
+                    $USE_CFC_CAP == "True":
+                        [ *cfc_2d ]
 
     # essential variable mapped to z_space
     hist_z_space:
@@ -143,20 +129,14 @@ Files:
         reduction_method: "mean"    # time average
         regional_section: "none"    # global
         fields:
-            $OCN_DIAG_MODE == "spinup":
-                - module:   "ocean_model_z"   # z_space
-                  packing:  2                 # single precision
-                  lists:    [ *prognostic ]
-            $OCN_DIAG_MODE not in ["spinup", "none"]:
-                $USE_CFC_CAP == "True":
-                    - module:   "ocean_model_z"   # z_space
-                      packing:  1                 # double precision
-                      lists:    [ *prognostic,
-                                  *cfc_3d ]
-                else:
-                    - module:   "ocean_model_z"   # z_space
-                      packing:  1                 # double precision
-                      lists:    [ *prognostic ]
+            $OCN_DIAG_MODE != "none":
+                module:   "ocean_model_z"   # z_space
+                packing: = 1 if $TEST else 2
+                lists:
+                    [ *prognostic ]
+                lists2:
+                    $USE_CFC_CAP == "True":
+                        [ *cfc_3d ]
 
     surface_avg:
         suffix: "sfc%4yr"
@@ -170,16 +150,11 @@ Files:
         reduction_method: "mean"    # time average
         regional_section: "none"    # global
         fields:
-            $OCN_DIAG_MODE in ["production", "development"] and $TEST == False:
-                - module:   "ocean_model"    # native
-                  packing:  1                # double precision
-                  lists:    [ *surface_flds,
-                              *kpp_diags ]
-            $OCN_DIAG_MODE == "spinup" and $TEST == False:
-                - module:   "ocean_model"    # native
-                  packing:  2                # single precision
-                  lists:    [ *surface_flds,
-                              *kpp_diags ]
+            $OCN_DIAG_MODE != "none":
+                module:   "ocean_model"    # native
+                packing: = 1 if $TEST else 2
+                lists:    [ *surface_flds,
+                            *kpp_diags ]
     forcing_daily_avg:
         suffix: "frc%4yr"
         output_freq: 1
@@ -191,10 +166,10 @@ Files:
         regional_section: "none"    # global
         fields:
             $OCN_DIAG_MODE == "development":
-                - module:   "ocean_model"  # native
-                  packing:  1            # double precision
-                  lists:    [ *forcing_flds,
-                              *forcing_flds_dev ]
+                module:   "ocean_model"  # native
+                packing: = 1 if $TEST else 2
+                lists:    [ *forcing_flds,
+                            *forcing_flds_dev ]
 
     visc_and_diff_daily_avg:
         suffix: "visc%4yr"
@@ -207,9 +182,9 @@ Files:
         regional_section: "none"    # global
         fields:
             $OCN_DIAG_MODE == "development":
-                - module:   "ocean_model"  # native
-                  packing:  1            # double precision
-                  lists:    [ *visc_flds ]
+                module:   "ocean_model"  # native
+                packing: = 1 if $TEST else 2
+                lists:    [ *visc_flds ]
 
     static:
         suffix: "static"
@@ -219,9 +194,9 @@ Files:
         reduction_method: ".false."     # instantaneous
         regional_section: "none"        # global
         fields:
-            - module:   "ocean_model"   # native
-              packing:  1               # double precision
-              lists:    [ *static_flds ]
+            module:   "ocean_model"   # native
+            packing: = 1 if $TEST else 2
+            lists:    [ *static_flds ]
 
 
     # Sections ------------------------------------
@@ -244,9 +219,9 @@ Files:
             $OCN_GRID == "tx0.66v1": "20.1 20.1 -70.0 -34.6 -1 -1"
         fields:
             $OCN_GRID == "tx0.66v1" and  $TEST == False and $OCN_DIAG_SECTIONS == True:
-                - module:   "ocean_model"  # native
-                  packing:  2            # single precision
-                  lists:    [ *vert_sections_u ]
+                module:   "ocean_model"  # native
+                packing:  2            # single precision
+                lists:    [ *vert_sections_u ]
 
     Bab_al_mandeb_Strait:
         suffix: "Bab_al_mandeb_Strait%4yr"
@@ -266,9 +241,9 @@ Files:
             $OCN_GRID == "tx0.66v1": "45.0 45.0 10.5 13.5 -1 -1"
         fields:
             $OCN_GRID == "tx0.66v1" and  $TEST == False and $OCN_DIAG_SECTIONS == True:
-                - module:   "ocean_model"  # native
-                  packing:  2            # single precision
-                  lists:    [ *vert_sections_u ]
+                module:   "ocean_model"  # native
+                packing:  2            # single precision
+                lists:    [ *vert_sections_u ]
 
     Barents_opening:
         suffix: "Barents_opening%4yr"
@@ -288,9 +263,9 @@ Files:
             $OCN_GRID == "tx0.66v1": "-5.2 18.8  78.93 78.93 -1 -1"
         fields:
             $OCN_GRID == "tx0.66v1" and  $TEST == False and $OCN_DIAG_SECTIONS == True:
-                - module:   "ocean_model"  # native
-                  packing:  2            # single precision
-                  lists:    [ *vert_sections_v ]
+                module:   "ocean_model"  # native
+                packing:  2            # single precision
+                lists:    [ *vert_sections_v ]
 
     Bering_Strait:
         suffix: "Bering_Strait%4yr"
@@ -310,9 +285,9 @@ Files:
             $OCN_GRID == "tx0.66v1": "-174.5  -171.5 66.6 66.6 -1 -1"
         fields:
             $OCN_GRID == "tx0.66v1" and  $TEST == False and $OCN_DIAG_SECTIONS == True:
-                - module:   "ocean_model"  # native
-                  packing:  2            # single precision
-                  lists:    [ *vert_sections_v ]
+                module:   "ocean_model"  # native
+                packing:  2            # single precision
+                lists:    [ *vert_sections_v ]
 
     Davis_Strait:
         suffix: "Davis_Strait%4yr"
@@ -332,9 +307,9 @@ Files:
             $OCN_GRID == "tx0.66v1": "-53.5 -45.3 69.5 69.5 -1 -1"
         fields:
             $OCN_GRID == "tx0.66v1" and  $TEST == False and $OCN_DIAG_SECTIONS == True:
-                - module:   "ocean_model"  # native
-                  packing:  2            # single precision
-                  lists:    [ *vert_sections_v ]
+                module:   "ocean_model"  # native
+                packing:  2            # single precision
+                lists:    [ *vert_sections_v ]
 
     Denmark_Strait:
         suffix: "Denmark_Strait%4yr"
@@ -354,9 +329,9 @@ Files:
             $OCN_GRID == "tx0.66v1": "-38.50 -21.5 65.0 65.0 -1 -1"
         fields:
             $OCN_GRID == "tx0.66v1" and  $TEST == False and $OCN_DIAG_SECTIONS == True:
-                - module:   "ocean_model"  # native
-                  packing:  2            # single precision
-                  lists:    [ *vert_sections_v ]
+                module:   "ocean_model"  # native
+                packing:  2            # single precision
+                lists:    [ *vert_sections_v ]
 
     Drake_Passage:
         suffix: "Drake_Passage%4yr"
@@ -376,9 +351,9 @@ Files:
             $OCN_GRID == "tx0.66v1": "-67.0 -67.0 -69.0 -55.2 -1 -1"
         fields:
             $OCN_GRID == "tx0.66v1" and  $TEST == False and $OCN_DIAG_SECTIONS == True:
-                - module:   "ocean_model"  # native
-                  packing:  2            # single precision
-                  lists:    [ *vert_sections_u ]
+                module:   "ocean_model"  # native
+                packing:  2            # single precision
+                lists:    [ *vert_sections_u ]
 
     English_Channel:
         suffix: "English_Channel%4yr"
@@ -398,9 +373,9 @@ Files:
             $OCN_GRID == "tx0.66v1": "0.0 0.0 51.0 52.9 -1 -1"
         fields:
             $OCN_GRID == "tx0.66v1" and  $TEST == False and $OCN_DIAG_SECTIONS == True:
-                - module:   "ocean_model"  # native
-                  packing:  2            # single precision
-                  lists:    [ *vert_sections_u ]
+                module:   "ocean_model"  # native
+                packing:  2            # single precision
+                lists:    [ *vert_sections_u ]
 
     Fram_Strait:
         suffix: "Fram_Strait%4yr"
@@ -420,9 +395,9 @@ Files:
             $OCN_GRID == "tx0.66v1": "-21.0 -9.8 80.5 80.5 -1 -1"
         fields:
             $OCN_GRID == "tx0.66v1" and  $TEST == False and $OCN_DIAG_SECTIONS == True:
-                - module:   "ocean_model"  # native
-                  packing:  2            # single precision
-                  lists:    [ *vert_sections_v ]
+                module:   "ocean_model"  # native
+                packing:  2            # single precision
+                lists:    [ *vert_sections_v ]
 
     Florida_Bahamas:
         suffix: "Florida_Bahamas%4yr"
@@ -442,9 +417,9 @@ Files:
             $OCN_GRID == "tx0.66v1": "-80.1 -77.9 25.3 25.3 -1 -1"
         fields:
             $OCN_GRID == "tx0.66v1" and  $TEST == False and $OCN_DIAG_SECTIONS == True:
-                - module:   "ocean_model"  # native
-                  packing:  2            # single precision
-                  lists:    [ *vert_sections_v ]
+                module:   "ocean_model"  # native
+                packing:  2            # single precision
+                lists:    [ *vert_sections_v ]
 
     Gibraltar_Strait:
         suffix: "Gibraltar_Strait%4yr"
@@ -464,9 +439,9 @@ Files:
             $OCN_GRID == "tx0.66v1": "-6.5 -6.5 34.3 37.4 -1 -1"
         fields:
             $OCN_GRID == "tx0.66v1" and  $TEST == False and $OCN_DIAG_SECTIONS == True:
-                - module:   "ocean_model"  # native
-                  packing:  2            # single precision
-                  lists:    [ *vert_sections_u ]
+                module:   "ocean_model"  # native
+                packing:  2            # single precision
+                lists:    [ *vert_sections_u ]
 
     Hormuz_Strait:
         suffix: "Hormuz_Strait%4yr"
@@ -486,9 +461,9 @@ Files:
             $OCN_GRID == "tx0.66v1": "55.9 55.9 25.0 27.5 -1 -1"
         fields:
             $OCN_GRID == "tx0.66v1" and  $TEST == False and $OCN_DIAG_SECTIONS == True:
-                - module:   "ocean_model"  # native
-                  packing:  2            # single precision
-                  lists:    [ *vert_sections_u ]
+                module:   "ocean_model"  # native
+                packing:  2            # single precision
+                lists:    [ *vert_sections_u ]
 
     Iceland_Norway:
         suffix: "Iceland_Norway%4yr"
@@ -508,9 +483,9 @@ Files:
             $OCN_GRID == "tx0.66v1": "-21.5 1.5 65.0 65.0 -1 -1"
         fields:
             $OCN_GRID == "tx0.66v1" and  $TEST == False and $OCN_DIAG_SECTIONS == True:
-                - module:   "ocean_model"  # native
-                  packing:  2            # single precision
-                  lists:    [ *vert_sections_v ]
+                module:   "ocean_model"  # native
+                packing:  2            # single precision
+                lists:    [ *vert_sections_v ]
 
     Indonesian_Throughflow:
         suffix: "Indonesian_Throughflow%4yr"
@@ -530,9 +505,9 @@ Files:
             $OCN_GRID == "tx0.66v1": "-246.5 -220.8 -7.0 -7.0 -1 -1"
         fields:
             $OCN_GRID == "tx0.66v1" and  $TEST == False and $OCN_DIAG_SECTIONS == True:
-                - module:   "ocean_model"  # native
-                  packing:  2            # single precision
-                  lists:    [ *vert_sections_v ]
+                module:   "ocean_model"  # native
+                packing:  2            # single precision
+                lists:    [ *vert_sections_v ]
 
     Mozambique_Channel:
         suffix: "Mozambique_Channel%4yr"
@@ -552,9 +527,9 @@ Files:
             $OCN_GRID == "tx0.66v1": "39.9 44.7 -16.0 -16.0 -1 -1"
         fields:
             $OCN_GRID == "tx0.66v1" and  $TEST == False and $OCN_DIAG_SECTIONS == True:
-                - module:   "ocean_model"  # native
-                  packing:  2            # single precision
-                  lists:    [ *vert_sections_v ]
+                module:   "ocean_model"  # native
+                packing:  2            # single precision
+                lists:    [ *vert_sections_v ]
 
     Pacific_undercurrent:
         suffix: "Pacific_undercurrent%4yr"
@@ -574,9 +549,9 @@ Files:
             $OCN_GRID == "tx0.66v1": "-155.0 -155.0 -2.0 2.0 -1 -1"
         fields:
             $OCN_GRID == "tx0.66v1" and  $TEST == False and $OCN_DIAG_SECTIONS == True:
-                - module:   "ocean_model"  # native
-                  packing:  2            # single precision
-                  lists:    [ *vert_sections_u ]
+                module:   "ocean_model"  # native
+                packing:  2            # single precision
+                lists:    [ *vert_sections_u ]
 
     Taiwan_Luzon:
         suffix: "Taiwan_Luzon%4yr"
@@ -596,9 +571,9 @@ Files:
             $OCN_GRID == "tx0.66v1": "-239.0 -239.0 18.8 22.5 -1 -1"
         fields:
             $OCN_GRID == "tx0.66v1" and  $TEST == False and $OCN_DIAG_SECTIONS == True:
-                - module:   "ocean_model"  # native
-                  packing:  2            # single precision
-                  lists:    [ *vert_sections_u ]
+                module:   "ocean_model"  # native
+                packing:  2            # single precision
+                lists:    [ *vert_sections_u ]
 
     Windward_Passage:
         suffix: "Windward_Passage%4yr"
@@ -618,7 +593,7 @@ Files:
             $OCN_GRID == "tx0.66v1": "-74.2 -73.2 20.39 20.39 -1 -1"
         fields:
             $OCN_GRID == "tx0.66v1" and  $TEST == False and $OCN_DIAG_SECTIONS == True:
-                - module:   "ocean_model"  # native
-                  packing:  2            # single precision
-                  lists:    [ *vert_sections_v ]
+                module:   "ocean_model"  # native
+                packing:  2            # single precision
+                lists:    [ *vert_sections_v ]
 ...

--- a/param_templates/json/diag_table.json
+++ b/param_templates/json/diag_table.json
@@ -167,7 +167,7 @@
          "fields": {
             "$OCN_DIAG_MODE != \"none\"": {
                "module": "ocean_model_rho2",
-               "packing": "= 1 if $TEST else 2",
+               "packing": "= 2",
                "lists": [
                   [
                      "volcello",
@@ -368,7 +368,7 @@
          "reduction_method": "mean",
          "regional_section": "none",
          "fields": {
-            "$OCN_DIAG_MODE != \"none\"": {
+            "$OCN_DIAG_MODE != \"none\" and $TEST is not True": {
                "module": "ocean_model",
                "packing": "= 1 if $TEST else 2",
                "lists": [

--- a/param_templates/json/diag_table.json
+++ b/param_templates/json/diag_table.json
@@ -165,23 +165,21 @@
          "reduction_method": "mean",
          "regional_section": "none",
          "fields": {
-            "$OCN_DIAG_MODE != \"none\"": [
-               {
-                  "module": "ocean_model_rho2",
-                  "packing": 2,
-                  "lists": [
-                     [
-                        "volcello",
-                        "vmo",
-                        "vhGM",
-                        "vhml",
-                        "umo",
-                        "uhGM",
-                        "uhml"
-                     ]
+            "$OCN_DIAG_MODE != \"none\"": {
+               "module": "ocean_model_rho2",
+               "packing": "= 1 if $TEST else 2",
+               "lists": [
+                  [
+                     "volcello",
+                     "vmo",
+                     "vhGM",
+                     "vhml",
+                     "umo",
+                     "uhGM",
+                     "uhml"
                   ]
-               }
-            ]
+               ]
+            }
          }
       },
       "hist": {
@@ -205,260 +203,43 @@
          "reduction_method": "mean",
          "regional_section": "none",
          "fields": {
-            "$OCN_DIAG_MODE == \"spinup\"": [
-               {
-                  "module": "ocean_model",
-                  "packing": 2,
-                  "lists": [
-                     [
-                        "soga",
-                        "thetaoga",
-                        "uh",
-                        "vh",
-                        "vhbt",
-                        "uhbt"
-                     ],
-                     [
-                        "agessc",
-                        "T_ady_2d",
-                        "T_adx_2d",
-                        "T_diffy_2d",
-                        "T_diffx_2d"
-                     ],
-                     [
-                        "diftrelo",
-                        "diftrblo",
-                        "difmxybo",
-                        "difmxylo"
-                     ],
-                     [
-                        "volcello",
-                        "vmo",
-                        "vhGM",
-                        "vhml",
-                        "umo",
-                        "uhGM",
-                        "uhml"
-                     ]
+            "$OCN_DIAG_MODE != \"none\"": {
+               "module": "ocean_model",
+               "packing": "= 1 if $TEST else 2",
+               "lists": [
+                  [
+                     "soga",
+                     "thetaoga",
+                     "uh",
+                     "vh",
+                     "vhbt",
+                     "uhbt"
+                  ],
+                  [
+                     "agessc",
+                     "T_ady_2d",
+                     "T_adx_2d",
+                     "T_diffy_2d",
+                     "T_diffx_2d"
+                  ],
+                  [
+                     "diftrelo",
+                     "diftrblo",
+                     "difmxybo",
+                     "difmxylo"
+                  ],
+                  [
+                     "volcello",
+                     "vmo",
+                     "vhGM",
+                     "vhml",
+                     "umo",
+                     "uhGM",
+                     "uhml"
                   ]
-               }
-            ],
-            "$OCN_DIAG_MODE not in [\"spinup\", \"none\"]": {
-               "$USE_CFC_CAP == \"True\"": [
-                  {
-                     "module": "ocean_model",
-                     "packing": 1,
-                     "lists": [
-                        [
-                           "uo",
-                           "vo",
-                           "h",
-                           "e",
-                           "thetao",
-                           "so",
-                           "rhoinsitu",
-                           "KE",
-                           "rhopot0"
-                        ],
-                        [
-                           "soga",
-                           "thetaoga",
-                           "uh",
-                           "vh",
-                           "vhbt",
-                           "uhbt"
-                        ],
-                        [
-                           "KPP_OBLdepth:oml"
-                        ],
-                        [
-                           "tauuo",
-                           "tauvo",
-                           "friver",
-                           "prsn",
-                           "prlq",
-                           "evs",
-                           "hfsso",
-                           "rlntds",
-                           "hfsnthermds",
-                           "sfdsi",
-                           "rsntds",
-                           "hfds",
-                           "ustar",
-                           "hfsifrazil",
-                           "wfo",
-                           "vprec",
-                           "ficeberg",
-                           "fsitherm",
-                           "hflso",
-                           "pso",
-                           "seaice_melt_heat",
-                           "Heat_PmE",
-                           "salt_flux_added"
-                        ],
-                        [
-                           "SSH",
-                           "tos",
-                           "sos",
-                           "SSU",
-                           "SSV",
-                           "mass_wt",
-                           "opottempmint",
-                           "somint",
-                           "Rd_dx",
-                           "speed",
-                           "mlotst"
-                        ],
-                        [
-                           "diftrelo",
-                           "diftrblo",
-                           "difmxybo",
-                           "difmxylo"
-                        ],
-                        [
-                           "volcello",
-                           "vmo",
-                           "vhGM",
-                           "vhml",
-                           "umo",
-                           "uhGM",
-                           "uhml"
-                        ],
-                        [
-                           "agessc",
-                           "T_ady_2d",
-                           "T_adx_2d",
-                           "T_diffy_2d",
-                           "T_diffx_2d"
-                        ],
-                        [
-                           "cfc11_flux",
-                           "cfc12_flux",
-                           "ice_fraction",
-                           "u10_sqr"
-                        ]
-                     ]
-                  }
                ],
-               "else": [
-                  {
-                     "module": "ocean_model",
-                     "packing": 1,
-                     "lists": [
-                        [
-                           "uo",
-                           "vo",
-                           "h",
-                           "e",
-                           "thetao",
-                           "so",
-                           "rhoinsitu",
-                           "KE",
-                           "rhopot0"
-                        ],
-                        [
-                           "soga",
-                           "thetaoga",
-                           "uh",
-                           "vh",
-                           "vhbt",
-                           "uhbt"
-                        ],
-                        [
-                           "KPP_OBLdepth:oml"
-                        ],
-                        [
-                           "tauuo",
-                           "tauvo",
-                           "friver",
-                           "prsn",
-                           "prlq",
-                           "evs",
-                           "hfsso",
-                           "rlntds",
-                           "hfsnthermds",
-                           "sfdsi",
-                           "rsntds",
-                           "hfds",
-                           "ustar",
-                           "hfsifrazil",
-                           "wfo",
-                           "vprec",
-                           "ficeberg",
-                           "fsitherm",
-                           "hflso",
-                           "pso",
-                           "seaice_melt_heat",
-                           "Heat_PmE",
-                           "salt_flux_added"
-                        ],
-                        [
-                           "SSH",
-                           "tos",
-                           "sos",
-                           "SSU",
-                           "SSV",
-                           "mass_wt",
-                           "opottempmint",
-                           "somint",
-                           "Rd_dx",
-                           "speed",
-                           "mlotst"
-                        ],
-                        [
-                           "diftrelo",
-                           "diftrblo",
-                           "difmxybo",
-                           "difmxylo"
-                        ],
-                        [
-                           "volcello",
-                           "vmo",
-                           "vhGM",
-                           "vhml",
-                           "umo",
-                           "uhGM",
-                           "uhml"
-                        ],
-                        [
-                           "agessc",
-                           "T_ady_2d",
-                           "T_adx_2d",
-                           "T_diffy_2d",
-                           "T_diffx_2d"
-                        ]
-                     ]
-                  }
-               ]
-            }
-         }
-      },
-      "hist_z_space": {
-         "suffix": {
-            "$OCN_DIAG_MODE == \"spinup\"": "h%4yr",
-            "else": "h%4yr-%2mo"
-         },
-         "output_freq": 1,
-         "output_freq_units": {
-            "$OCN_DIAG_MODE == \"spinup\"": "years",
-            "$TEST == True": "days",
-            "else": "months"
-         },
-         "time_axis_units": "days",
-         "new_file_freq": 1,
-         "new_file_freq_units": {
-            "$OCN_DIAG_MODE == \"spinup\"": "years",
-            "$TEST == True": "days",
-            "else": "months"
-         },
-         "reduction_method": "mean",
-         "regional_section": "none",
-         "fields": {
-            "$OCN_DIAG_MODE == \"spinup\"": [
-               {
-                  "module": "ocean_model_z",
-                  "packing": 2,
-                  "lists": [
+               "lists2": {
+                  "$OCN_DIAG_MODE not in [\"spinup\", \"none\"]": [
                      [
                         "uo",
                         "vo",
@@ -469,134 +250,10 @@
                         "rhoinsitu",
                         "KE",
                         "rhopot0"
-                     ]
-                  ]
-               }
-            ],
-            "$OCN_DIAG_MODE not in [\"spinup\", \"none\"]": {
-               "$USE_CFC_CAP == \"True\"": [
-                  {
-                     "module": "ocean_model_z",
-                     "packing": 1,
-                     "lists": [
-                        [
-                           "uo",
-                           "vo",
-                           "h",
-                           "e",
-                           "thetao",
-                           "so",
-                           "rhoinsitu",
-                           "KE",
-                           "rhopot0"
-                        ],
-                        [
-                           "cfc11",
-                           "cfc12"
-                        ]
-                     ]
-                  }
-               ],
-               "else": [
-                  {
-                     "module": "ocean_model_z",
-                     "packing": 1,
-                     "lists": [
-                        [
-                           "uo",
-                           "vo",
-                           "h",
-                           "e",
-                           "thetao",
-                           "so",
-                           "rhoinsitu",
-                           "KE",
-                           "rhopot0"
-                        ]
-                     ]
-                  }
-               ]
-            }
-         }
-      },
-      "surface_avg": {
-         "suffix": "sfc%4yr",
-         "output_freq": {
-            "$OCN_DIAG_MODE == \"spinup\"": 5,
-            "else": 1
-         },
-         "output_freq_units": "days",
-         "time_axis_units": "days",
-         "new_file_freq": 1,
-         "new_file_freq_units": "years",
-         "reduction_method": "mean",
-         "regional_section": "none",
-         "fields": {
-            "$OCN_DIAG_MODE in [\"production\", \"development\"] and $TEST == False": [
-               {
-                  "module": "ocean_model",
-                  "packing": 1,
-                  "lists": [
-                     [
-                        "SSH",
-                        "tos",
-                        "sos",
-                        "SSU",
-                        "SSV",
-                        "mass_wt",
-                        "opottempmint",
-                        "somint",
-                        "Rd_dx",
-                        "speed",
-                        "mlotst"
                      ],
                      [
                         "KPP_OBLdepth:oml"
-                     ]
-                  ]
-               }
-            ],
-            "$OCN_DIAG_MODE == \"spinup\" and $TEST == False": [
-               {
-                  "module": "ocean_model",
-                  "packing": 2,
-                  "lists": [
-                     [
-                        "SSH",
-                        "tos",
-                        "sos",
-                        "SSU",
-                        "SSV",
-                        "mass_wt",
-                        "opottempmint",
-                        "somint",
-                        "Rd_dx",
-                        "speed",
-                        "mlotst"
                      ],
-                     [
-                        "KPP_OBLdepth:oml"
-                     ]
-                  ]
-               }
-            ]
-         }
-      },
-      "forcing_daily_avg": {
-         "suffix": "frc%4yr",
-         "output_freq": 1,
-         "output_freq_units": "days",
-         "time_axis_units": "days",
-         "new_file_freq": 365,
-         "new_file_freq_units": "days",
-         "reduction_method": "mean",
-         "regional_section": "none",
-         "fields": {
-            "$OCN_DIAG_MODE == \"development\"": [
-               {
-                  "module": "ocean_model",
-                  "packing": 1,
-                  "lists": [
                      [
                         "tauuo",
                         "tauvo",
@@ -623,27 +280,178 @@
                         "salt_flux_added"
                      ],
                      [
-                        "net_heat_coupler",
-                        "LwLatSens",
-                        "heat_content_lrunoff",
-                        "heat_content_frunoff",
-                        "heat_content_icemelt",
-                        "heat_content_lprec",
-                        "heat_content_fprec",
-                        "heat_content_vprec",
-                        "heat_content_cond",
-                        "hfevapds",
-                        "heat_content_massin",
-                        "heat_content_surfwater",
-                        "vprec_global_adjustment",
-                        "net_fresh_water_global_adjustment",
-                        "salt_flux_global_restoring_adjustment",
-                        "net_massout",
-                        "net_massin"
+                        "SSH",
+                        "tos",
+                        "sos",
+                        "SSU",
+                        "SSV",
+                        "mass_wt",
+                        "opottempmint",
+                        "somint",
+                        "Rd_dx",
+                        "speed",
+                        "mlotst"
+                     ]
+                  ]
+               },
+               "lists3": {
+                  "$USE_CFC_CAP == \"True\"": [
+                     [
+                        "cfc11_flux",
+                        "cfc12_flux",
+                        "ice_fraction",
+                        "u10_sqr"
                      ]
                   ]
                }
-            ]
+            }
+         }
+      },
+      "hist_z_space": {
+         "suffix": {
+            "$OCN_DIAG_MODE == \"spinup\"": "h%4yr",
+            "else": "h%4yr-%2mo"
+         },
+         "output_freq": 1,
+         "output_freq_units": {
+            "$OCN_DIAG_MODE == \"spinup\"": "years",
+            "$TEST == True": "days",
+            "else": "months"
+         },
+         "time_axis_units": "days",
+         "new_file_freq": 1,
+         "new_file_freq_units": {
+            "$OCN_DIAG_MODE == \"spinup\"": "years",
+            "$TEST == True": "days",
+            "else": "months"
+         },
+         "reduction_method": "mean",
+         "regional_section": "none",
+         "fields": {
+            "$OCN_DIAG_MODE != \"none\"": {
+               "module": "ocean_model_z",
+               "packing": "= 1 if $TEST else 2",
+               "lists": [
+                  [
+                     "uo",
+                     "vo",
+                     "h",
+                     "e",
+                     "thetao",
+                     "so",
+                     "rhoinsitu",
+                     "KE",
+                     "rhopot0"
+                  ]
+               ],
+               "lists2": {
+                  "$USE_CFC_CAP == \"True\"": [
+                     [
+                        "cfc11",
+                        "cfc12"
+                     ]
+                  ]
+               }
+            }
+         }
+      },
+      "surface_avg": {
+         "suffix": "sfc%4yr",
+         "output_freq": {
+            "$OCN_DIAG_MODE == \"spinup\"": 5,
+            "else": 1
+         },
+         "output_freq_units": "days",
+         "time_axis_units": "days",
+         "new_file_freq": 1,
+         "new_file_freq_units": "years",
+         "reduction_method": "mean",
+         "regional_section": "none",
+         "fields": {
+            "$OCN_DIAG_MODE != \"none\"": {
+               "module": "ocean_model",
+               "packing": "= 1 if $TEST else 2",
+               "lists": [
+                  [
+                     "SSH",
+                     "tos",
+                     "sos",
+                     "SSU",
+                     "SSV",
+                     "mass_wt",
+                     "opottempmint",
+                     "somint",
+                     "Rd_dx",
+                     "speed",
+                     "mlotst"
+                  ],
+                  [
+                     "KPP_OBLdepth:oml"
+                  ]
+               ]
+            }
+         }
+      },
+      "forcing_daily_avg": {
+         "suffix": "frc%4yr",
+         "output_freq": 1,
+         "output_freq_units": "days",
+         "time_axis_units": "days",
+         "new_file_freq": 365,
+         "new_file_freq_units": "days",
+         "reduction_method": "mean",
+         "regional_section": "none",
+         "fields": {
+            "$OCN_DIAG_MODE == \"development\"": {
+               "module": "ocean_model",
+               "packing": "= 1 if $TEST else 2",
+               "lists": [
+                  [
+                     "tauuo",
+                     "tauvo",
+                     "friver",
+                     "prsn",
+                     "prlq",
+                     "evs",
+                     "hfsso",
+                     "rlntds",
+                     "hfsnthermds",
+                     "sfdsi",
+                     "rsntds",
+                     "hfds",
+                     "ustar",
+                     "hfsifrazil",
+                     "wfo",
+                     "vprec",
+                     "ficeberg",
+                     "fsitherm",
+                     "hflso",
+                     "pso",
+                     "seaice_melt_heat",
+                     "Heat_PmE",
+                     "salt_flux_added"
+                  ],
+                  [
+                     "net_heat_coupler",
+                     "LwLatSens",
+                     "heat_content_lrunoff",
+                     "heat_content_frunoff",
+                     "heat_content_icemelt",
+                     "heat_content_lprec",
+                     "heat_content_fprec",
+                     "heat_content_vprec",
+                     "heat_content_cond",
+                     "hfevapds",
+                     "heat_content_massin",
+                     "heat_content_surfwater",
+                     "vprec_global_adjustment",
+                     "net_fresh_water_global_adjustment",
+                     "salt_flux_global_restoring_adjustment",
+                     "net_massout",
+                     "net_massin"
+                  ]
+               ]
+            }
          }
       },
       "visc_and_diff_daily_avg": {
@@ -656,20 +464,18 @@
          "reduction_method": "mean",
          "regional_section": "none",
          "fields": {
-            "$OCN_DIAG_MODE == \"development\"": [
-               {
-                  "module": "ocean_model",
-                  "packing": 1,
-                  "lists": [
-                     [
-                        "diftrelo",
-                        "diftrblo",
-                        "difmxybo",
-                        "difmxylo"
-                     ]
+            "$OCN_DIAG_MODE == \"development\"": {
+               "module": "ocean_model",
+               "packing": "= 1 if $TEST else 2",
+               "lists": [
+                  [
+                     "diftrelo",
+                     "diftrblo",
+                     "difmxybo",
+                     "difmxylo"
                   ]
-               }
-            ]
+               ]
+            }
          }
       },
       "static": {
@@ -679,31 +485,29 @@
          "time_axis_units": "days",
          "reduction_method": ".false.",
          "regional_section": "none",
-         "fields": [
-            {
-               "module": "ocean_model",
-               "packing": 1,
-               "lists": [
-                  [
-                     "geolon",
-                     "geolat",
-                     "geolon_c",
-                     "geolat_c",
-                     "geolon_u",
-                     "geolat_u",
-                     "geolon_v",
-                     "geolat_v",
-                     "area_t",
-                     "depth_ocean",
-                     "wet",
-                     "wet_c",
-                     "wet_u",
-                     "wet_v",
-                     "Coriolis"
-                  ]
+         "fields": {
+            "module": "ocean_model",
+            "packing": "= 1 if $TEST else 2",
+            "lists": [
+               [
+                  "geolon",
+                  "geolat",
+                  "geolon_c",
+                  "geolat_c",
+                  "geolon_u",
+                  "geolat_u",
+                  "geolon_v",
+                  "geolat_v",
+                  "area_t",
+                  "depth_ocean",
+                  "wet",
+                  "wet_c",
+                  "wet_u",
+                  "wet_v",
+                  "Coriolis"
                ]
-            }
-         ]
+            ]
+         }
       },
       "Agulhas": {
          "suffix": "agulhas_section%4yr",
@@ -726,21 +530,19 @@
             "$OCN_GRID == \"tx0.66v1\"": "20.1 20.1 -70.0 -34.6 -1 -1"
          },
          "fields": {
-            "$OCN_GRID == \"tx0.66v1\" and  $TEST == False and $OCN_DIAG_SECTIONS == True": [
-               {
-                  "module": "ocean_model",
-                  "packing": 2,
-                  "lists": [
-                     [
-                        "volcello",
-                        "thetao",
-                        "so",
-                        "umo",
-                        "uo"
-                     ]
+            "$OCN_GRID == \"tx0.66v1\" and  $TEST == False and $OCN_DIAG_SECTIONS == True": {
+               "module": "ocean_model",
+               "packing": 2,
+               "lists": [
+                  [
+                     "volcello",
+                     "thetao",
+                     "so",
+                     "umo",
+                     "uo"
                   ]
-               }
-            ]
+               ]
+            }
          }
       },
       "Bab_al_mandeb_Strait": {
@@ -764,21 +566,19 @@
             "$OCN_GRID == \"tx0.66v1\"": "45.0 45.0 10.5 13.5 -1 -1"
          },
          "fields": {
-            "$OCN_GRID == \"tx0.66v1\" and  $TEST == False and $OCN_DIAG_SECTIONS == True": [
-               {
-                  "module": "ocean_model",
-                  "packing": 2,
-                  "lists": [
-                     [
-                        "volcello",
-                        "thetao",
-                        "so",
-                        "umo",
-                        "uo"
-                     ]
+            "$OCN_GRID == \"tx0.66v1\" and  $TEST == False and $OCN_DIAG_SECTIONS == True": {
+               "module": "ocean_model",
+               "packing": 2,
+               "lists": [
+                  [
+                     "volcello",
+                     "thetao",
+                     "so",
+                     "umo",
+                     "uo"
                   ]
-               }
-            ]
+               ]
+            }
          }
       },
       "Barents_opening": {
@@ -802,21 +602,19 @@
             "$OCN_GRID == \"tx0.66v1\"": "-5.2 18.8  78.93 78.93 -1 -1"
          },
          "fields": {
-            "$OCN_GRID == \"tx0.66v1\" and  $TEST == False and $OCN_DIAG_SECTIONS == True": [
-               {
-                  "module": "ocean_model",
-                  "packing": 2,
-                  "lists": [
-                     [
-                        "volcello",
-                        "thetao",
-                        "so",
-                        "vmo",
-                        "vo"
-                     ]
+            "$OCN_GRID == \"tx0.66v1\" and  $TEST == False and $OCN_DIAG_SECTIONS == True": {
+               "module": "ocean_model",
+               "packing": 2,
+               "lists": [
+                  [
+                     "volcello",
+                     "thetao",
+                     "so",
+                     "vmo",
+                     "vo"
                   ]
-               }
-            ]
+               ]
+            }
          }
       },
       "Bering_Strait": {
@@ -840,21 +638,19 @@
             "$OCN_GRID == \"tx0.66v1\"": "-174.5  -171.5 66.6 66.6 -1 -1"
          },
          "fields": {
-            "$OCN_GRID == \"tx0.66v1\" and  $TEST == False and $OCN_DIAG_SECTIONS == True": [
-               {
-                  "module": "ocean_model",
-                  "packing": 2,
-                  "lists": [
-                     [
-                        "volcello",
-                        "thetao",
-                        "so",
-                        "vmo",
-                        "vo"
-                     ]
+            "$OCN_GRID == \"tx0.66v1\" and  $TEST == False and $OCN_DIAG_SECTIONS == True": {
+               "module": "ocean_model",
+               "packing": 2,
+               "lists": [
+                  [
+                     "volcello",
+                     "thetao",
+                     "so",
+                     "vmo",
+                     "vo"
                   ]
-               }
-            ]
+               ]
+            }
          }
       },
       "Davis_Strait": {
@@ -878,21 +674,19 @@
             "$OCN_GRID == \"tx0.66v1\"": "-53.5 -45.3 69.5 69.5 -1 -1"
          },
          "fields": {
-            "$OCN_GRID == \"tx0.66v1\" and  $TEST == False and $OCN_DIAG_SECTIONS == True": [
-               {
-                  "module": "ocean_model",
-                  "packing": 2,
-                  "lists": [
-                     [
-                        "volcello",
-                        "thetao",
-                        "so",
-                        "vmo",
-                        "vo"
-                     ]
+            "$OCN_GRID == \"tx0.66v1\" and  $TEST == False and $OCN_DIAG_SECTIONS == True": {
+               "module": "ocean_model",
+               "packing": 2,
+               "lists": [
+                  [
+                     "volcello",
+                     "thetao",
+                     "so",
+                     "vmo",
+                     "vo"
                   ]
-               }
-            ]
+               ]
+            }
          }
       },
       "Denmark_Strait": {
@@ -916,21 +710,19 @@
             "$OCN_GRID == \"tx0.66v1\"": "-38.50 -21.5 65.0 65.0 -1 -1"
          },
          "fields": {
-            "$OCN_GRID == \"tx0.66v1\" and  $TEST == False and $OCN_DIAG_SECTIONS == True": [
-               {
-                  "module": "ocean_model",
-                  "packing": 2,
-                  "lists": [
-                     [
-                        "volcello",
-                        "thetao",
-                        "so",
-                        "vmo",
-                        "vo"
-                     ]
+            "$OCN_GRID == \"tx0.66v1\" and  $TEST == False and $OCN_DIAG_SECTIONS == True": {
+               "module": "ocean_model",
+               "packing": 2,
+               "lists": [
+                  [
+                     "volcello",
+                     "thetao",
+                     "so",
+                     "vmo",
+                     "vo"
                   ]
-               }
-            ]
+               ]
+            }
          }
       },
       "Drake_Passage": {
@@ -954,21 +746,19 @@
             "$OCN_GRID == \"tx0.66v1\"": "-67.0 -67.0 -69.0 -55.2 -1 -1"
          },
          "fields": {
-            "$OCN_GRID == \"tx0.66v1\" and  $TEST == False and $OCN_DIAG_SECTIONS == True": [
-               {
-                  "module": "ocean_model",
-                  "packing": 2,
-                  "lists": [
-                     [
-                        "volcello",
-                        "thetao",
-                        "so",
-                        "umo",
-                        "uo"
-                     ]
+            "$OCN_GRID == \"tx0.66v1\" and  $TEST == False and $OCN_DIAG_SECTIONS == True": {
+               "module": "ocean_model",
+               "packing": 2,
+               "lists": [
+                  [
+                     "volcello",
+                     "thetao",
+                     "so",
+                     "umo",
+                     "uo"
                   ]
-               }
-            ]
+               ]
+            }
          }
       },
       "English_Channel": {
@@ -992,21 +782,19 @@
             "$OCN_GRID == \"tx0.66v1\"": "0.0 0.0 51.0 52.9 -1 -1"
          },
          "fields": {
-            "$OCN_GRID == \"tx0.66v1\" and  $TEST == False and $OCN_DIAG_SECTIONS == True": [
-               {
-                  "module": "ocean_model",
-                  "packing": 2,
-                  "lists": [
-                     [
-                        "volcello",
-                        "thetao",
-                        "so",
-                        "umo",
-                        "uo"
-                     ]
+            "$OCN_GRID == \"tx0.66v1\" and  $TEST == False and $OCN_DIAG_SECTIONS == True": {
+               "module": "ocean_model",
+               "packing": 2,
+               "lists": [
+                  [
+                     "volcello",
+                     "thetao",
+                     "so",
+                     "umo",
+                     "uo"
                   ]
-               }
-            ]
+               ]
+            }
          }
       },
       "Fram_Strait": {
@@ -1030,21 +818,19 @@
             "$OCN_GRID == \"tx0.66v1\"": "-21.0 -9.8 80.5 80.5 -1 -1"
          },
          "fields": {
-            "$OCN_GRID == \"tx0.66v1\" and  $TEST == False and $OCN_DIAG_SECTIONS == True": [
-               {
-                  "module": "ocean_model",
-                  "packing": 2,
-                  "lists": [
-                     [
-                        "volcello",
-                        "thetao",
-                        "so",
-                        "vmo",
-                        "vo"
-                     ]
+            "$OCN_GRID == \"tx0.66v1\" and  $TEST == False and $OCN_DIAG_SECTIONS == True": {
+               "module": "ocean_model",
+               "packing": 2,
+               "lists": [
+                  [
+                     "volcello",
+                     "thetao",
+                     "so",
+                     "vmo",
+                     "vo"
                   ]
-               }
-            ]
+               ]
+            }
          }
       },
       "Florida_Bahamas": {
@@ -1068,21 +854,19 @@
             "$OCN_GRID == \"tx0.66v1\"": "-80.1 -77.9 25.3 25.3 -1 -1"
          },
          "fields": {
-            "$OCN_GRID == \"tx0.66v1\" and  $TEST == False and $OCN_DIAG_SECTIONS == True": [
-               {
-                  "module": "ocean_model",
-                  "packing": 2,
-                  "lists": [
-                     [
-                        "volcello",
-                        "thetao",
-                        "so",
-                        "vmo",
-                        "vo"
-                     ]
+            "$OCN_GRID == \"tx0.66v1\" and  $TEST == False and $OCN_DIAG_SECTIONS == True": {
+               "module": "ocean_model",
+               "packing": 2,
+               "lists": [
+                  [
+                     "volcello",
+                     "thetao",
+                     "so",
+                     "vmo",
+                     "vo"
                   ]
-               }
-            ]
+               ]
+            }
          }
       },
       "Gibraltar_Strait": {
@@ -1106,21 +890,19 @@
             "$OCN_GRID == \"tx0.66v1\"": "-6.5 -6.5 34.3 37.4 -1 -1"
          },
          "fields": {
-            "$OCN_GRID == \"tx0.66v1\" and  $TEST == False and $OCN_DIAG_SECTIONS == True": [
-               {
-                  "module": "ocean_model",
-                  "packing": 2,
-                  "lists": [
-                     [
-                        "volcello",
-                        "thetao",
-                        "so",
-                        "umo",
-                        "uo"
-                     ]
+            "$OCN_GRID == \"tx0.66v1\" and  $TEST == False and $OCN_DIAG_SECTIONS == True": {
+               "module": "ocean_model",
+               "packing": 2,
+               "lists": [
+                  [
+                     "volcello",
+                     "thetao",
+                     "so",
+                     "umo",
+                     "uo"
                   ]
-               }
-            ]
+               ]
+            }
          }
       },
       "Hormuz_Strait": {
@@ -1144,21 +926,19 @@
             "$OCN_GRID == \"tx0.66v1\"": "55.9 55.9 25.0 27.5 -1 -1"
          },
          "fields": {
-            "$OCN_GRID == \"tx0.66v1\" and  $TEST == False and $OCN_DIAG_SECTIONS == True": [
-               {
-                  "module": "ocean_model",
-                  "packing": 2,
-                  "lists": [
-                     [
-                        "volcello",
-                        "thetao",
-                        "so",
-                        "umo",
-                        "uo"
-                     ]
+            "$OCN_GRID == \"tx0.66v1\" and  $TEST == False and $OCN_DIAG_SECTIONS == True": {
+               "module": "ocean_model",
+               "packing": 2,
+               "lists": [
+                  [
+                     "volcello",
+                     "thetao",
+                     "so",
+                     "umo",
+                     "uo"
                   ]
-               }
-            ]
+               ]
+            }
          }
       },
       "Iceland_Norway": {
@@ -1182,21 +962,19 @@
             "$OCN_GRID == \"tx0.66v1\"": "-21.5 1.5 65.0 65.0 -1 -1"
          },
          "fields": {
-            "$OCN_GRID == \"tx0.66v1\" and  $TEST == False and $OCN_DIAG_SECTIONS == True": [
-               {
-                  "module": "ocean_model",
-                  "packing": 2,
-                  "lists": [
-                     [
-                        "volcello",
-                        "thetao",
-                        "so",
-                        "vmo",
-                        "vo"
-                     ]
+            "$OCN_GRID == \"tx0.66v1\" and  $TEST == False and $OCN_DIAG_SECTIONS == True": {
+               "module": "ocean_model",
+               "packing": 2,
+               "lists": [
+                  [
+                     "volcello",
+                     "thetao",
+                     "so",
+                     "vmo",
+                     "vo"
                   ]
-               }
-            ]
+               ]
+            }
          }
       },
       "Indonesian_Throughflow": {
@@ -1220,21 +998,19 @@
             "$OCN_GRID == \"tx0.66v1\"": "-246.5 -220.8 -7.0 -7.0 -1 -1"
          },
          "fields": {
-            "$OCN_GRID == \"tx0.66v1\" and  $TEST == False and $OCN_DIAG_SECTIONS == True": [
-               {
-                  "module": "ocean_model",
-                  "packing": 2,
-                  "lists": [
-                     [
-                        "volcello",
-                        "thetao",
-                        "so",
-                        "vmo",
-                        "vo"
-                     ]
+            "$OCN_GRID == \"tx0.66v1\" and  $TEST == False and $OCN_DIAG_SECTIONS == True": {
+               "module": "ocean_model",
+               "packing": 2,
+               "lists": [
+                  [
+                     "volcello",
+                     "thetao",
+                     "so",
+                     "vmo",
+                     "vo"
                   ]
-               }
-            ]
+               ]
+            }
          }
       },
       "Mozambique_Channel": {
@@ -1258,21 +1034,19 @@
             "$OCN_GRID == \"tx0.66v1\"": "39.9 44.7 -16.0 -16.0 -1 -1"
          },
          "fields": {
-            "$OCN_GRID == \"tx0.66v1\" and  $TEST == False and $OCN_DIAG_SECTIONS == True": [
-               {
-                  "module": "ocean_model",
-                  "packing": 2,
-                  "lists": [
-                     [
-                        "volcello",
-                        "thetao",
-                        "so",
-                        "vmo",
-                        "vo"
-                     ]
+            "$OCN_GRID == \"tx0.66v1\" and  $TEST == False and $OCN_DIAG_SECTIONS == True": {
+               "module": "ocean_model",
+               "packing": 2,
+               "lists": [
+                  [
+                     "volcello",
+                     "thetao",
+                     "so",
+                     "vmo",
+                     "vo"
                   ]
-               }
-            ]
+               ]
+            }
          }
       },
       "Pacific_undercurrent": {
@@ -1296,21 +1070,19 @@
             "$OCN_GRID == \"tx0.66v1\"": "-155.0 -155.0 -2.0 2.0 -1 -1"
          },
          "fields": {
-            "$OCN_GRID == \"tx0.66v1\" and  $TEST == False and $OCN_DIAG_SECTIONS == True": [
-               {
-                  "module": "ocean_model",
-                  "packing": 2,
-                  "lists": [
-                     [
-                        "volcello",
-                        "thetao",
-                        "so",
-                        "umo",
-                        "uo"
-                     ]
+            "$OCN_GRID == \"tx0.66v1\" and  $TEST == False and $OCN_DIAG_SECTIONS == True": {
+               "module": "ocean_model",
+               "packing": 2,
+               "lists": [
+                  [
+                     "volcello",
+                     "thetao",
+                     "so",
+                     "umo",
+                     "uo"
                   ]
-               }
-            ]
+               ]
+            }
          }
       },
       "Taiwan_Luzon": {
@@ -1334,21 +1106,19 @@
             "$OCN_GRID == \"tx0.66v1\"": "-239.0 -239.0 18.8 22.5 -1 -1"
          },
          "fields": {
-            "$OCN_GRID == \"tx0.66v1\" and  $TEST == False and $OCN_DIAG_SECTIONS == True": [
-               {
-                  "module": "ocean_model",
-                  "packing": 2,
-                  "lists": [
-                     [
-                        "volcello",
-                        "thetao",
-                        "so",
-                        "umo",
-                        "uo"
-                     ]
+            "$OCN_GRID == \"tx0.66v1\" and  $TEST == False and $OCN_DIAG_SECTIONS == True": {
+               "module": "ocean_model",
+               "packing": 2,
+               "lists": [
+                  [
+                     "volcello",
+                     "thetao",
+                     "so",
+                     "umo",
+                     "uo"
                   ]
-               }
-            ]
+               ]
+            }
          }
       },
       "Windward_Passage": {
@@ -1372,21 +1142,19 @@
             "$OCN_GRID == \"tx0.66v1\"": "-74.2 -73.2 20.39 20.39 -1 -1"
          },
          "fields": {
-            "$OCN_GRID == \"tx0.66v1\" and  $TEST == False and $OCN_DIAG_SECTIONS == True": [
-               {
-                  "module": "ocean_model",
-                  "packing": 2,
-                  "lists": [
-                     [
-                        "volcello",
-                        "thetao",
-                        "so",
-                        "vmo",
-                        "vo"
-                     ]
+            "$OCN_GRID == \"tx0.66v1\" and  $TEST == False and $OCN_DIAG_SECTIONS == True": {
+               "module": "ocean_model",
+               "packing": 2,
+               "lists": [
+                  [
+                     "volcello",
+                     "thetao",
+                     "so",
+                     "vmo",
+                     "vo"
                   ]
-               }
-            ]
+               ]
+            }
          }
       }
    }


### PR DESCRIPTION
This PR improves the flexibility of diag_table.yaml and makes it more concise by:
 - allow conditional guards for field list attributes, `module`, `packing` and `list`.
 - allow ternary if statements for those attributes, e.g., `packing: = 1 if $TEST else 2`
 - allow multiple fields lists to be specified within the same fields block. This works by specifying multiple entries whose labels start with `lists`, e.g., `lists`, `lists2`, `lists3`, etc. Each of these lists may be subject to different conditionals. This eliminates repetition of the same lists for different conditionals. 
 
 For example, here is an old, repetitive list specification:
```
        fields:
            $OCN_DIAG_MODE == "spinup":
                - module:   "ocean_model"
                  packing:  2                 # single precision
                  lists:    [ *hist_additional,
                              *tracers,
                              *visc_flds,
                              *transports ]
            $OCN_DIAG_MODE not in ["spinup", "none"]:
                $USE_CFC_CAP == "True":
                    - module:   "ocean_model"
                      packing:  1                 # double precision
                      lists:    [ *prognostic,
                                  *hist_additional,
                                  *kpp_diags,
                                  *forcing_flds,
                                  *surface_flds,
                                  *visc_flds,
                                  *transports,
                                  *tracers,
                                  *cfc_2d ]
                else:
                    - module:   "ocean_model"
                      packing:  1                 # double precision
                      lists:    [ *prognostic,
                                  *hist_additional,
                                  *kpp_diags,
                                  *forcing_flds,
                                  *surface_flds,
                                  *visc_flds,
                                  *transports,
                                  *tracers ]
```

The above specification is now shortened as follows:

```
            $OCN_DIAG_MODE != "none":
                module:   "ocean_model"
                packing: = 1 if $TEST else 2
                lists:
                        [ *hist_additional,
                          *tracers,
                          *visc_flds,
                          *transports ]
                lists2:
                    $OCN_DIAG_MODE not in ["spinup", "none"]:
                        [ *prognostic,
                          *kpp_diags,
                          *forcing_flds,
                          *surface_flds]
                lists3:
                    $USE_CFC_CAP == "True":
                        [ *cfc_2d ]
```