### PR TITLE
Introduce GEOM_FILE parameter

### DIFF
--- a/cime_config/config_archive.xml
+++ b/cime_config/config_archive.xml
@@ -7,6 +7,7 @@
     <!-- match filenames of the form
          h.static[._optional instance number].nc[.optional tile number] -->
     <hist_file_extension>h\.static(\._\d*)?\.nc(\.\d*)?$</hist_file_extension>
+    <hist_file_extension>h\.ocean_geometry\.nc(\.\d*)?$</hist_file_extension>
     <!-- Match hist extension (i.e., stream name), used to identify last file
          in each stream in baseline generation within testing -->
     <hist_file_ext_regex>\w+\.\w+(\._\d*)?</hist_file_ext_regex>

--- a/param_templates/MOM_input.yaml
+++ b/param_templates/MOM_input.yaml
@@ -3610,7 +3610,13 @@ Global:
         datatype: list
         value:
             $OCN_GRID in ["tx0.66v1", "tx2_3v2", "tx0.25v1"]: True
-
+    GEOM_FILE:
+        description: |
+            default = ocean_geometry.nc
+            The file into which to write the ocean geometry.
+        datatype: string
+        value:
+            $CASE.mom6.h.ocean_geometry.nc
 
 KPP:
     N_SMOOTH:

--- a/param_templates/json/MOM_input.json
+++ b/param_templates/json/MOM_input.json
@@ -2936,6 +2936,11 @@
          "value": {
             "$OCN_GRID in [\"tx0.66v1\", \"tx2_3v2\", \"tx0.25v1\"]": true
          }
+      },
+      "GEOM_FILE": {
+         "description": "default = ocean_geometry.nc\nThe file into which to write the ocean geometry.\n",
+         "datatype": "string",
+         "value": "$CASE.mom6.h.ocean_geometry.nc"
       }
    },
    "KPP": {


### PR DESCRIPTION
This PR adds a new runtime parameter GEOM_FILE that controls the name of the ocean_geometry file. By default, this file name is now prepended by the case name to short term archive these files.

This PR should be evaluated in conjunction with https://github.com/NCAR/MOM6/pull/278