### PR TITLE
MOM6 Runtime debug flag adjustments

### DIFF
--- a/cime_config/testdefs/testlist_mom.xml
+++ b/cime_config/testdefs/testlist_mom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0"?>
 <testlist version="2.0">
-  <test name="ERS" grid="T62_g16" compset="CMOM_IAF">
+  <test name="ERS" grid="T62_g16" compset="CMOM_IAF" testmods="mom/debug">
     <machines>
       <machine name="cheyenne" compiler="intel" category="aux_mom"/>
       <machine name="hobart" compiler="intel" category="aux_mom"/>
       <machine name="izumi" compiler="intel" category="aux_mom"/>
     </machines>
     <options>
-      <option name="wallclock">00:30:00</option>
+      <option name="wallclock">01:00:00</option>
     </options>
   </test>
   <test name="SMS_D" grid="T62_t061" compset="GMOM_IAF">
@@ -32,7 +32,7 @@
       <option name="wallclock">01:00:00</option>
     </options>
   </test>
-  <test name="ERS" grid="T62_t061" compset="GMOM_JRA">
+  <test name="ERS" grid="T62_t061" compset="GMOM_JRA" testmods="mom/debug">
     <machines>
       <machine name="cheyenne" compiler="intel" category="aux_mom"/>
       <machine name="hobart" compiler="intel" category="aux_mom"/>
@@ -42,12 +42,12 @@
       <option name="wallclock">01:00:00</option>
     </options>
   </test>
-  <test name="ERS" grid="TL319_t061" compset="GMOM_JRA_WD">
+  <test name="ERS" grid="TL319_t061" compset="GMOM_JRA_WD" testmods="mom/debug">
     <machines>
       <machine name="cheyenne" compiler="intel" category="aux_mom"/>
     </machines>
     <options>
-      <option name="wallclock">01:00:00</option>
+      <option name="wallclock">01:30:00</option>
     </options>
   </test>
   <test name="ERS" grid="TL319_t061_wt061" compset="GMOM_JRA_WD">
@@ -57,7 +57,7 @@
       <machine name="cheyenne" compiler="intel" category="prealpha"/>
     </machines>
     <options>
-      <option name="wallclock">01:00:00</option>
+      <option name="wallclock">01:30:00</option>
     </options>
   </test>
   <test name="SMS" grid="T62_t025" compset="CMOM">
@@ -65,17 +65,17 @@
       <machine name="cheyenne" compiler="intel" category="aux_mom"/>
     </machines>
     <options>
-      <option name="wallclock">00:30:00</option>
+      <option name="wallclock">01:00:00</option>
     </options>
   </test>
-  <test name="ERI" grid="T62_t061" compset="GMOM">
+  <test name="ERI" grid="T62_t061" compset="GMOM" testmods="mom/debug">
     <machines>
       <machine name="cheyenne" compiler="intel" category="aux_mom"/>
       <machine name="hobart" compiler="intel" category="aux_mom"/>
       <machine name="izumi" compiler="intel" category="aux_mom"/>
     </machines>
     <options>
-      <option name="wallclock">01:30:00</option>
+      <option name="wallclock">02:00:00</option>
     </options>
   </test>
   <test name="PET" grid="TL319_t061" compset="GMOM_JRA">
@@ -84,7 +84,7 @@
       <machine name="cheyenne" compiler="intel" category="pr_mom"/>
     </machines>
     <options>
-      <option name="wallclock">00:30:00</option>
+      <option name="wallclock">01:00:00</option>
     </options>
   </test>
   <test name="SMS_Ld2" grid="f09_t061" compset="B1850MOM" testmods="mom/bmom">
@@ -94,16 +94,16 @@
       <machine name="izumi" compiler="intel" category="aux_mom"/>
     </machines>
     <options>
-      <option name="wallclock">00:30:00</option>
+      <option name="wallclock">01:00:00</option>
     </options>
   </test>
-  <test name="DIMCS_Ld1" grid="TL319_t061" compset="GMOM_JRA" testmods="mom/cfc_mods">
+  <test name="DIMCS_Ld1" grid="TL319_t061" compset="GMOM_JRA" testmods="mom/cfc_mods--mom/debug">
     <machines>
       <machine name="cheyenne" compiler="intel" category="aux_mom"/>
       <machine name="izumi" compiler="intel" category="aux_mom"/>
     </machines>
     <options>
-      <option name="wallclock">02:00:00</option>
+      <option name="wallclock">02:30:00</option>
     </options>
   </test>
 </testlist>

--- a/cime_config/testdefs/testmods_dirs/mom/debug/user_nl_mom
+++ b/cime_config/testdefs/testmods_dirs/mom/debug/user_nl_mom
@@ -1,0 +1,1 @@
+DEBUG = True

--- a/param_templates/MOM_input.yaml
+++ b/param_templates/MOM_input.yaml
@@ -1949,7 +1949,7 @@ Global:
             "If true, write out verbose debugging data."
         datatype: logical
         units: Boolean
-        value: $TEST # i.e., True for all tests
+        value: False
     CHECK_DIFFUSIVE_CFL:
         description: |
             "[Boolean] default = False

--- a/param_templates/json/MOM_input.json
+++ b/param_templates/json/MOM_input.json
@@ -1501,7 +1501,7 @@
          "description": "\"If true, write out verbose debugging data.\"\n",
          "datatype": "logical",
          "units": "Boolean",
-         "value": "$TEST"
+         "value": false
       },
       "CHECK_DIFFUSIVE_CFL": {
          "description": "\"[Boolean] default = False\nIf true, use enough iterations the diffusion to ensure\nthat the diffusive equivalent of the CFL limit is not\nviolated.  If false, always use the greater of 1 or\nMAX_TR_DIFFUSION_CFL iteration.\"\n",


### PR DESCRIPTION
This PR:
- Sets the default value of MOM6 debug to False.
- Introduces the mom6/debug testdef and adds it to the ERS, ERI, and DIMCS tests.
- Adjusts the wallclock times of the tests with the mom6/debug testdef.