### PR TITLE
Add rpointer_content entry in config_archive.xml

### DIFF
--- a/cime_config/config_archive.xml
+++ b/cime_config/config_archive.xml
@@ -12,6 +12,7 @@
     <hist_file_ext_regex>\w+\.\w+(\._\d*)?</hist_file_ext_regex>
     <rpointer>
       <rpointer_file>rpointer.ocn$NINST_STRING</rpointer_file>
+      <rpointer_content>$CASE.mom6$NINST_STRING.r.$DATENAME.nc</rpointer_content>
     </rpointer>
   </comp_archive_spec>
 </components>


### PR DESCRIPTION
This PR fixes a short term archiver issue that occurs when`DOUT_S_SAVE_INTERIM_RESTART_FILES` is set to True.