### PR TITLE
Unresolved diag table generation and handling

### DIFF
--- a/cime_config/MOM_RPS/FType_diag_table.py
+++ b/cime_config/MOM_RPS/FType_diag_table.py
@@ -4,6 +4,29 @@ from CIME.ParamGen.paramgen import ParamGen
 class FType_diag_table(ParamGen):
     """Encapsulates data and read/write methods for MOM6 diag_table input file."""
 
+    @classmethod
+    def resolve(cls, unresolved_diag_table_path, resolved_diag_table_path, casename):
+        """Resolve the casename in an unresolved diag_table.
+
+        Parameters
+        ----------
+        unresolved_diag_table_path : str
+            The path to the unresolved diag_table.
+        resolved_diag_table_path : str
+            The path to the resolved diag_table to be created.
+        casename : str
+            The casename to be resolved.
+        """
+        assert os.path.exists(unresolved_diag_table_path), \
+            "Unresolved diag_table file not found: "+unresolved_diag_table_path
+        
+        resolved_diag_table = open(resolved_diag_table_path, 'w')
+        with open(unresolved_diag_table_path, 'r') as diag_table_unresolved:
+            for line in diag_table_unresolved:
+                resolved_diag_table.write(line.replace('${CASE}', casename))
+        
+        resolved_diag_table.close()
+
     def write(self, output_path, case, MOM_input_final):
 
         def get_all_fields(fields_block):
@@ -43,7 +66,7 @@ class FType_diag_table(ParamGen):
         with open(os.path.join(output_path), 'w') as diag_table:
 
             # Print header:
-            casename = case.get_value("CASE")
+            casename = '${CASE}'
             diag_table.write('"MOM6 diagnostic fields table for CESM case: '+casename+'"\n')
             diag_table.write('1 1 1 0 0 0\n') #TODO
             filename = lambda suffix : '"'+casename+'.mom6.'+suffix+'"'

--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -37,9 +37,11 @@ def prep_input(case, inst_suffixes):
     in SourceMods, those versions will be copied to run directory instead."""
 
     Buildconf = case.get_value("CASEBUILD")
-    rundir = case.get_value("RUNDIR")
     comp_root_dir_ocn = case.get_value("COMP_ROOT_DIR_OCN")
     caseroot = case.get_value("CASEROOT")
+    casename = case.get_value("CASE")
+    rundir = case.get_value("RUNDIR")
+    momconfdir  = os.path.join(caseroot, "Buildconf", "momconf")
     SourceMods_dir = os.path.join(caseroot,"SourceMods","src.mom")
     SourceMods_listdir = os.listdir(SourceMods_dir)
     multi_instance = inst_suffixes[0] != ''
@@ -48,9 +50,11 @@ def prep_input(case, inst_suffixes):
       infra_api = case.get_value("MOM6_INFRA_API")
       expect(infra_api != "FMS1", "Cannot run with FMS1 infra API when multi-instance mode is enabled.")
 
-    # Make sure that rundir exists. If not, make it:
+    # Make sure that rundir and momconf directories exist. If not, make them:
     if not os.path.exists(rundir):
         os.makedirs(rundir)
+    if not os.path.exists(momconfdir):
+        os.makedirs(momconfdir)
 
     # Parse json files and create MOM6 input files in rundir
     json_templates_dir = os.path.join(comp_root_dir_ocn,"param_templates","json")
@@ -107,14 +111,26 @@ def prep_input(case, inst_suffixes):
     input_data_list.write(input_data_list_buildconf, case, MOM_input_final)
 
     # 6. Create diag_table:
-    diag_table_template = os.path.join(json_templates_dir, "diag_table.json")
-    diag_table_srcmod = os.path.join(SourceMods_dir, "diag_table")
     diag_table_rundir = os.path.join(rundir,"diag_table")
     if "diag_table" in SourceMods_listdir:
+        # A resolved diag_table is provided in SourceMods. Directly copy it to rundir.
+        expect('diag_table.unresolved' not in SourceMods_listdir, \
+               "Cannot provide both resolved and unresolved diag_table in SourceMods!")
+        diag_table_srcmod = os.path.join(SourceMods_dir, "diag_table")
         shutil.copy(diag_table_srcmod, diag_table_rundir)
     else:
-        diag_table = FType_diag_table.from_json(diag_table_template)
-        diag_table.write(diag_table_rundir, case, MOM_input_final)
+        unresolved_diag_table_confdir = os.path.join(momconfdir,"diag_table.unresolved")
+        if "diag_table.unresolved" in SourceMods_listdir:
+            # An unresolved diag_table is provided in SourceMods. Directly copy it to momconf.
+            unresolved_diag_table_srcmod = os.path.join(SourceMods_dir, "diag_table.unresolved")
+            shutil.copy(unresolved_diag_table_srcmod, unresolved_diag_table_confdir)
+        else:
+            # Create an unresolved diag_table in momconf using the template
+            diag_table_template = os.path.join(json_templates_dir, "diag_table.json")
+            unresolved_diag_table = FType_diag_table.from_json(diag_table_template)
+            unresolved_diag_table.write(unresolved_diag_table_confdir, case, MOM_input_final)
+        # Resolve unresolved diag_table in momconf and write it to rundir
+        FType_diag_table.resolve(unresolved_diag_table_confdir, diag_table_rundir, casename)
 
 def init_MOM_override(rundir, inst_suffix):
     # Create an empty MOM_override:
@@ -150,7 +166,6 @@ def process_user_nl_mom(case, inst_suffix):
 
 def _copy_input_files(case, dest_dir, inst_suffixes):
     """ Saves copies of MOM6 input files in momconf directory for the record."""
-    caseroot = case.get_value("CASEROOT")
     rundir   = case.get_value("RUNDIR")
     if not os.path.isdir(dest_dir):
         os.makedirs(dest_dir)
@@ -158,7 +173,7 @@ def _copy_input_files(case, dest_dir, inst_suffixes):
     for inst_suffix in inst_suffixes:
         for filename in ["MOM_input", "MOM_override"]:
             shutil.copy(os.path.join(rundir,filename+inst_suffix), dest_dir)
-    for filename in ["diag_table", "input.nml"]:
+    for filename in ["input.nml"]:
         shutil.copy(os.path.join(rundir,filename), dest_dir)
 
 

--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -10,6 +10,7 @@
 # pylint: disable=wildcard-import,unused-wildcard-import,wrong-import-position
 
 import os, shutil, sys, re
+import logging
 
 CIMEROOT = os.environ.get("CIMEROOT")
 if CIMEROOT is None:
@@ -18,7 +19,7 @@ sys.path.append(os.path.join(CIMEROOT, "scripts", "Tools"))
 
 # The scope of the following path expansion is limited to this script only,
 # and is needed to import MOM6 input file classes:
-sys.path.append(os.path.join(os.path.dirname(os.path.abspath(__file__)),"MOM_RPS"))
+sys.path.append(os.path.join(os.path.dirname(os.path.abspath(__file__)), "MOM_RPS"))
 
 from standard_script_setup import *
 from CIME.case import Case
@@ -31,8 +32,9 @@ from FType_diag_table import FType_diag_table
 
 logger = logging.getLogger(__name__)
 
+
 def prep_input(case, inst_suffixes):
-    """ Generates out-of-the-box versions of MOM6 input files including MOM_input, MOM_override, diag_table
+    """Generates out-of-the-box versions of MOM6 input files including MOM_input, MOM_override, diag_table
     input.nml, and mom.input_data_list, inside the run directory. If any of these input files are provided
     in SourceMods, those versions will be copied to run directory instead."""
 
@@ -41,14 +43,17 @@ def prep_input(case, inst_suffixes):
     caseroot = case.get_value("CASEROOT")
     casename = case.get_value("CASE")
     rundir = case.get_value("RUNDIR")
-    momconfdir  = os.path.join(caseroot, "Buildconf", "momconf")
-    SourceMods_dir = os.path.join(caseroot,"SourceMods","src.mom")
+    momconfdir = os.path.join(caseroot, "Buildconf", "momconf")
+    SourceMods_dir = os.path.join(caseroot, "SourceMods", "src.mom")
     SourceMods_listdir = os.listdir(SourceMods_dir)
-    multi_instance = inst_suffixes[0] != ''
+    multi_instance = inst_suffixes[0] != ""
 
     if multi_instance:
-      infra_api = case.get_value("MOM6_INFRA_API")
-      expect(infra_api != "FMS1", "Cannot run with FMS1 infra API when multi-instance mode is enabled.")
+        infra_api = case.get_value("MOM6_INFRA_API")
+        expect(
+            infra_api != "FMS1",
+            "Cannot run with FMS1 infra API when multi-instance mode is enabled.",
+        )
 
     # Make sure that rundir and momconf directories exist. If not, make them:
     if not os.path.exists(rundir):
@@ -57,33 +62,41 @@ def prep_input(case, inst_suffixes):
         os.makedirs(momconfdir)
 
     # Parse json files and create MOM6 input files in rundir
-    json_templates_dir = os.path.join(comp_root_dir_ocn,"param_templates","json")
+    json_templates_dir = os.path.join(comp_root_dir_ocn, "param_templates", "json")
 
     # 1. Create MOM_input:
     MOM_input_template = os.path.join(json_templates_dir, "MOM_input.json")
-    MOM_input_rundir = os.path.join(rundir,f"MOM_input{inst_suffixes[0]}")
+    MOM_input_rundir = os.path.join(rundir, f"MOM_input{inst_suffixes[0]}")
     if multi_instance:
         # don't allow separate MOM_input files for separate instances
-        assert not any([re.match("MOM_input_+\d", filename) for filename in SourceMods_listdir]), \
-            "Cannot provide separate instances of MOM_input"
+        assert not any(
+            [re.match("MOM_input_+\d", filename) for filename in SourceMods_listdir]
+        ), "Cannot provide separate instances of MOM_input"
     if "MOM_input" in SourceMods_listdir:
-        shutil.copy(os.path.join(SourceMods_dir,"MOM_input"), MOM_input_rundir)
+        shutil.copy(os.path.join(SourceMods_dir, "MOM_input"), MOM_input_rundir)
     else:
         # Create MOM_input in rundir using template
         MOM_input = FType_MOM_params.from_json(MOM_input_template)
-        MOM_input.write(output_path=MOM_input_rundir, output_format="MOM_input", case=case)
+        MOM_input.write(
+            output_path=MOM_input_rundir, output_format="MOM_input", case=case
+        )
     # If multi-instance, create MOM_input copies for each instance
     for inst_suffix in inst_suffixes[1:]:
-        shutil.copy(MOM_input_rundir, os.path.join(rundir,f"MOM_input{inst_suffix}"))
-
+        shutil.copy(MOM_input_rundir, os.path.join(rundir, f"MOM_input{inst_suffix}"))
 
     # 2. Create MOM_override:
     for inst_suffix in inst_suffixes:
-        user_nl_mom = FType_MOM_params.from_MOM_input(os.path.join(caseroot,f"user_nl_mom{inst_suffix}"))
+        user_nl_mom = FType_MOM_params.from_MOM_input(
+            os.path.join(caseroot, f"user_nl_mom{inst_suffix}")
+        )
         if f"MOM_override{inst_suffix}" in SourceMods_listdir:
-            assert len(user_nl_mom.data)==0, "Cannot provide parameter changes via both SourceMods and user_nl_mom!"
-            shutil.copy(os.path.join(SourceMods_dir,f"MOM_override{inst_suffix}"),
-                        os.path.join(rundir,f"MOM_override{inst_suffix}"))
+            assert (
+                len(user_nl_mom.data) == 0
+            ), "Cannot provide parameter changes via both SourceMods and user_nl_mom!"
+            shutil.copy(
+                os.path.join(SourceMods_dir, f"MOM_override{inst_suffix}"),
+                os.path.join(rundir, f"MOM_override{inst_suffix}"),
+            )
         else:
             init_MOM_override(rundir, inst_suffix)
             process_user_nl_mom(case, inst_suffix)
@@ -91,13 +104,15 @@ def prep_input(case, inst_suffixes):
     # 3. Read in final versions of MOM_input and MOM_override, so as to use them when inferring
     #    values of expandable variables in the templates of subsequent MOM6 input files.
     MOM_input_final = FType_MOM_params.from_MOM_input(MOM_input_rundir)
-    MOM_override_final = FType_MOM_params.from_MOM_input(os.path.join(rundir,f"MOM_override{inst_suffixes[0]}"))
+    MOM_override_final = FType_MOM_params.from_MOM_input(
+        os.path.join(rundir, f"MOM_override{inst_suffixes[0]}")
+    )
     MOM_input_final.append(MOM_override_final)
 
     # 4. Create input.nml:
     input_nml_template = os.path.join(json_templates_dir, "input_nml.json")
-    input_nml_srcmod = os.path.join(SourceMods_dir,"input.nml") 
-    input_nml_rundir = os.path.join(rundir,"input.nml") 
+    input_nml_srcmod = os.path.join(SourceMods_dir, "input.nml")
+    input_nml_rundir = os.path.join(rundir, "input.nml")
     if "input.nml" in SourceMods_listdir:
         shutil.copy(input_nml_srcmod, input_nml_rundir)
     else:
@@ -106,103 +121,126 @@ def prep_input(case, inst_suffixes):
 
     # 5. Create mom.input_data_list:
     input_data_list_template = os.path.join(json_templates_dir, "input_data_list.json")
-    input_data_list_buildconf = os.path.join(Buildconf,"mom.input_data_list")
+    input_data_list_buildconf = os.path.join(Buildconf, "mom.input_data_list")
     input_data_list = FType_input_data_list.from_json(input_data_list_template)
     input_data_list.write(input_data_list_buildconf, case, MOM_input_final)
 
     # 6. Create diag_table:
-    diag_table_rundir = os.path.join(rundir,"diag_table")
+    diag_table_rundir = os.path.join(rundir, "diag_table")
     if "diag_table" in SourceMods_listdir:
         # A resolved diag_table is provided in SourceMods. Directly copy it to rundir.
-        expect('diag_table.unresolved' not in SourceMods_listdir, \
-               "Cannot provide both resolved and unresolved diag_table in SourceMods!")
+        expect(
+            "diag_table.unresolved" not in SourceMods_listdir,
+            "Cannot provide both resolved and unresolved diag_table in SourceMods!",
+        )
         diag_table_srcmod = os.path.join(SourceMods_dir, "diag_table")
         shutil.copy(diag_table_srcmod, diag_table_rundir)
     else:
-        unresolved_diag_table_confdir = os.path.join(momconfdir,"diag_table.unresolved")
+        unresolved_diag_table_confdir = os.path.join(
+            momconfdir, "diag_table.unresolved"
+        )
         if "diag_table.unresolved" in SourceMods_listdir:
             # An unresolved diag_table is provided in SourceMods. Directly copy it to momconf.
-            unresolved_diag_table_srcmod = os.path.join(SourceMods_dir, "diag_table.unresolved")
+            unresolved_diag_table_srcmod = os.path.join(
+                SourceMods_dir, "diag_table.unresolved"
+            )
             shutil.copy(unresolved_diag_table_srcmod, unresolved_diag_table_confdir)
         else:
             # Create an unresolved diag_table in momconf using the template
             diag_table_template = os.path.join(json_templates_dir, "diag_table.json")
             unresolved_diag_table = FType_diag_table.from_json(diag_table_template)
-            unresolved_diag_table.write(unresolved_diag_table_confdir, case, MOM_input_final)
+            unresolved_diag_table.write(
+                unresolved_diag_table_confdir, case, MOM_input_final
+            )
         # Resolve unresolved diag_table in momconf and write it to rundir
-        FType_diag_table.resolve(unresolved_diag_table_confdir, diag_table_rundir, casename)
+        FType_diag_table.resolve(
+            unresolved_diag_table_confdir, diag_table_rundir, casename
+        )
+
 
 def init_MOM_override(rundir, inst_suffix):
     # Create an empty MOM_override:
-    with open(os.path.join(rundir,f"MOM_override{inst_suffix}"), 'w') as MOM_override:
-        MOM_override.write(\
-            '! WARNING: DO NOT EDIT this file! Any user change made in this file will be\n'+\
-            '!          overriden. This file is automatically generated. MOM6 parameter\n'+\
-            '!          changes may be made via SourceMods or user_nl_mom.\n'+\
-            '!-------------------------------------------------------------------------\n\n')
+    with open(os.path.join(rundir, f"MOM_override{inst_suffix}"), "w") as MOM_override:
+        MOM_override.write(
+            "! WARNING: DO NOT EDIT this file! Any user change made in this file will be\n"
+            + "!          overriden. This file is automatically generated. MOM6 parameter\n"
+            + "!          changes may be made via SourceMods or user_nl_mom.\n"
+            + "!-------------------------------------------------------------------------\n\n"
+        )
+
 
 def process_user_nl_mom(case, inst_suffix):
-    """ Calls the appropriate MOM_RPS functions to parse user_nl_mom and create MOM_override."""
+    """Calls the appropriate MOM_RPS functions to parse user_nl_mom and create MOM_override."""
     caseroot = case.get_value("CASEROOT")
-    rundir   = case.get_value("RUNDIR")
+    rundir = case.get_value("RUNDIR")
 
-    user_nl_mom = FType_MOM_params.from_MOM_input(os.path.join(caseroot,f"user_nl_mom{inst_suffix}"))
+    user_nl_mom = FType_MOM_params.from_MOM_input(
+        os.path.join(caseroot, f"user_nl_mom{inst_suffix}")
+    )
 
     # copy the user_nl_mom parameters into MOM_override:
-    if len(user_nl_mom.data)>0:
+    if len(user_nl_mom.data) > 0:
 
         # check if a copy of MOM_override is provided in SourceMods:
-        SourceMods_dir = os.path.join(caseroot,"SourceMods","src.mom")
+        SourceMods_dir = os.path.join(caseroot, "SourceMods", "src.mom")
         if f"MOM_override{inst_suffix}" in os.listdir(SourceMods_dir):
-            raise SystemExit("ERROR: Cannot provide parameter changes via both SourceMods and user_nl_mom!")
+            raise SystemExit(
+                "ERROR: Cannot provide parameter changes via both SourceMods and user_nl_mom!"
+            )
 
         # parse the MOM_input file staged in rundir:
-        MOM_input_rundir = FType_MOM_params.from_MOM_input(os.path.join(rundir,f"MOM_input{inst_suffix}"))
+        MOM_input_rundir = FType_MOM_params.from_MOM_input(
+            os.path.join(rundir, f"MOM_input{inst_suffix}")
+        )
 
         # Write MOM_override (based on data from user_nl_mom)
-        user_nl_mom.write(output_path = os.path.join(rundir,f"MOM_override{inst_suffix}"),
-                          output_format = "MOM_override",
-                          def_params = MOM_input_rundir)
+        user_nl_mom.write(
+            output_path=os.path.join(rundir, f"MOM_override{inst_suffix}"),
+            output_format="MOM_override",
+            def_params=MOM_input_rundir,
+        )
+
 
 def _copy_input_files(case, dest_dir, inst_suffixes):
-    """ Saves copies of MOM6 input files in momconf directory for the record."""
-    rundir   = case.get_value("RUNDIR")
+    """Saves copies of MOM6 input files in momconf directory for the record."""
+    rundir = case.get_value("RUNDIR")
     if not os.path.isdir(dest_dir):
         os.makedirs(dest_dir)
 
     for inst_suffix in inst_suffixes:
         for filename in ["MOM_input", "MOM_override"]:
-            shutil.copy(os.path.join(rundir,filename+inst_suffix), dest_dir)
+            shutil.copy(os.path.join(rundir, filename + inst_suffix), dest_dir)
     for filename in ["input.nml"]:
-        shutil.copy(os.path.join(rundir,filename), dest_dir)
+        shutil.copy(os.path.join(rundir, filename), dest_dir)
 
 
 # pylint: disable=unused-argument
 ###############################################################################
 def buildnml(case, caseroot, compname):
-###############################################################################
-    """Build the MOM6 namelist """
+    ###############################################################################
+    """Build the MOM6 namelist"""
 
     # Build the component namelist
     if compname != "mom":
         raise AttributeError
 
     ninst = case.get_value("NINST_OCN")
-    inst_suffixes = ["_{:04d}".format(i+1) for i in range(ninst)] if ninst>1 else ['']
+    inst_suffixes = (
+        ["_{:04d}".format(i + 1) for i in range(ninst)] if ninst > 1 else [""]
+    )
 
     # prepare all input files
     prep_input(case, inst_suffixes)
 
     # save copies of input files in momconf
     caseroot = case.get_value("CASEROOT")
-    momconfdir  = os.path.join(caseroot, "Buildconf", "momconf")
+    momconfdir = os.path.join(caseroot, "Buildconf", "momconf")
     _copy_input_files(case, momconfdir, inst_suffixes)
 
     # save copies of input files in CaseDocs
-    casedocsdir  = os.path.join(caseroot, "CaseDocs")
+    casedocsdir = os.path.join(caseroot, "CaseDocs")
     _copy_input_files(case, casedocsdir, inst_suffixes)
 
-    return
 
 ###############################################################################
 def _main_func():
@@ -210,6 +248,7 @@ def _main_func():
     caseroot = parse_input(sys.argv)
     with Case(caseroot) as case:
         buildnml(case, caseroot, "mom")
+
 
 if __name__ == "__main__":
     _main_func()


### PR DESCRIPTION
- The buildnml script now generates a "diag_table.unresolved" file alongside
the usual "diag_table" in the Buildconf/momconf directory. In this unresolved
 version, the case name is represented as ${CASE}, enabling easy sharing of a
 diag table across multiple cases in a portable manner. This unresolved diag
table can be placed in SourceMods/src.mom and modified if needed. If a
diag_table.uresolved file is found in SourceMods/src.mom, the buildnml script
creates a new "diag_table" file in the RUNDIR directory based on the unresolved
one, replacing ${CASE} with  the actual case name. If both diag_table and
diag_table.unresolved files are encountered in the SourceMods directory, an
error will be triggered to instruct the user to use only one of them.
- black reformatting of buildnml

see the following commit only for unresolved diag_table changes: 009b3cf0064f78f2e8e4bc7fdeae51937f07a7ad

testing: aux_mom.derecho (ongoing)