### PR TITLE
Switch to FMS2 API

### DIFF
--- a/cime_config/buildlib
+++ b/cime_config/buildlib
@@ -62,6 +62,7 @@ def buildlib(caseroot, libroot, bldroot):
         # create Filepath file for mom
         #-------------------------------------------------------
         memory_mode =  case.get_value("MOM6_MEMORY_MODE")
+        infra_api =  case.get_value("MOM6_INFRA_API")
 
         user_incldir = "\"-I{} -I{} -I{}\"".\
                         format(os.path.join(srcroot,"libraries","FMS","src","include"),
@@ -75,7 +76,7 @@ def buildlib(caseroot, libroot, bldroot):
             paths = [os.path.join(caseroot,"SourceMods","src.mom"),
                      os.path.join(comp_root_dir_ocn,"MOM6","config_src","drivers", driver),
                      os.path.join(comp_root_dir_ocn,"MOM6","config_src","memory", memory_mode),
-                     os.path.join(comp_root_dir_ocn,"MOM6","config_src","infra", "FMS1"),
+                     os.path.join(comp_root_dir_ocn,"MOM6","config_src","infra", infra_api),
                      os.path.join(comp_root_dir_ocn,"MOM6","config_src","external","GFDL_ocean_BGC"),
                      os.path.join(comp_root_dir_ocn,"MOM6","config_src","external","ODA_hooks"),
                      os.path.join(comp_root_dir_ocn,"MOM6","config_src","external","stochastic_physics"),

--- a/cime_config/config_component.xml
+++ b/cime_config/config_component.xml
@@ -30,6 +30,17 @@
     </desc>
   </entry>
 
+
+  <entry id="MOM6_INFRA_API">
+    <type>char</type>
+    <valid_values>FMS1,FMS2</valid_values>
+    <default_value>FMS2</default_value>
+    <group>build_component_mom</group>
+    <file>env_build.xml</file>
+    <desc> This variable controls the MOM6 infrastructure API.
+    </desc>
+  </entry>
+
   <entry id="OCN_DIAG_MODE">
     <type>char</type>
     <valid_values>spinup,production,development,none</valid_values>

--- a/param_templates/MOM_input.yaml
+++ b/param_templates/MOM_input.yaml
@@ -404,7 +404,7 @@ Global:
             "Name of the file from which to read horizontal grid data."
         datatype: string
         value:
-            $OCN_GRID == "gx1v6": "ocean_hgrid.nc"
+            $OCN_GRID == "gx1v6": "ocean_hgrid_230424.nc"
             $OCN_GRID == "tx0.66v1": "ocean_hgrid_180829.nc"
             $OCN_GRID == "tx0.25v1": "ocean_hgrid.nc"
     USE_TRIPOLAR_GEOLONB_BUG:
@@ -446,7 +446,7 @@ Global:
             The file from which the bathymetry is read."
         datatype: string
         value:
-            $OCN_GRID == "gx1v6": "ocean_topog.nc"
+            $OCN_GRID == "gx1v6": "ocean_topog_230424.nc"
             $OCN_GRID == "tx0.66v1": "ocean_topog_200701.nc"
             $OCN_GRID == "tx0.25v1": "ocean_topog.nc"
     MAXIMUM_DEPTH:
@@ -3361,6 +3361,14 @@ Global:
         datatype: string
         value:
             $COMP_WAV in ["ww3", "ww3dev"] and $WAV_GRID == "wtx0.66v1" : "0.04, 0.11, 0.33"
+    IO_LAYOUT:
+        description: |
+            The processor layout to be used, or 0,0 to automatically set the io_layout to
+            be the same as the layout.
+        datatype: list
+        value:
+            $OCN_GRID == "tx0.25v1":
+              4, 3
 
 
 KPP:

--- a/param_templates/json/MOM_input.json
+++ b/param_templates/json/MOM_input.json
@@ -46,9 +46,11 @@
          }
       },
       "IO_LAYOUT": {
-         "description": "\"default = 0\nThe processor layout to be used, or 0,0 to automatically\nset the io_layout to be the same as the layout.\"\n",
-         "datatype": "string",
-         "value": "1, 1"
+         "description": "The processor layout to be used, or 0,0 to automatically set the io_layout to\nbe the same as the layout.\n",
+         "datatype": "list",
+         "value": {
+            "$OCN_GRID == \"tx0.25v1\"": "4, 3"
+         }
       },
       "NK": {
          "description": "\"[nondim]\nThe number of model layers.\"\n",
@@ -281,7 +283,7 @@
          "description": "\"Name of the file from which to read horizontal grid data.\"\n",
          "datatype": "string",
          "value": {
-            "$OCN_GRID == \"gx1v6\"": "ocean_hgrid.nc",
+            "$OCN_GRID == \"gx1v6\"": "ocean_hgrid_230424.nc",
             "$OCN_GRID == \"tx0.66v1\"": "ocean_hgrid_180829.nc",
             "$OCN_GRID == \"tx0.25v1\"": "ocean_hgrid.nc"
          }
@@ -307,7 +309,7 @@
          "description": "\"default = 'topog.nc'\nThe file from which the bathymetry is read.\"\n",
          "datatype": "string",
          "value": {
-            "$OCN_GRID == \"gx1v6\"": "ocean_topog.nc",
+            "$OCN_GRID == \"gx1v6\"": "ocean_topog_230424.nc",
             "$OCN_GRID == \"tx0.66v1\"": "ocean_topog_200701.nc",
             "$OCN_GRID == \"tx0.25v1\"": "ocean_topog.nc"
          }


### PR DESCRIPTION
This PR introduces a new xml variable called MOM6_INFRA_API to control the infrastructure api. By default, it is set to FMS2 but can be changed by running, for instance, `./xmlchange MOM6_INFRA_API=FMS1`. The switch is needed for multi-instance runs, i.e., #137 