### PR TITLE
* Enable geothermal heating, stochastic pertubations, and 3D KHTR

### DIFF
--- a/cime_config/config_component.xml
+++ b/cime_config/config_component.xml
@@ -30,7 +30,6 @@
     </desc>
   </entry>
 
-
   <entry id="MOM6_INFRA_API">
     <type>char</type>
     <valid_values>FMS1,FMS2</valid_values>
@@ -38,6 +37,21 @@
     <group>build_component_mom</group>
     <file>env_build.xml</file>
     <desc> This variable controls the MOM6 infrastructure API.
+    </desc>
+  </entry>
+
+  <entry id="MOM6_VERTICAL_GRID">
+    <type>char</type>
+    <valid_values>zstar_65L,hycom1,zstar_60L,sigma_shelf_zstar</valid_values>
+    <default_value>zstar_65L</default_value>
+    <values>
+      <value grid="oi%tx0.25v1">hycom1</value>
+      <value grid="oi%gx1v6">zstar_60L</value>
+      <value grid="oi%MISOMIP">sigma_shelf_zstar</value>
+    </values>
+    <group>case_comp</group>
+    <file>env_run.xml</file>
+    <desc> This variable controls what vertical grid is used in MOM6.
     </desc>
   </entry>
 

--- a/param_templates/MOM_input.yaml
+++ b/param_templates/MOM_input.yaml
@@ -691,6 +691,14 @@ Global:
             $OCN_GRID == "tx0.66v1": True
             $OCN_GRID == "tx2_3v2": True
             $OCN_GRID == "tx0.25v1": True
+    USE_STANLEY_ISO:
+        description: |
+            "[Boolean] default = False
+            If true, turn on Stanley SGS T variance parameterization in isopycnal slope code."
+        datatype: logical
+        units: Boolean
+        value:
+            $OCN_GRID == "tx2_3v2": True
     ETA_TOLERANCE:
         description: |
             "[m] default = 3.15E-09
@@ -737,6 +745,16 @@ Global:
         value:
             $OCN_GRID == "gx1v6": True
             $OCN_GRID == "tx0.66v1": True
+            $OCN_GRID == "tx2_3v2": True
+    NDIFF_TAPERING:
+        description: |
+            "[Boolean] default = False
+            If true, neutral diffusion linearly decays to zero within a transition
+            zone defined using boundary layer depths.  Only applicable when
+            NDIFF_INTERIOR_ONLY = True."
+        datatype: logical
+        units: Boolean
+        value:
             $OCN_GRID == "tx2_3v2": True
     USE_HORIZONTAL_BOUNDARY_DIFFUSION:
         description: |
@@ -893,6 +911,14 @@ Global:
         datatype: logical
         units: Boolean
         value: True
+    USE_STANLEY_PGF:
+        description: |
+            "[Boolean] default = False
+            If true, turn on Stanley SGS T variance parameterization in PGF code."
+        datatype: logical
+        units: Boolean
+        value:
+            $OCN_GRID == "tx2_3v2": True
     LAPLACIAN:
         description: |
             "[Boolean] default = False
@@ -1345,6 +1371,22 @@ Global:
         units: nondimensional
         value:
             $OCN_GRID == "tx0.25v1": 0.1
+    STOCH_EOS:
+        decription:
+            "[Boolean] default = False
+            If true, stochastic perturbations are applied to the EOS in the PGF."
+        datatype: logical
+        units: Boolean
+        value:
+            $OCN_GRID == "tx2_3v2": True
+    STANLEY_COEFF:
+        decription:
+            "[nondim] default = -1.0
+            Coefficient correlating the temperature gradient and SGS T variance."
+        datatype: real
+        units: nondimensional
+        value:
+            $OCN_GRID == "tx2_3v2": 0.5
     USE_KH_IN_MEKE:
         description: |
             "[Boolean] default = False
@@ -1378,6 +1420,14 @@ Global:
             $OCN_GRID == "gx1v6": 0.01
             $OCN_GRID == "tx0.66v1": 0.01
             $OCN_GRID == "tx2_3v2": 0.01
+    USE_STANLEY_GM:
+        description: |
+            "[Boolean] default = False
+            If true, turn on Stanley SGS T variance parameterization in GM code."
+        datatype: logical
+        units: Boolean
+        value:
+            $OCN_GRID == "tx2_3v2": True
     MIXEDLAYER_RESTRAT:
         description: |
             "[Boolean] default = False
@@ -1440,6 +1490,14 @@ Global:
             $OCN_GRID == "tx0.66v1": 3.45600E+05
             $OCN_GRID == "tx2_3v2": 3.45600E+05
             $OCN_GRID == "tx0.25v1": 2.592E+06
+    USE_STANLEY_ML:
+        description: |
+            "[Boolean] default = False
+            If true, turn on Stanley SGS T variance parameterization in ML restrat code."
+        datatype: logical
+        units: Boolean
+        value:
+            $OCN_GRID == "tx2_3v2": True
     USE_CVMix_CONVECTION:
         description: |
             "[Boolean] default = False
@@ -2010,6 +2068,15 @@ Global:
             $OCN_GRID == "tx0.66v1": '"PPM:H3"'
             $OCN_GRID == "tx2_3v2": '"PPM:H3"'
             $OCN_GRID == "tx0.25v1": '"PPM:H3"'
+    KHTR_USE_EBT_STRUCT:
+        description: |
+            "[Boolean] default = False
+            If true, uses the equivalent barotropic structure as the vertical structure of
+            the tracer diffusivity."
+        datatype: logical
+        units: Boolean
+        value:
+            $OCN_GRID == "tx2_3v2": True
     KHTR:
         description: |
             "[m2 s-1] default = 0.0

--- a/param_templates/MOM_input.yaml
+++ b/param_templates/MOM_input.yaml
@@ -1372,7 +1372,7 @@ Global:
         value:
             $OCN_GRID == "tx0.25v1": 0.1
     STOCH_EOS:
-        decription:
+        description:
             "[Boolean] default = False
             If true, stochastic perturbations are applied to the EOS in the PGF."
         datatype: logical
@@ -1380,7 +1380,7 @@ Global:
         value:
             $OCN_GRID == "tx2_3v2": True
     STANLEY_COEFF:
-        decription:
+        description:
             "[nondim] default = -1.0
             Coefficient correlating the temperature gradient and SGS T variance."
         datatype: real

--- a/param_templates/MOM_input.yaml
+++ b/param_templates/MOM_input.yaml
@@ -2689,6 +2689,7 @@ Global:
         datatype: logical
         units: Boolean
         value:
+            $OCN_GRID == "tx2_3v2": True
             $OCN_GRID == "tx0.25v1": True
     TOPO_EDITS_FILE:
         description: |
@@ -3399,6 +3400,7 @@ Global:
         datatype: real
         units: W m-2 or various
         value:
+            $OCN_GRID == "tx2_3v2": 1.0
             $OCN_GRID == "tx0.25v1": 1.0
     GEOTHERMAL_FILE:
         description: |
@@ -3407,6 +3409,7 @@ Global:
             read, or blank to use a constant heating rate."
         datatype: string
         value:
+            $OCN_GRID == "tx2_3v2": "geothermal_davies2013_tx2_3_20231120_cdf5.nc"
             $OCN_GRID == "tx0.25v1": "geothermal_davies2013_v1.nc"
     GEOTHERMAL_VARNAME:
         description: |
@@ -3415,6 +3418,7 @@ Global:
             GEOTHERMAL_FILE."
         datatype: string
         value:
+            $OCN_GRID == "tx2_3v2": "geothermal_hf"
             $OCN_GRID == "tx0.25v1": "geothermal_hf"
     USE_WAVES:
         description: |

--- a/param_templates/MOM_input.yaml
+++ b/param_templates/MOM_input.yaml
@@ -108,11 +108,10 @@ Global:
         datatype: integer
         units: nondim
         value:
-            $OCN_GRID == "gx1v6": 60
-            $OCN_GRID == "tx0.66v1": 65
-            $OCN_GRID == "tx2_3v2": 65
-            $OCN_GRID == "tx0.25v1": 75
-            $OCN_GRID == "MISOMIP": 36
+            $MOM6_VERTICAL_GRID == "zstar_60L": 60
+            $MOM6_VERTICAL_GRID == "zstar_65L": 65
+            $MOM6_VERTICAL_GRID == "hycom1": 75
+            $MOM6_VERTICAL_GRID == "sigma_shelf_zstar": 36
     USE_LEGACY_DIABATIC_DRIVER:
         description: |
             "[Boolean] default = True
@@ -358,7 +357,7 @@ Global:
             "This specifies how layers are to be defined:
             file - read coordinate information from the file
             specified by (COORD_FILE).
-            linear - linear based on interfaces not layesrs.
+            linear - linear based on interfaces not layers.
             ts_ref - use reference temperature and salinity
             ts_range - use range of temperature and salinity
             (T_REF and S_REF) to determine surface density
@@ -371,9 +370,6 @@ Global:
             The file from which the coordinate densities are read."
         datatype: string
         value:
-            $OCN_GRID == "gx1v6": "none"
-            $OCN_GRID == "tx0.66v1": "none"
-            $OCN_GRID == "tx2_3v2": "none"
             $OCN_GRID == "tx0.25v1": "file"
             $OCN_GRID == "MISOMIP": "linear"
     REMAP_UV_USING_OLD_ALG:
@@ -402,7 +398,7 @@ Global:
         datatype: logical
         units: Boolean
         value:
-            $OCN_GRID == "tx0.25v1": True
+            $MOM6_VERTICAL_GRID == "hycom1": True
     GRID_CONFIG:
         description: |
             "A character string that determines the method for
@@ -806,9 +802,9 @@ Global:
             ADAPTIVE - optimize for smooth neutral density surfaces"
         datatype: string
         value:
-            $OCN_GRID == "tx0.25v1": "HYCOM1"
-            $OCN_GRID == "MISOMIP": "SIGMA_SHELF_ZSTAR"
-            else: "Z*"
+            $MOM6_VERTICAL_GRID == "zstar_65L" or $MOM6_VERTICAL_GRID == "zstar_60L": "Z*"
+            $MOM6_VERTICAL_GRID == "hycom1": "HYCOM1"
+            $MOM6_VERTICAL_GRID == "sigma_shelf_zstar": "SIGMA_SHELF_ZSTAR"
     ALE_COORDINATE_CONFIG:
         description: |
             "default = 'UNIFORM'
@@ -828,10 +824,10 @@ Global:
             HYBRID:vgrid.nc,sigma2,dz"
         datatype: string
         value:
-            $OCN_GRID == "gx1v6": '"FILE:ocean_vgrid.nc,dz"'
-            $OCN_GRID == "tx0.66v1": '"FILE:vgrid_65L_20200626.nc,dz"'
-            $OCN_GRID == "tx2_3v2": '"FILE:vgrid_65L_20200626.nc,dz"'
-            $OCN_GRID == "tx0.25v1": '"HYBRID:hycom1_75_800m.nc,sigma2,FNC1:2,4000,4.5,.01"'
+            $MOM6_VERTICAL_GRID == "zstar_65L": '"FILE:vgrid_65L_20200626.nc,dz"'
+            $MOM6_VERTICAL_GRID == "zstar_60L": '"FILE:ocean_vgrid.nc,dz"'
+            $MOM6_VERTICAL_GRID == "hycom1" and $OCN_GRID != "tx0.25v1": '"HYBRID:hybrid_75layer_zstar2.50m-2020-11-23.nc,sigma2,dz"'
+            $MOM6_VERTICAL_GRID == "hycom1" and $OCN_GRID == "tx0.25v1": '"HYBRID:hycom1_75_800m.nc,sigma2,FNC1:2,4000,4.5,.01"'
     REGRID_COMPRESSIBILITY_FRACTION:
         description: |
             "[not defined] default = 0.0
@@ -841,7 +837,7 @@ Global:
         datatype: real
         units: not defined
         value:
-            $OCN_GRID == "tx0.25v1": 0.01
+            $MOM6_VERTICAL_GRID == "hycom1": 0.01
     MAXIMUM_INT_DEPTH_CONFIG:
         description: |
             "default = 'NONE'
@@ -856,7 +852,7 @@ Global:
             The list of maximum depths for each interface."
         datatype: string
         value:
-            $OCN_GRID == "tx0.25v1": '"FNC1:5,8000.0,1.0,.01"'
+            $MOM6_VERTICAL_GRID == "hycom1": '"FNC1:5,8000.0,1.0,.01"'
     MAX_LAYER_THICKNESS_CONFIG:
         description: |
             "default = 'NONE'
@@ -871,7 +867,7 @@ Global:
             The list of maximum thickness for each layer."
         datatype: string
         value:
-            $OCN_GRID == "tx0.25v1": '"FNC1:400,31000.0,0.1,.01"'
+            $MOM6_VERTICAL_GRID == "hycom1": '"FNC1:400,31000.0,0.1,.01"'
     BOUND_CORIOLIS:
         description: |
             "[Boolean] default = False
@@ -3440,7 +3436,8 @@ Global:
             "TODO"
         datatype: string
         value:
-            $OCN_GRID == "MISOMIP": "PPM_H4"
+            $MOM6_VERTICAL_GRID == "hycom1" and $OCN_GRID != "tx0.25v1": "P1M_H2"
+            $MOM6_VERTICAL_GRID == "MISOMIP": "PPM_H4"
     MLE_USE_PBL_MLD:
         description: |
             "TODO"

--- a/param_templates/MOM_input.yaml
+++ b/param_templates/MOM_input.yaml
@@ -3476,7 +3476,7 @@ Global:
             read, or blank to use a constant heating rate."
         datatype: string
         value:
-            $OCN_GRID == "tx2_3v2": "geothermal_davies2013_tx2_3_20231120_cdf5.nc"
+            $OCN_GRID == "tx2_3v2": "geothermal_davies2013_tx2_3_20240318_cdf5.nc"
             $OCN_GRID == "tx0.25v1": "geothermal_davies2013_v1.nc"
     GEOTHERMAL_VARNAME:
         description: |

--- a/param_templates/json/MOM_input.json
+++ b/param_templates/json/MOM_input.json
@@ -2811,7 +2811,7 @@
          "description": "\"default = ''\nThe file from which the geothermal heating is to be\nread, or blank to use a constant heating rate.\"\n",
          "datatype": "string",
          "value": {
-            "$OCN_GRID == \"tx2_3v2\"": "geothermal_davies2013_tx2_3_20231120_cdf5.nc",
+            "$OCN_GRID == \"tx2_3v2\"": "geothermal_davies2013_tx2_3_20240318_cdf5.nc",
             "$OCN_GRID == \"tx0.25v1\"": "geothermal_davies2013_v1.nc"
          }
       },

--- a/param_templates/json/MOM_input.json
+++ b/param_templates/json/MOM_input.json
@@ -1019,7 +1019,7 @@
          }
       },
       "STOCH_EOS": {
-         "decription": "[Boolean] default = False If true, stochastic perturbations are applied to the EOS in the PGF.",
+         "description": "[Boolean] default = False If true, stochastic perturbations are applied to the EOS in the PGF.",
          "datatype": "logical",
          "units": "Boolean",
          "value": {
@@ -1027,7 +1027,7 @@
          }
       },
       "STANLEY_COEFF": {
-         "decription": "[nondim] default = -1.0 Coefficient correlating the temperature gradient and SGS T variance.",
+         "description": "[nondim] default = -1.0 Coefficient correlating the temperature gradient and SGS T variance.",
          "datatype": "real",
          "units": "nondimensional",
          "value": {

--- a/param_templates/json/MOM_input.json
+++ b/param_templates/json/MOM_input.json
@@ -2136,6 +2136,7 @@
          "datatype": "logical",
          "units": "Boolean",
          "value": {
+            "$OCN_GRID == \"tx2_3v2\"": true,
             "$OCN_GRID == \"tx0.25v1\"": true
          }
       },
@@ -2738,6 +2739,7 @@
          "datatype": "real",
          "units": "W m-2 or various",
          "value": {
+            "$OCN_GRID == \"tx2_3v2\"": 1.0,
             "$OCN_GRID == \"tx0.25v1\"": 1.0
          }
       },
@@ -2745,6 +2747,7 @@
          "description": "\"default = ''\nThe file from which the geothermal heating is to be\nread, or blank to use a constant heating rate.\"\n",
          "datatype": "string",
          "value": {
+            "$OCN_GRID == \"tx2_3v2\"": "geothermal_davies2013_tx2_3_20231120_cdf5.nc",
             "$OCN_GRID == \"tx0.25v1\"": "geothermal_davies2013_v1.nc"
          }
       },
@@ -2752,6 +2755,7 @@
          "description": "\"default = 'geo_heat'\nThe name of the geothermal heating variable in\nGEOTHERMAL_FILE.\"\n",
          "datatype": "string",
          "value": {
+            "$OCN_GRID == \"tx2_3v2\"": "geothermal_hf",
             "$OCN_GRID == \"tx0.25v1\"": "geothermal_hf"
          }
       },

--- a/param_templates/json/MOM_input.json
+++ b/param_templates/json/MOM_input.json
@@ -60,11 +60,10 @@
          "datatype": "integer",
          "units": "nondim",
          "value": {
-            "$OCN_GRID == \"gx1v6\"": 60,
-            "$OCN_GRID == \"tx0.66v1\"": 65,
-            "$OCN_GRID == \"tx2_3v2\"": 65,
-            "$OCN_GRID == \"tx0.25v1\"": 75,
-            "$OCN_GRID == \"MISOMIP\"": 36
+            "$MOM6_VERTICAL_GRID == \"zstar_60L\"": 60,
+            "$MOM6_VERTICAL_GRID == \"zstar_65L\"": 65,
+            "$MOM6_VERTICAL_GRID == \"hycom1\"": 75,
+            "$MOM6_VERTICAL_GRID == \"sigma_shelf_zstar\"": 36
          }
       },
       "USE_LEGACY_DIABATIC_DRIVER": {
@@ -257,12 +256,9 @@
          "value": "${DIN_LOC_ROOT}/ocn/mom/grid_indpt/cfc_atm_20230310.nc"
       },
       "COORD_CONFIG": {
-         "description": "\"This specifies how layers are to be defined:\nfile - read coordinate information from the file\nspecified by (COORD_FILE).\nlinear - linear based on interfaces not layesrs.\nts_ref - use reference temperature and salinity\nts_range - use range of temperature and salinity\n(T_REF and S_REF) to determine surface density\nand GINT calculate internal densities.\ngprime - use reference density (RHO_0) for surface\ndensity and GINT calculate internal densities.\nts_profile - use temperature and salinity profiles\n(read from COORD_FILE) to set layer densities.\nUSER - call a user modified routine.\nThe file from which the coordinate densities are read.\"\n",
+         "description": "\"This specifies how layers are to be defined:\nfile - read coordinate information from the file\nspecified by (COORD_FILE).\nlinear - linear based on interfaces not layers.\nts_ref - use reference temperature and salinity\nts_range - use range of temperature and salinity\n(T_REF and S_REF) to determine surface density\nand GINT calculate internal densities.\ngprime - use reference density (RHO_0) for surface\ndensity and GINT calculate internal densities.\nts_profile - use temperature and salinity profiles\n(read from COORD_FILE) to set layer densities.\nUSER - call a user modified routine.\nThe file from which the coordinate densities are read.\"\n",
          "datatype": "string",
          "value": {
-            "$OCN_GRID == \"gx1v6\"": "none",
-            "$OCN_GRID == \"tx0.66v1\"": "none",
-            "$OCN_GRID == \"tx2_3v2\"": "none",
             "$OCN_GRID == \"tx0.25v1\"": "file",
             "$OCN_GRID == \"MISOMIP\"": "linear"
          }
@@ -285,7 +281,7 @@
          "datatype": "logical",
          "units": "Boolean",
          "value": {
-            "$OCN_GRID == \"tx0.25v1\"": true
+            "$MOM6_VERTICAL_GRID == \"hycom1\"": true
          }
       },
       "GRID_CONFIG": {
@@ -604,19 +600,19 @@
          "description": "\"default = 'LAYER'\nCoordinate mode for vertical regridding.\nChoose among the following possibilities:\nLAYER - Isopycnal or stacked shallow water layers\nZSTAR, Z* - stetched geopotential z*\nSIGMA_SHELF_ZSTAR - stetched geopotential z* ignoring shelf\nSIGMA - terrain following coordinates\nRHO   - continuous isopycnal\nHYCOM1 - HyCOM-like hybrid coordinate\nSLIGHT - stretched coordinates above continuous isopycnal\nADAPTIVE - optimize for smooth neutral density surfaces\"\n",
          "datatype": "string",
          "value": {
-            "$OCN_GRID == \"tx0.25v1\"": "HYCOM1",
-            "$OCN_GRID == \"MISOMIP\"": "SIGMA_SHELF_ZSTAR",
-            "else": "Z*"
+            "$MOM6_VERTICAL_GRID == \"zstar_65L\" or $MOM6_VERTICAL_GRID == \"zstar_60L\"": "Z*",
+            "$MOM6_VERTICAL_GRID == \"hycom1\"": "HYCOM1",
+            "$MOM6_VERTICAL_GRID == \"sigma_shelf_zstar\"": "SIGMA_SHELF_ZSTAR"
          }
       },
       "ALE_COORDINATE_CONFIG": {
          "description": "\"default = 'UNIFORM'\nDetermines how to specify the coordinate\nresolution. Valid options are:\nPARAM       - use the vector-parameter ALE_RESOLUTION\nUNIFORM[:N] - uniformly distributed\nFILE:string - read from a file. The string specifies\nthe filename and variable name, separated\nby a comma or space, e.g. FILE:lev.nc,dz\nor FILE:lev.nc,interfaces=zw\nWOA09[:N]   - the WOA09 vertical grid (approximately)\nFNC1:string - FNC1:dz_min,H_total,power,precision\nHYBRID:string - read from a file. The string specifies\nthe filename and two variable names, separated\nby a comma or space, for sigma-2 and dz. e.g.\nHYBRID:vgrid.nc,sigma2,dz\"\n",
          "datatype": "string",
          "value": {
-            "$OCN_GRID == \"gx1v6\"": "\"FILE:ocean_vgrid.nc,dz\"",
-            "$OCN_GRID == \"tx0.66v1\"": "\"FILE:vgrid_65L_20200626.nc,dz\"",
-            "$OCN_GRID == \"tx2_3v2\"": "\"FILE:vgrid_65L_20200626.nc,dz\"",
-            "$OCN_GRID == \"tx0.25v1\"": "\"HYBRID:hycom1_75_800m.nc,sigma2,FNC1:2,4000,4.5,.01\""
+            "$MOM6_VERTICAL_GRID == \"zstar_65L\"": "\"FILE:vgrid_65L_20200626.nc,dz\"",
+            "$MOM6_VERTICAL_GRID == \"zstar_60L\"": "\"FILE:ocean_vgrid.nc,dz\"",
+            "$MOM6_VERTICAL_GRID == \"hycom1\" and $OCN_GRID != \"tx0.25v1\"": "\"HYBRID:hybrid_75layer_zstar2.50m-2020-11-23.nc,sigma2,dz\"",
+            "$MOM6_VERTICAL_GRID == \"hycom1\" and $OCN_GRID == \"tx0.25v1\"": "\"HYBRID:hycom1_75_800m.nc,sigma2,FNC1:2,4000,4.5,.01\""
          }
       },
       "REGRID_COMPRESSIBILITY_FRACTION": {
@@ -624,21 +620,21 @@
          "datatype": "real",
          "units": "not defined",
          "value": {
-            "$OCN_GRID == \"tx0.25v1\"": 0.01
+            "$MOM6_VERTICAL_GRID == \"hycom1\"": 0.01
          }
       },
       "MAXIMUM_INT_DEPTH_CONFIG": {
          "description": "\"default = 'NONE'\nDetermines how to specify the maximum interface depths.\nValid options are:\nNONE        - there are no maximum interface depths\nPARAM       - use the vector-parameter MAXIMUM_INTERFACE_DEPTHS\nFILE:string - read from a file. The string specifies\nthe filename and variable name, separated\nby a comma or space, e.g. FILE:lev.nc,Z\nFNC1:string - FNC1:dz_min,H_total,power,precision\nThe list of maximum depths for each interface.\"\n",
          "datatype": "string",
          "value": {
-            "$OCN_GRID == \"tx0.25v1\"": "\"FNC1:5,8000.0,1.0,.01\""
+            "$MOM6_VERTICAL_GRID == \"hycom1\"": "\"FNC1:5,8000.0,1.0,.01\""
          }
       },
       "MAX_LAYER_THICKNESS_CONFIG": {
          "description": "\"default = 'NONE'\nDetermines how to specify the maximum layer thicknesses.\nValid options are:\nNONE        - there are no maximum layer thicknesses\nPARAM       - use the vector-parameter MAX_LAYER_THICKNESS\nFILE:string - read from a file. The string specifies\nthe filename and variable name, separated\nby a comma or space, e.g. FILE:lev.nc,Z\nFNC1:string - FNC1:dz_min,H_total,power,precision\nThe list of maximum thickness for each layer.\"\n",
          "datatype": "string",
          "value": {
-            "$OCN_GRID == \"tx0.25v1\"": "\"FNC1:400,31000.0,0.1,.01\""
+            "$MOM6_VERTICAL_GRID == \"hycom1\"": "\"FNC1:400,31000.0,0.1,.01\""
          }
       },
       "BOUND_CORIOLIS": {
@@ -2779,7 +2775,8 @@
          "description": "\"TODO\"\n",
          "datatype": "string",
          "value": {
-            "$OCN_GRID == \"MISOMIP\"": "PPM_H4"
+            "$MOM6_VERTICAL_GRID == \"hycom1\" and $OCN_GRID != \"tx0.25v1\"": "P1M_H2",
+            "$MOM6_VERTICAL_GRID == \"MISOMIP\"": "PPM_H4"
          }
       },
       "MLE_USE_PBL_MLD": {

--- a/param_templates/json/MOM_input.json
+++ b/param_templates/json/MOM_input.json
@@ -516,6 +516,14 @@
             "$OCN_GRID == \"tx0.25v1\"": true
          }
       },
+      "USE_STANLEY_ISO": {
+         "description": "\"[Boolean] default = False\nIf true, turn on Stanley SGS T variance parameterization in isopycnal slope code.\"\n",
+         "datatype": "logical",
+         "units": "Boolean",
+         "value": {
+            "$OCN_GRID == \"tx2_3v2\"": true
+         }
+      },
       "ETA_TOLERANCE": {
          "description": "\"[m] default = 3.15E-09\nThe tolerance for the differences between the\nbarotropic and baroclinic estimates of the sea surface\nheight due to the fluxes through each face.  The total\ntolerance for SSH is 4 times this value.  The default\nis 0.5*NK*ANGSTROM, and this should not be set less x\nthan about 10^-15*MAXIMUM_DEPTH.\"\n",
          "datatype": "real",
@@ -550,6 +558,14 @@
          "value": {
             "$OCN_GRID == \"gx1v6\"": true,
             "$OCN_GRID == \"tx0.66v1\"": true,
+            "$OCN_GRID == \"tx2_3v2\"": true
+         }
+      },
+      "NDIFF_TAPERING": {
+         "description": "\"[Boolean] default = False\nIf true, neutral diffusion linearly decays to zero within a transition\nzone defined using boundary layer depths.  Only applicable when\nNDIFF_INTERIOR_ONLY = True.\"\n",
+         "datatype": "logical",
+         "units": "Boolean",
+         "value": {
             "$OCN_GRID == \"tx2_3v2\"": true
          }
       },
@@ -652,6 +668,14 @@
          "datatype": "logical",
          "units": "Boolean",
          "value": true
+      },
+      "USE_STANLEY_PGF": {
+         "description": "\"[Boolean] default = False\nIf true, turn on Stanley SGS T variance parameterization in PGF code.\"\n",
+         "datatype": "logical",
+         "units": "Boolean",
+         "value": {
+            "$OCN_GRID == \"tx2_3v2\"": true
+         }
       },
       "LAPLACIAN": {
          "description": "\"[Boolean] default = False\nIf true, use a Laplacian horizontal viscosity.\"\n",
@@ -994,6 +1018,22 @@
             "$OCN_GRID == \"tx0.25v1\"": 0.1
          }
       },
+      "STOCH_EOS": {
+         "decription": "[Boolean] default = False If true, stochastic perturbations are applied to the EOS in the PGF.",
+         "datatype": "logical",
+         "units": "Boolean",
+         "value": {
+            "$OCN_GRID == \"tx2_3v2\"": true
+         }
+      },
+      "STANLEY_COEFF": {
+         "decription": "[nondim] default = -1.0 Coefficient correlating the temperature gradient and SGS T variance.",
+         "datatype": "real",
+         "units": "nondimensional",
+         "value": {
+            "$OCN_GRID == \"tx2_3v2\"": 0.5
+         }
+      },
       "USE_KH_IN_MEKE": {
          "description": "\"[Boolean] default = False\nIf true, uses the thickness diffusivity calculated here to diffuse MEKE.\"\n",
          "datatype": "logical",
@@ -1022,6 +1062,14 @@
             "$OCN_GRID == \"gx1v6\"": 0.01,
             "$OCN_GRID == \"tx0.66v1\"": 0.01,
             "$OCN_GRID == \"tx2_3v2\"": 0.01
+         }
+      },
+      "USE_STANLEY_GM": {
+         "description": "\"[Boolean] default = False\nIf true, turn on Stanley SGS T variance parameterization in GM code.\"\n",
+         "datatype": "logical",
+         "units": "Boolean",
+         "value": {
+            "$OCN_GRID == \"tx2_3v2\"": true
          }
       },
       "MIXEDLAYER_RESTRAT": {
@@ -1064,6 +1112,14 @@
             "$OCN_GRID == \"tx0.66v1\"": 345600.0,
             "$OCN_GRID == \"tx2_3v2\"": 345600.0,
             "$OCN_GRID == \"tx0.25v1\"": 2592000.0
+         }
+      },
+      "USE_STANLEY_ML": {
+         "description": "\"[Boolean] default = False\nIf true, turn on Stanley SGS T variance parameterization in ML restrat code.\"\n",
+         "datatype": "logical",
+         "units": "Boolean",
+         "value": {
+            "$OCN_GRID == \"tx2_3v2\"": true
          }
       },
       "USE_CVMix_CONVECTION": {
@@ -1560,6 +1616,14 @@
             "$OCN_GRID == \"tx0.66v1\"": "\"PPM:H3\"",
             "$OCN_GRID == \"tx2_3v2\"": "\"PPM:H3\"",
             "$OCN_GRID == \"tx0.25v1\"": "\"PPM:H3\""
+         }
+      },
+      "KHTR_USE_EBT_STRUCT": {
+         "description": "\"[Boolean] default = False\nIf true, uses the equivalent barotropic structure as the vertical structure of\nthe tracer diffusivity.\"\n",
+         "datatype": "logical",
+         "units": "Boolean",
+         "value": {
+            "$OCN_GRID == \"tx2_3v2\"": true
          }
       },
       "KHTR": {


### PR DESCRIPTION
Update the workhorse configuration (tx2_3v2) to include geothermal heating, stochastic pertubations, and 3D KHTR. By default, KHTR (mesoscale tracer diffusion) = KHTH (GM coefficient).

These are the changes needed to replicate the latest baselines:

* zstar - https://github.com/NCAR/omwg_dev/issues/14
* hycom1 - https://github.com/NCAR/omwg_dev/issues/6 (PS: coordinate settings for hycom1 still need to be done manually)

This pull request modifies the answers, and I have confirmed that we can compare it bit-for-bit with [2024.015](https://github.com/NCAR/omwg_dev/issues/14) without any additional namelist changes. 