### PR TITLE
add database_comms dir to buildlib src path

### DIFF
--- a/cime_config/buildlib
+++ b/cime_config/buildlib
@@ -80,6 +80,7 @@ def buildlib(caseroot, libroot, bldroot):
                      os.path.join(comp_root_dir_ocn,"MOM6","config_src","external","ODA_hooks"),
                      os.path.join(comp_root_dir_ocn,"MOM6","config_src","external","stochastic_physics"),
                      os.path.join(comp_root_dir_ocn,"MOM6","config_src","external","drifters"),
+                     os.path.join(comp_root_dir_ocn,"MOM6","config_src","external","database_comms"),
                      os.path.join(comp_root_dir_ocn,"MOM6","src","ALE"),
                      os.path.join(comp_root_dir_ocn,"MOM6","src","core"),
                      os.path.join(comp_root_dir_ocn,"MOM6","src","diagnostics"),


### PR DESCRIPTION
Adds database_comms dir to buildlib src path. This was necessitated by https://github.com/mom-ocean/MOM6/pull/1582

@gustavo-marques can you confirm this fixes the build error you got when running aux_mom?