### PR TITLE
Add PE layouts for derecho

### DIFF
--- a/cime_config/config_pes.xml
+++ b/cime_config/config_pes.xml
@@ -110,6 +110,107 @@
         </rootpe>
       </pes>
     </mach>
+    <mach name="derecho">
+      <pes pesize="any" compset="DATM.+CICE.+SWAV">
+        <comment>none</comment>
+        <ntasks>
+          <ntasks_atm>128</ntasks_atm>
+          <ntasks_rof>128</ntasks_rof>
+          <ntasks_cpl>128</ntasks_cpl>
+          <ntasks_ice>128</ntasks_ice>
+          <ntasks_ocn>384</ntasks_ocn>
+          <ntasks_lnd>1</ntasks_lnd>
+          <ntasks_wav>1</ntasks_wav>
+          <ntasks_glc>1</ntasks_glc>
+        </ntasks>
+        <nthrds>
+          <nthrds_atm>1</nthrds_atm>
+          <nthrds_lnd>1</nthrds_lnd>
+          <nthrds_rof>1</nthrds_rof>
+          <nthrds_ice>1</nthrds_ice>
+          <nthrds_ocn>1</nthrds_ocn>
+          <nthrds_glc>1</nthrds_glc>
+          <nthrds_wav>1</nthrds_wav>
+          <nthrds_cpl>1</nthrds_cpl>
+        </nthrds>
+        <rootpe>
+          <rootpe_atm>0</rootpe_atm>
+          <rootpe_rof>0</rootpe_rof>
+          <rootpe_cpl>0</rootpe_cpl>
+          <rootpe_ice>0</rootpe_ice>
+          <rootpe_ocn>128</rootpe_ocn>
+          <rootpe_lnd>0</rootpe_lnd>
+          <rootpe_wav>0</rootpe_wav>
+          <rootpe_glc>0</rootpe_glc>
+        </rootpe>
+      </pes>
+      <pes pesize="any" compset="DATM.+CICE.+WW3">
+        <comment>none</comment>
+        <ntasks>
+          <ntasks_atm>128</ntasks_atm>
+          <ntasks_rof>128</ntasks_rof>
+          <ntasks_cpl>128</ntasks_cpl>
+          <ntasks_ice>128</ntasks_ice>
+          <ntasks_ocn>384</ntasks_ocn>
+          <ntasks_lnd>1</ntasks_lnd>
+          <ntasks_wav>128</ntasks_wav>
+          <ntasks_glc>1</ntasks_glc>
+        </ntasks>
+        <nthrds>
+          <nthrds_atm>1</nthrds_atm>
+          <nthrds_lnd>1</nthrds_lnd>
+          <nthrds_rof>1</nthrds_rof>
+          <nthrds_ice>1</nthrds_ice>
+          <nthrds_ocn>1</nthrds_ocn>
+          <nthrds_glc>1</nthrds_glc>
+          <nthrds_wav>1</nthrds_wav>
+          <nthrds_cpl>1</nthrds_cpl>
+        </nthrds>
+        <rootpe>
+          <rootpe_atm>0</rootpe_atm>
+          <rootpe_rof>0</rootpe_rof>
+          <rootpe_cpl>0</rootpe_cpl>
+          <rootpe_ice>0</rootpe_ice>
+          <rootpe_ocn>128</rootpe_ocn>
+          <rootpe_lnd>0</rootpe_lnd>
+          <rootpe_wav>0</rootpe_wav>
+          <rootpe_glc>0</rootpe_glc>
+        </rootpe>
+      </pes>
+      <pes pesize="any" compset="DATM.+DICE.+SWAV">
+        <comment>none</comment>
+        <ntasks>
+          <ntasks_atm>128</ntasks_atm>
+          <ntasks_rof>128</ntasks_rof>
+          <ntasks_cpl>128</ntasks_cpl>
+          <ntasks_ice>128</ntasks_ice>
+          <ntasks_ocn>256</ntasks_ocn>
+          <ntasks_lnd>1</ntasks_lnd>
+          <ntasks_wav>1</ntasks_wav>
+          <ntasks_glc>1</ntasks_glc>
+        </ntasks>
+        <nthrds>
+          <nthrds_atm>1</nthrds_atm>
+          <nthrds_lnd>1</nthrds_lnd>
+          <nthrds_rof>1</nthrds_rof>
+          <nthrds_ice>1</nthrds_ice>
+          <nthrds_ocn>1</nthrds_ocn>
+          <nthrds_glc>1</nthrds_glc>
+          <nthrds_wav>1</nthrds_wav>
+          <nthrds_cpl>1</nthrds_cpl>
+        </nthrds>
+        <rootpe>
+          <rootpe_atm>0</rootpe_atm>
+          <rootpe_rof>0</rootpe_rof>
+          <rootpe_cpl>0</rootpe_cpl>
+          <rootpe_ice>0</rootpe_ice>
+          <rootpe_ocn>128</rootpe_ocn>
+          <rootpe_lnd>0</rootpe_lnd>
+          <rootpe_wav>0</rootpe_wav>
+          <rootpe_glc>0</rootpe_glc>
+        </rootpe>
+      </pes>
+    </mach>
     <mach name="cheyenne">
       <pes pesize="any" compset="DATM.+CICE.+SWAV">
         <comment>none</comment>
@@ -487,6 +588,107 @@
         </rootpe>
       </pes>
     </mach>
+    <mach name="derecho">
+      <pes pesize="any" compset="DATM.+CICE.+SWAV">
+        <comment>none</comment>
+        <ntasks>
+          <ntasks_atm>128</ntasks_atm>
+          <ntasks_rof>128</ntasks_rof>
+          <ntasks_cpl>128</ntasks_cpl>
+          <ntasks_ice>128</ntasks_ice>
+          <ntasks_ocn>896</ntasks_ocn>
+          <ntasks_lnd>1</ntasks_lnd>
+          <ntasks_wav>1</ntasks_wav>
+          <ntasks_glc>1</ntasks_glc>
+        </ntasks>
+        <nthrds>
+          <nthrds_atm>1</nthrds_atm>
+          <nthrds_lnd>1</nthrds_lnd>
+          <nthrds_rof>1</nthrds_rof>
+          <nthrds_ice>1</nthrds_ice>
+          <nthrds_ocn>1</nthrds_ocn>
+          <nthrds_glc>1</nthrds_glc>
+          <nthrds_wav>1</nthrds_wav>
+          <nthrds_cpl>1</nthrds_cpl>
+        </nthrds>
+        <rootpe>
+          <rootpe_atm>0</rootpe_atm>
+          <rootpe_rof>0</rootpe_rof>
+          <rootpe_cpl>0</rootpe_cpl>
+          <rootpe_ice>0</rootpe_ice>
+          <rootpe_ocn>128</rootpe_ocn>
+          <rootpe_lnd>0</rootpe_lnd>
+          <rootpe_wav>0</rootpe_wav>
+          <rootpe_glc>0</rootpe_glc>
+        </rootpe>
+      </pes>
+      <pes pesize="any" compset="DATM.+CICE.+WW3">
+        <comment>none</comment>
+        <ntasks>
+          <ntasks_atm>128</ntasks_atm>
+          <ntasks_rof>128</ntasks_rof>
+          <ntasks_cpl>128</ntasks_cpl>
+          <ntasks_ice>128</ntasks_ice>
+          <ntasks_ocn>384</ntasks_ocn>
+          <ntasks_lnd>1</ntasks_lnd>
+          <ntasks_wav>256</ntasks_wav>
+          <ntasks_glc>1</ntasks_glc>
+        </ntasks>
+        <nthrds>
+          <nthrds_atm>1</nthrds_atm>
+          <nthrds_lnd>1</nthrds_lnd>
+          <nthrds_rof>1</nthrds_rof>
+          <nthrds_ice>1</nthrds_ice>
+          <nthrds_ocn>1</nthrds_ocn>
+          <nthrds_glc>1</nthrds_glc>
+          <nthrds_wav>1</nthrds_wav>
+          <nthrds_cpl>1</nthrds_cpl>
+        </nthrds>
+        <rootpe>
+          <rootpe_atm>0</rootpe_atm>
+          <rootpe_rof>0</rootpe_rof>
+          <rootpe_cpl>0</rootpe_cpl>
+          <rootpe_ice>0</rootpe_ice>
+          <rootpe_ocn>256</rootpe_ocn>
+          <rootpe_lnd>0</rootpe_lnd>
+          <rootpe_wav>0</rootpe_wav>
+          <rootpe_glc>0</rootpe_glc>
+        </rootpe>
+      </pes>
+      <pes pesize="any" compset="DATM.+DICE.+SWAV">
+        <comment>none</comment>
+        <ntasks>
+          <ntasks_atm>128</ntasks_atm>
+          <ntasks_rof>128</ntasks_rof>
+          <ntasks_cpl>128</ntasks_cpl>
+          <ntasks_ice>128</ntasks_ice>
+          <ntasks_ocn>896</ntasks_ocn>
+          <ntasks_lnd>1</ntasks_lnd>
+          <ntasks_wav>1</ntasks_wav>
+          <ntasks_glc>1</ntasks_glc>
+        </ntasks>
+        <nthrds>
+          <nthrds_atm>1</nthrds_atm>
+          <nthrds_lnd>1</nthrds_lnd>
+          <nthrds_rof>1</nthrds_rof>
+          <nthrds_ice>1</nthrds_ice>
+          <nthrds_ocn>1</nthrds_ocn>
+          <nthrds_glc>1</nthrds_glc>
+          <nthrds_wav>1</nthrds_wav>
+          <nthrds_cpl>1</nthrds_cpl>
+        </nthrds>
+        <rootpe>
+          <rootpe_atm>0</rootpe_atm>
+          <rootpe_rof>0</rootpe_rof>
+          <rootpe_cpl>0</rootpe_cpl>
+          <rootpe_ice>0</rootpe_ice>
+          <rootpe_ocn>128</rootpe_ocn>
+          <rootpe_lnd>0</rootpe_lnd>
+          <rootpe_wav>0</rootpe_wav>
+          <rootpe_glc>0</rootpe_glc>
+        </rootpe>
+      </pes>
+    </mach>
     <mach name="cheyenne">
       <pes pesize="any" compset="DATM.+CICE.+SWAV">
         <comment>none</comment>
@@ -831,6 +1033,107 @@
         </rootpe>
       </pes>
     </mach>
+    <mach name="derecho">
+      <pes pesize="any" compset="DATM.+DICE.+SWAV">
+        <comment>none</comment>
+        <ntasks>
+          <ntasks_atm>128</ntasks_atm>
+          <ntasks_rof>128</ntasks_rof>
+          <ntasks_cpl>128</ntasks_cpl>
+          <ntasks_ice>128</ntasks_ice>
+          <ntasks_ocn>896</ntasks_ocn>
+          <ntasks_lnd>1</ntasks_lnd>
+          <ntasks_wav>1</ntasks_wav>
+          <ntasks_glc>1</ntasks_glc>
+        </ntasks>
+        <nthrds>
+          <nthrds_atm>1</nthrds_atm>
+          <nthrds_lnd>1</nthrds_lnd>
+          <nthrds_rof>1</nthrds_rof>
+          <nthrds_ice>1</nthrds_ice>
+          <nthrds_ocn>1</nthrds_ocn>
+          <nthrds_glc>1</nthrds_glc>
+          <nthrds_wav>1</nthrds_wav>
+          <nthrds_cpl>1</nthrds_cpl>
+        </nthrds>
+        <rootpe>
+          <rootpe_atm>0</rootpe_atm>
+          <rootpe_rof>0</rootpe_rof>
+          <rootpe_cpl>0</rootpe_cpl>
+          <rootpe_ice>0</rootpe_ice>
+          <rootpe_ocn>128</rootpe_ocn>
+          <rootpe_lnd>0</rootpe_lnd>
+          <rootpe_wav>0</rootpe_wav>
+          <rootpe_glc>0</rootpe_glc>
+        </rootpe>
+      </pes>
+      <pes pesize="any" compset="DATM.+CICE.+SWAV">
+        <comment>none</comment>
+        <ntasks>
+          <ntasks_atm>128</ntasks_atm>
+          <ntasks_rof>128</ntasks_rof>
+          <ntasks_cpl>128</ntasks_cpl>
+          <ntasks_ice>128</ntasks_ice>
+          <ntasks_ocn>896</ntasks_ocn>
+          <ntasks_lnd>1</ntasks_lnd>
+          <ntasks_wav>1</ntasks_wav>
+          <ntasks_glc>1</ntasks_glc>
+        </ntasks>
+        <nthrds>
+          <nthrds_atm>1</nthrds_atm>
+          <nthrds_lnd>1</nthrds_lnd>
+          <nthrds_rof>1</nthrds_rof>
+          <nthrds_ice>1</nthrds_ice>
+          <nthrds_ocn>1</nthrds_ocn>
+          <nthrds_glc>1</nthrds_glc>
+          <nthrds_wav>1</nthrds_wav>
+          <nthrds_cpl>1</nthrds_cpl>
+        </nthrds>
+        <rootpe>
+          <rootpe_atm>0</rootpe_atm>
+          <rootpe_rof>0</rootpe_rof>
+          <rootpe_cpl>0</rootpe_cpl>
+          <rootpe_ice>0</rootpe_ice>
+          <rootpe_ocn>128</rootpe_ocn>
+          <rootpe_lnd>0</rootpe_lnd>
+          <rootpe_wav>0</rootpe_wav>
+          <rootpe_glc>0</rootpe_glc>
+        </rootpe>
+      </pes>
+      <pes pesize="any" compset="DATM.+CICE.+WW3">
+        <comment>none</comment>
+        <ntasks>
+          <ntasks_atm>128</ntasks_atm>
+          <ntasks_rof>128</ntasks_rof>
+          <ntasks_cpl>128</ntasks_cpl>
+          <ntasks_ice>128</ntasks_ice>
+          <ntasks_ocn>384</ntasks_ocn>
+          <ntasks_lnd>1</ntasks_lnd>
+          <ntasks_wav>256</ntasks_wav>
+          <ntasks_glc>1</ntasks_glc>
+        </ntasks>
+        <nthrds>
+          <nthrds_atm>1</nthrds_atm>
+          <nthrds_lnd>1</nthrds_lnd>
+          <nthrds_rof>1</nthrds_rof>
+          <nthrds_ice>1</nthrds_ice>
+          <nthrds_ocn>1</nthrds_ocn>
+          <nthrds_glc>1</nthrds_glc>
+          <nthrds_wav>1</nthrds_wav>
+          <nthrds_cpl>1</nthrds_cpl>
+        </nthrds>
+        <rootpe>
+          <rootpe_atm>0</rootpe_atm>
+          <rootpe_rof>0</rootpe_rof>
+          <rootpe_cpl>0</rootpe_cpl>
+          <rootpe_ice>0</rootpe_ice>
+          <rootpe_ocn>256</rootpe_ocn>
+          <rootpe_lnd>0</rootpe_lnd>
+          <rootpe_wav>0</rootpe_wav>
+          <rootpe_glc>0</rootpe_glc>
+        </rootpe>
+      </pes>
+    </mach>
     <mach name="cheyenne">
       <pes pesize="any" compset="DATM.+DICE.+SWAV">
         <comment>none</comment>
@@ -934,6 +1237,74 @@
     </mach>
   </grid>
   <grid name="a%T62.+oi%tx0.25v1">
+    <mach name="derecho">
+      <pes pesize="any" compset="any">
+        <comment>none</comment>
+        <ntasks>
+          <ntasks_atm>128</ntasks_atm>
+          <ntasks_rof>128</ntasks_rof>
+          <ntasks_cpl>128</ntasks_cpl>
+          <ntasks_ice>128</ntasks_ice>
+          <ntasks_ocn>896</ntasks_ocn>
+          <ntasks_lnd>1</ntasks_lnd>
+          <ntasks_wav>1</ntasks_wav>
+          <ntasks_glc>1</ntasks_glc>
+        </ntasks>
+        <nthrds>
+          <nthrds_atm>1</nthrds_atm>
+          <nthrds_lnd>1</nthrds_lnd>
+          <nthrds_rof>1</nthrds_rof>
+          <nthrds_ice>1</nthrds_ice>
+          <nthrds_ocn>1</nthrds_ocn>
+          <nthrds_glc>1</nthrds_glc>
+          <nthrds_wav>1</nthrds_wav>
+          <nthrds_cpl>1</nthrds_cpl>
+        </nthrds>
+        <rootpe>
+          <rootpe_atm>0</rootpe_atm>
+          <rootpe_rof>0</rootpe_rof>
+          <rootpe_cpl>0</rootpe_cpl>
+          <rootpe_ice>0</rootpe_ice>
+          <rootpe_ocn>128</rootpe_ocn>
+          <rootpe_lnd>0</rootpe_lnd>
+          <rootpe_wav>0</rootpe_wav>
+          <rootpe_glc>0</rootpe_glc>
+        </rootpe>
+      </pes>
+      <pes pesize="any" compset="DATM.+CICE.+SWAV">
+        <comment>none</comment>
+        <ntasks>
+          <ntasks_atm>128</ntasks_atm>
+          <ntasks_rof>128</ntasks_rof>
+          <ntasks_cpl>128</ntasks_cpl>
+          <ntasks_ice>256</ntasks_ice>
+          <ntasks_ocn>512</ntasks_ocn>
+          <ntasks_lnd>1</ntasks_lnd>
+          <ntasks_wav>1</ntasks_wav>
+          <ntasks_glc>1</ntasks_glc>
+        </ntasks>
+        <nthrds>
+          <nthrds_atm>1</nthrds_atm>
+          <nthrds_lnd>1</nthrds_lnd>
+          <nthrds_rof>1</nthrds_rof>
+          <nthrds_ice>1</nthrds_ice>
+          <nthrds_ocn>1</nthrds_ocn>
+          <nthrds_glc>1</nthrds_glc>
+          <nthrds_wav>1</nthrds_wav>
+          <nthrds_cpl>1</nthrds_cpl>
+        </nthrds>
+        <rootpe>
+          <rootpe_atm>0</rootpe_atm>
+          <rootpe_rof>0</rootpe_rof>
+          <rootpe_cpl>0</rootpe_cpl>
+          <rootpe_ice>0</rootpe_ice>
+          <rootpe_ocn>256</rootpe_ocn>
+          <rootpe_lnd>0</rootpe_lnd>
+          <rootpe_wav>0</rootpe_wav>
+          <rootpe_glc>0</rootpe_glc>
+        </rootpe>
+      </pes>
+    </mach>
     <mach name="cheyenne">
       <pes pesize="any" compset="any">
         <comment>none</comment>
@@ -1004,6 +1375,41 @@
     </mach>
   </grid>
   <grid name="oi%tx0.66v1.+w%wtx0.66v1">
+    <mach name="derecho">
+      <pes pesize="any" compset="any">
+        <comment>none</comment>
+        <ntasks>
+          <ntasks_atm>128</ntasks_atm>
+          <ntasks_rof>128</ntasks_rof>
+          <ntasks_cpl>128</ntasks_cpl>
+          <ntasks_ice>128</ntasks_ice>
+          <ntasks_ocn>512</ntasks_ocn>
+          <ntasks_lnd>1</ntasks_lnd>
+          <ntasks_wav>128</ntasks_wav>
+          <ntasks_glc>1</ntasks_glc>
+        </ntasks>
+        <nthrds>
+          <nthrds_atm>1</nthrds_atm>
+          <nthrds_lnd>1</nthrds_lnd>
+          <nthrds_rof>1</nthrds_rof>
+          <nthrds_ice>1</nthrds_ice>
+          <nthrds_ocn>1</nthrds_ocn>
+          <nthrds_glc>1</nthrds_glc>
+          <nthrds_wav>1</nthrds_wav>
+          <nthrds_cpl>1</nthrds_cpl>
+        </nthrds>
+        <rootpe>
+          <rootpe_atm>0</rootpe_atm>
+          <rootpe_rof>0</rootpe_rof>
+          <rootpe_cpl>0</rootpe_cpl>
+          <rootpe_ice>0</rootpe_ice>
+          <rootpe_ocn>256</rootpe_ocn>
+          <rootpe_lnd>0</rootpe_lnd>
+          <rootpe_wav>128</rootpe_wav>
+          <rootpe_glc>0</rootpe_glc>
+        </rootpe>
+      </pes>
+    </mach>
     <mach name="cheyenne">
       <pes pesize="any" compset="any">
         <comment>none</comment>


### PR DESCRIPTION
I did not test this extensively, but I ran cases using the `CMOM_JRA` and `GMOM_JRA` compsets on the `TL319_t232` grid for 1 month (with default output streams). I then ran the same cases using WW3DEV instead of SWAV. In all cases, the runs on derecho had higher throughput and lower cost than the same run on cheyenne.