### PR TITLE
Miscellaneous minor fixes

### DIFF
--- a/cime_config/config_compsets.xml
+++ b/cime_config/config_compsets.xml
@@ -75,18 +75,4 @@
     <lname>2000_DATM%JRA_SLND_CICE_MOM6_DROF%JRA_SGLC_WW3DEV</lname>
   </compset>
 
-  <!-- Ocean-Only compsets -->
-
-  <compset>
-    <alias>CMOMu</alias>
-    <lname>2000_SATM_SLND_SICE_MOM6_SROF_SGLC_SWAV</lname>
-  </compset>
-
-  <!-- MOM6+CISM compsets -->
-
-  <compset>
-    <alias>CMOMG</alias>
-    <lname>2000_SATM_SLND_SICE_MOM6_SROF_CISM2%EVOLVE_SWAV</lname>
-  </compset>
-
 </compsets>

--- a/cime_config/testdefs/testlist_mom.xml
+++ b/cime_config/testdefs/testlist_mom.xml
@@ -68,7 +68,7 @@
       <option name="wallclock">00:30:00</option>
     </options>
   </test>
-  <test name="ERI_Vmct" grid="T62_t061" compset="GMOM">
+  <test name="ERI" grid="T62_t061" compset="GMOM">
     <machines>
       <machine name="cheyenne" compiler="intel" category="aux_mom"/>
       <machine name="hobart" compiler="intel" category="aux_mom"/>

--- a/cime_config/testdefs/testlist_mom.xml
+++ b/cime_config/testdefs/testlist_mom.xml
@@ -10,15 +10,6 @@
       <option name="wallclock">00:30:00</option>
     </options>
   </test>
-  <test name="SMS_D_Ld2_Vmct" grid="T62_g16" compset="CMOM">
-    <machines>
-      <machine name="cheyenne" compiler="gnu" category="aux_mom"/>
-      <machine name="cheyenne" compiler="gnu" category="pr_mom"/>
-    </machines>
-    <options>
-      <option name="wallclock">00:30:00</option>
-    </options>
-  </test>
   <test name="SMS_D" grid="T62_t061" compset="GMOM_IAF">
     <machines>
       <machine name="cheyenne" compiler="intel" category="aux_mom"/>
@@ -28,15 +19,6 @@
     </machines>
     <options>
       <option name="wallclock">01:00:00</option>
-    </options>
-  </test>
-  <test name="SMS_Vmct" grid="T62_t061" compset="GMOM">
-    <machines>
-      <machine name="cheyenne" compiler="gnu" category="aux_mom"/>
-      <machine name="cheyenne" compiler="intel" category="prealpha"/>
-    </machines>
-    <options>
-      <option name="wallclock">00:30:00</option>
     </options>
   </test>
   <test name="SMS_Ld40" grid="T62_t061" compset="CMOM_IAF">
@@ -121,7 +103,7 @@
       <machine name="izumi" compiler="intel" category="aux_mom"/>
     </machines>
     <options>
-      <option name="wallclock">01:30:00</option>
+      <option name="wallclock">02:00:00</option>
     </options>
   </test>
 </testlist>

--- a/param_templates/MOM_input.yaml
+++ b/param_templates/MOM_input.yaml
@@ -1948,9 +1948,7 @@ Global:
             "If true, write out verbose debugging data."
         datatype: logical
         units: Boolean
-        value: 
-            $TEST: = $TESTCASE == "DIMCS"
-            else: $DEBUG
+        value: $TEST # i.e., True for all tests
     CHECK_DIFFUSIVE_CFL:
         description: |
             "[Boolean] default = False

--- a/param_templates/json/MOM_input.json
+++ b/param_templates/json/MOM_input.json
@@ -1501,10 +1501,7 @@
          "description": "\"If true, write out verbose debugging data.\"\n",
          "datatype": "logical",
          "units": "Boolean",
-         "value": {
-            "$TEST": "= $TESTCASE == \"DIMCS\"",
-            "else": "$DEBUG"
-         }
+         "value": "$TEST"
       },
       "CHECK_DIFFUSIVE_CFL": {
          "description": "\"[Boolean] default = False\nIf true, use enough iterations the diffusion to ensure\nthat the diffusive equivalent of the CFL limit is not\nviolated.  If false, always use the greater of 1 or\nMAX_TR_DIFFUSION_CFL iteration.\"\n",


### PR DESCRIPTION
- Remove mct tests and increase DIMCS wallclock time
- Remove CMOMu and CMOMg compsets. Fixes #108 
- Turn on the debug flag for all test cases. Fixes #113 

testing: aux_mom.