### PR TITLE
Remove use_mpp_io from input.nml

### DIFF
--- a/param_templates/input_nml.yaml
+++ b/param_templates/input_nml.yaml
@@ -23,8 +23,6 @@ fms_nml:
 diag_manager_nml:
     flush_nc_files:
         value: .true.
-    use_mpp_io:
-        value: .true.
 
 mpp_io_nml:
     cf_compliance:

--- a/param_templates/json/input_nml.json
+++ b/param_templates/json/input_nml.json
@@ -30,9 +30,6 @@
    "diag_manager_nml": {
       "flush_nc_files": {
          "value": ".true."
-      },
-      "use_mpp_io": {
-         "value": ".true."
       }
    },
    "mpp_io_nml": {


### PR DESCRIPTION
This change is necessary to bump up the FMS version to 2021.03.01.
see: https://github.com/ESCOMP/FMS_interface/pull/15