### PR TITLE
Facilitate hybrid runs

### DIFF
--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -217,6 +217,30 @@ def _copy_input_files(case, dest_dir, inst_suffixes):
     ]:
         shutil.copy(os.path.join(rundir, filename), dest_dir)
 
+def prechecks(case, inst_suffixes):
+    """Performs prechecks to ensure that necessary restart files and rpointer files are present in rundir."""
+
+    rundir = case.get_value("RUNDIR")
+    run_type = case.get_value("RUN_TYPE")
+    continue_run = case.get_value("CONTINUE_RUN")
+    get_refcase = case.get_value("GET_REFCASE")
+    run_refcase = case.get_value("RUN_REFCASE")
+    run_refdate = case.get_value("RUN_REFDATE")
+    run_reftod = case.get_value("RUN_REFTOD")
+
+    # check if rpointer files are present in rundir
+    if run_type != "startup" or continue_run:
+        for inst_suffix in inst_suffixes:
+            pointer_file = os.path.join(rundir, "rpointer.ocn" + inst_suffix)
+            expect(
+                os.path.exists(pointer_file),
+                f"Missing rpointer file rpointer.ocn{inst_suffix} in rundir.",
+            )
+        
+    # check if the restart file is present in rundir
+    if run_type in ["branch", "hybrid"] and not continue_run and not get_refcase:
+        restart_file = os.path.join(rundir, f'./{run_refcase}.mom6.r.{run_refdate}-{run_reftod}.nc')
+        assert os.path.exists(restart_file), f"Missing restart file {run_refcase}.mom6.r.{run_refdate}-{run_reftod}.nc in rundir."
 
 # pylint: disable=unused-argument
 ###############################################################################
@@ -232,6 +256,9 @@ def buildnml(case, caseroot, compname):
     inst_suffixes = (
         ["_{:04d}".format(i + 1) for i in range(ninst)] if ninst > 1 else [""]
     )
+
+    # prechecks
+    prechecks(case, inst_suffixes)
 
     # prepare all input files
     prep_input(case, inst_suffixes)

--- a/param_templates/MOM_input.yaml
+++ b/param_templates/MOM_input.yaml
@@ -526,10 +526,10 @@ Global:
         datatype: logical
         units: Boolean
         value:
-            $OCN_GRID == "gx1v6": True
-            $OCN_GRID == "tx0.66v1": True
-            $OCN_GRID == "tx2_3v2": True
-            $OCN_GRID == "tx0.25v1": True
+            $RUN_TYPE != "hybrid" or $CONTINUE_RUN == True and $OCN_GRID in ["gx1v6", "tx0.66v1", "tx2_3v2", "tx0.25v1"]:
+                True
+            else:
+                False
     TEMP_SALT_Z_INIT_FILE:
         description: |
             "default = 'temp_salt_z.nc'
@@ -3006,7 +3006,16 @@ Global:
             USER - call a user modified routine."
         datatype: string
         value:
-            $OCN_GRID == "MISOMIP": "ISOMIP"
+            $RUN_TYPE == "hybrid" and $CONTINUE_RUN == False: 
+                "thickness_file"
+            else:
+                $OCN_GRID == "MISOMIP": "ISOMIP"
+    THICKNESS_FILE:
+        description: "The name of the thickness file"
+        datatype: string
+        value:
+            $RUN_TYPE == "hybrid" and $CONTINUE_RUN == False:
+                = f'./{$RUN_REFCASE}.mom6.r.{$RUN_REFDATE}-{$RUN_REFTOD}.nc'
     SPONGE_CONFIG:
         description: |
             "default = 'file'
@@ -3054,7 +3063,45 @@ Global:
             USER - call a user modified routine."
         datatype: string
         value:
-            $OCN_GRID == "MISOMIP": "ISOMIP"
+            $RUN_TYPE == "hybrid" and $CONTINUE_RUN == False:
+                "file"
+            else:
+                $OCN_GRID == "MISOMIP": "ISOMIP"
+    TS_FILE:
+        description: "The initial condition file for the temperature and salinity."
+        datatype: string
+        value:
+            $RUN_TYPE == "hybrid" and $CONTINUE_RUN == False: 
+                = f'./{$RUN_REFCASE}.mom6.r.{$RUN_REFDATE}-{$RUN_REFTOD}.nc'
+    TEMP_IC_VAR:
+        description: "The initial condition variable for potential temperature"
+        datatype: string
+        value:
+            $RUN_TYPE == "hybrid" and $CONTINUE_RUN == False: "Temp"
+    SALT_IC_VAR:
+        description: "The initial condition variable for the salinity."
+        datatype: string
+        value:
+            $RUN_TYPE == "hybrid" and $CONTINUE_RUN == False: "Salt"
+    VELOCITY_CONFIG:
+        description: "A string that determines how the initial velocities are specified for a new run."
+        datatype: string
+        value:
+            $RUN_TYPE == "hybrid" and $CONTINUE_RUN == False: "file"
+    VELOCITY_FILE:
+        description: "The name of the velocity initial condition file."
+        datatype: string
+        value:
+            $RUN_TYPE == "hybrid" and $CONTINUE_RUN == False:
+                = f'./{$RUN_REFCASE}.mom6.r.{$RUN_REFDATE}-{$RUN_REFTOD}.nc'
+    AGE_IC_FILE:
+        description: |
+            "The file in which the age-tracer initial values can be found, or an empty
+            string for internal initialization."
+        datatype: string
+        value:
+            $RUN_TYPE == "hybrid" and $CONTINUE_RUN == False:
+                = f'./{$RUN_REFCASE}.mom6.r.{$RUN_REFDATE}-{$RUN_REFTOD}.nc'
     T_REF:
         description: |
             "[degC]

--- a/param_templates/MOM_input.yaml
+++ b/param_templates/MOM_input.yaml
@@ -526,7 +526,7 @@ Global:
         datatype: logical
         units: Boolean
         value:
-            $RUN_TYPE != "hybrid" or $CONTINUE_RUN == True and $OCN_GRID in ["gx1v6", "tx0.66v1", "tx2_3v2", "tx0.25v1"]:
+            $RUN_TYPE != "hybrid" and $OCN_GRID in ["gx1v6", "tx0.66v1", "tx2_3v2", "tx0.25v1"]:
                 True
             else:
                 False
@@ -3006,7 +3006,7 @@ Global:
             USER - call a user modified routine."
         datatype: string
         value:
-            $RUN_TYPE == "hybrid" and $CONTINUE_RUN == False: 
+            $RUN_TYPE == "hybrid":
                 "thickness_file"
             else:
                 $OCN_GRID == "MISOMIP": "ISOMIP"
@@ -3014,7 +3014,7 @@ Global:
         description: "The name of the thickness file"
         datatype: string
         value:
-            $RUN_TYPE == "hybrid" and $CONTINUE_RUN == False:
+            $RUN_TYPE == "hybrid":
                 = f'./{$RUN_REFCASE}.mom6.r.{$RUN_REFDATE}-{$RUN_REFTOD}.nc'
     SPONGE_CONFIG:
         description: |
@@ -3063,7 +3063,7 @@ Global:
             USER - call a user modified routine."
         datatype: string
         value:
-            $RUN_TYPE == "hybrid" and $CONTINUE_RUN == False:
+            $RUN_TYPE == "hybrid":
                 "file"
             else:
                 $OCN_GRID == "MISOMIP": "ISOMIP"
@@ -3071,28 +3071,28 @@ Global:
         description: "The initial condition file for the temperature and salinity."
         datatype: string
         value:
-            $RUN_TYPE == "hybrid" and $CONTINUE_RUN == False: 
+            $RUN_TYPE == "hybrid":
                 = f'./{$RUN_REFCASE}.mom6.r.{$RUN_REFDATE}-{$RUN_REFTOD}.nc'
     TEMP_IC_VAR:
         description: "The initial condition variable for potential temperature"
         datatype: string
         value:
-            $RUN_TYPE == "hybrid" and $CONTINUE_RUN == False: "Temp"
+            $RUN_TYPE == "hybrid": "Temp"
     SALT_IC_VAR:
         description: "The initial condition variable for the salinity."
         datatype: string
         value:
-            $RUN_TYPE == "hybrid" and $CONTINUE_RUN == False: "Salt"
+            $RUN_TYPE == "hybrid": "Salt"
     VELOCITY_CONFIG:
         description: "A string that determines how the initial velocities are specified for a new run."
         datatype: string
         value:
-            $RUN_TYPE == "hybrid" and $CONTINUE_RUN == False: "file"
+            $RUN_TYPE == "hybrid": "file"
     VELOCITY_FILE:
         description: "The name of the velocity initial condition file."
         datatype: string
         value:
-            $RUN_TYPE == "hybrid" and $CONTINUE_RUN == False:
+            $RUN_TYPE == "hybrid":
                 = f'./{$RUN_REFCASE}.mom6.r.{$RUN_REFDATE}-{$RUN_REFTOD}.nc'
     AGE_IC_FILE:
         description: |

--- a/param_templates/json/MOM_input.json
+++ b/param_templates/json/MOM_input.json
@@ -373,7 +373,7 @@
          "datatype": "logical",
          "units": "Boolean",
          "value": {
-            "$RUN_TYPE != \"hybrid\" or $CONTINUE_RUN == True and $OCN_GRID in [\"gx1v6\", \"tx0.66v1\", \"tx2_3v2\", \"tx0.25v1\"]": true,
+            "$RUN_TYPE != \"hybrid\" and $OCN_GRID in [\"gx1v6\", \"tx0.66v1\", \"tx2_3v2\", \"tx0.25v1\"]": true,
             "else": false
          }
       },
@@ -2403,7 +2403,7 @@
          "description": "\"A string that determines how the initial layer\nthicknesses are specified for a new run:\nfile - read interface heights from the file specified\nthickness_file - read thicknesses from the file specified\nby (THICKNESS_FILE).\ncoord - determined by ALE coordinate.\nuniform - uniform thickness layers evenly distributed\nbetween the surface and MAXIMUM_DEPTH.\nDOME - use a slope and channel configuration for the\nDOME sill-overflow test case.\nISOMIP - use a configuration for the\nISOMIP test case.\nbenchmark - use the benchmark test case thicknesses.\nsearch - search a density profile for the interface\ndensities. This is not yet implemented.\ncircle_obcs - the circle_obcs test case is used.\nDOME2D - 2D version of DOME initialization.\nadjustment2d - TBD AJA.\nsloshing - TBD AJA.\nseamount - TBD AJA.\nrossby_front - a mixed layer front in thermal wind balance.\nUSER - call a user modified routine.\"\n",
          "datatype": "string",
          "value": {
-            "$RUN_TYPE == \"hybrid\" and $CONTINUE_RUN == False": "thickness_file",
+            "$RUN_TYPE == \"hybrid\"": "thickness_file",
             "else": {
                "$OCN_GRID == \"MISOMIP\"": "ISOMIP"
             }
@@ -2413,7 +2413,7 @@
          "description": "The name of the thickness file",
          "datatype": "string",
          "value": {
-            "$RUN_TYPE == \"hybrid\" and $CONTINUE_RUN == False": "= f'./{$RUN_REFCASE}.mom6.r.{$RUN_REFDATE}-{$RUN_REFTOD}.nc'"
+            "$RUN_TYPE == \"hybrid\"": "= f'./{$RUN_REFCASE}.mom6.r.{$RUN_REFDATE}-{$RUN_REFTOD}.nc'"
          }
       },
       "SPONGE_CONFIG": {
@@ -2442,7 +2442,7 @@
          "description": "\"A string that determines how the initial tempertures\nand salinities are specified for a new run:\nfile - read velocities from the file specified\nby (TS_FILE).\nfit - find the temperatures that are consistent with\nthe layer densities and salinity S_REF.\nTS_profile - use temperature and salinity profiles\n(read from TS_FILE) to set layer densities.\nbenchmark - use the benchmark test case T & S.\nlinear - linear in logical layer space.\nDOME2D - 2D DOME initialization.\nISOMIP - ISOMIP initialization.\nadjustment2d - TBD AJA.\nsloshing - TBD AJA.\nseamount - TBD AJA.\nrossby_front - a mixed layer front in thermal wind balance.\nSCM_ideal_hurr - used in the SCM idealized hurricane test.\nUSER - call a user modified routine.\"\n",
          "datatype": "string",
          "value": {
-            "$RUN_TYPE == \"hybrid\" and $CONTINUE_RUN == False": "file",
+            "$RUN_TYPE == \"hybrid\"": "file",
             "else": {
                "$OCN_GRID == \"MISOMIP\"": "ISOMIP"
             }
@@ -2452,35 +2452,35 @@
          "description": "The initial condition file for the temperature and salinity.",
          "datatype": "string",
          "value": {
-            "$RUN_TYPE == \"hybrid\" and $CONTINUE_RUN == False": "= f'./{$RUN_REFCASE}.mom6.r.{$RUN_REFDATE}-{$RUN_REFTOD}.nc'"
+            "$RUN_TYPE == \"hybrid\"": "= f'./{$RUN_REFCASE}.mom6.r.{$RUN_REFDATE}-{$RUN_REFTOD}.nc'"
          }
       },
       "TEMP_IC_VAR": {
          "description": "The initial condition variable for potential temperature",
          "datatype": "string",
          "value": {
-            "$RUN_TYPE == \"hybrid\" and $CONTINUE_RUN == False": "Temp"
+            "$RUN_TYPE == \"hybrid\"": "Temp"
          }
       },
       "SALT_IC_VAR": {
          "description": "The initial condition variable for the salinity.",
          "datatype": "string",
          "value": {
-            "$RUN_TYPE == \"hybrid\" and $CONTINUE_RUN == False": "Salt"
+            "$RUN_TYPE == \"hybrid\"": "Salt"
          }
       },
       "VELOCITY_CONFIG": {
          "description": "A string that determines how the initial velocities are specified for a new run.",
          "datatype": "string",
          "value": {
-            "$RUN_TYPE == \"hybrid\" and $CONTINUE_RUN == False": "file"
+            "$RUN_TYPE == \"hybrid\"": "file"
          }
       },
       "VELOCITY_FILE": {
          "description": "The name of the velocity initial condition file.",
          "datatype": "string",
          "value": {
-            "$RUN_TYPE == \"hybrid\" and $CONTINUE_RUN == False": "= f'./{$RUN_REFCASE}.mom6.r.{$RUN_REFDATE}-{$RUN_REFTOD}.nc'"
+            "$RUN_TYPE == \"hybrid\"": "= f'./{$RUN_REFCASE}.mom6.r.{$RUN_REFDATE}-{$RUN_REFTOD}.nc'"
          }
       },
       "AGE_IC_FILE": {

--- a/param_templates/json/MOM_input.json
+++ b/param_templates/json/MOM_input.json
@@ -373,10 +373,8 @@
          "datatype": "logical",
          "units": "Boolean",
          "value": {
-            "$OCN_GRID == \"gx1v6\"": true,
-            "$OCN_GRID == \"tx0.66v1\"": true,
-            "$OCN_GRID == \"tx2_3v2\"": true,
-            "$OCN_GRID == \"tx0.25v1\"": true
+            "$RUN_TYPE != \"hybrid\" or $CONTINUE_RUN == True and $OCN_GRID in [\"gx1v6\", \"tx0.66v1\", \"tx2_3v2\", \"tx0.25v1\"]": true,
+            "else": false
          }
       },
       "TEMP_SALT_Z_INIT_FILE": {
@@ -2405,7 +2403,17 @@
          "description": "\"A string that determines how the initial layer\nthicknesses are specified for a new run:\nfile - read interface heights from the file specified\nthickness_file - read thicknesses from the file specified\nby (THICKNESS_FILE).\ncoord - determined by ALE coordinate.\nuniform - uniform thickness layers evenly distributed\nbetween the surface and MAXIMUM_DEPTH.\nDOME - use a slope and channel configuration for the\nDOME sill-overflow test case.\nISOMIP - use a configuration for the\nISOMIP test case.\nbenchmark - use the benchmark test case thicknesses.\nsearch - search a density profile for the interface\ndensities. This is not yet implemented.\ncircle_obcs - the circle_obcs test case is used.\nDOME2D - 2D version of DOME initialization.\nadjustment2d - TBD AJA.\nsloshing - TBD AJA.\nseamount - TBD AJA.\nrossby_front - a mixed layer front in thermal wind balance.\nUSER - call a user modified routine.\"\n",
          "datatype": "string",
          "value": {
-            "$OCN_GRID == \"MISOMIP\"": "ISOMIP"
+            "$RUN_TYPE == \"hybrid\" and $CONTINUE_RUN == False": "thickness_file",
+            "else": {
+               "$OCN_GRID == \"MISOMIP\"": "ISOMIP"
+            }
+         }
+      },
+      "THICKNESS_FILE": {
+         "description": "The name of the thickness file",
+         "datatype": "string",
+         "value": {
+            "$RUN_TYPE == \"hybrid\" and $CONTINUE_RUN == False": "= f'./{$RUN_REFCASE}.mom6.r.{$RUN_REFDATE}-{$RUN_REFTOD}.nc'"
          }
       },
       "SPONGE_CONFIG": {
@@ -2434,7 +2442,52 @@
          "description": "\"A string that determines how the initial tempertures\nand salinities are specified for a new run:\nfile - read velocities from the file specified\nby (TS_FILE).\nfit - find the temperatures that are consistent with\nthe layer densities and salinity S_REF.\nTS_profile - use temperature and salinity profiles\n(read from TS_FILE) to set layer densities.\nbenchmark - use the benchmark test case T & S.\nlinear - linear in logical layer space.\nDOME2D - 2D DOME initialization.\nISOMIP - ISOMIP initialization.\nadjustment2d - TBD AJA.\nsloshing - TBD AJA.\nseamount - TBD AJA.\nrossby_front - a mixed layer front in thermal wind balance.\nSCM_ideal_hurr - used in the SCM idealized hurricane test.\nUSER - call a user modified routine.\"\n",
          "datatype": "string",
          "value": {
-            "$OCN_GRID == \"MISOMIP\"": "ISOMIP"
+            "$RUN_TYPE == \"hybrid\" and $CONTINUE_RUN == False": "file",
+            "else": {
+               "$OCN_GRID == \"MISOMIP\"": "ISOMIP"
+            }
+         }
+      },
+      "TS_FILE": {
+         "description": "The initial condition file for the temperature and salinity.",
+         "datatype": "string",
+         "value": {
+            "$RUN_TYPE == \"hybrid\" and $CONTINUE_RUN == False": "= f'./{$RUN_REFCASE}.mom6.r.{$RUN_REFDATE}-{$RUN_REFTOD}.nc'"
+         }
+      },
+      "TEMP_IC_VAR": {
+         "description": "The initial condition variable for potential temperature",
+         "datatype": "string",
+         "value": {
+            "$RUN_TYPE == \"hybrid\" and $CONTINUE_RUN == False": "Temp"
+         }
+      },
+      "SALT_IC_VAR": {
+         "description": "The initial condition variable for the salinity.",
+         "datatype": "string",
+         "value": {
+            "$RUN_TYPE == \"hybrid\" and $CONTINUE_RUN == False": "Salt"
+         }
+      },
+      "VELOCITY_CONFIG": {
+         "description": "A string that determines how the initial velocities are specified for a new run.",
+         "datatype": "string",
+         "value": {
+            "$RUN_TYPE == \"hybrid\" and $CONTINUE_RUN == False": "file"
+         }
+      },
+      "VELOCITY_FILE": {
+         "description": "The name of the velocity initial condition file.",
+         "datatype": "string",
+         "value": {
+            "$RUN_TYPE == \"hybrid\" and $CONTINUE_RUN == False": "= f'./{$RUN_REFCASE}.mom6.r.{$RUN_REFDATE}-{$RUN_REFTOD}.nc'"
+         }
+      },
+      "AGE_IC_FILE": {
+         "description": "\"The file in which the age-tracer initial values can be found, or an empty\nstring for internal initialization.\"\n",
+         "datatype": "string",
+         "value": {
+            "$RUN_TYPE == \"hybrid\" and $CONTINUE_RUN == False": "= f'./{$RUN_REFCASE}.mom6.r.{$RUN_REFDATE}-{$RUN_REFTOD}.nc'"
          }
       },
       "T_REF": {


### PR DESCRIPTION
This PR adds several pre checks for hybrid runs and introduces/modified MOM_input parameters to facilitate hybrid CESM runs. The modified parameters are mainly the IC file names, which are now automatically set to the restart files of the reference case specified via xml commands.

This PR should be evaluated in conjunction with https://github.com/NCAR/MOM6/pull/273

Usage:

The users can now run hybrid CESM-MOM6 runs by setting the following xml variables:

    ./xmlchange RUN_TYPE=hybrid
    ./xmlchange RUN_REFCASE= ??? (the reference case name, e.g., g.e23.GMOM_JRA.base.001)
    ./xmlchange RUN_REFDATE=??? (e.g., 0001-01-06)
    ./xmlchange RUN_REFTOD=??? (the default is  00000 )

After setting the above xml variables, the MOM_input file will automatically be updated to run a hybrid case. Optionally, the following may be set to automatically link the necessary restart file:

    ./xmlchange RUN_REFDIR=??? ( the rest/ directory in short term archive path)
    ./xmlchange GET_REFCASE=True