### PR TITLE
*New baselines for tx2_3v2 05/03/2024  

### DIFF
--- a/cime_config/config_component.xml
+++ b/cime_config/config_component.xml
@@ -42,7 +42,7 @@
 
   <entry id="MOM6_VERTICAL_GRID">
     <type>char</type>
-    <valid_values>zstar_65L,hycom1,zstar_60L,sigma_shelf_zstar</valid_values>
+    <valid_values>zstar_75L,zstar_65L,hycom1,zstar_60L,sigma_shelf_zstar</valid_values>
     <default_value>zstar_65L</default_value>
     <values>
       <value grid="oi%tx0.25v1">hycom1</value>

--- a/param_templates/MOM_input.yaml
+++ b/param_templates/MOM_input.yaml
@@ -3558,7 +3558,7 @@ Global:
             "TODO"
         datatype: string
         value:
-            $MOM6_VERTICAL_GRID == "hycom1" and $OCN_GRID != "tx0.25v1": "PPM_CW"
+            $OCN_GRID == "tx2_3v2": "PPM_CW"
             $MOM6_VERTICAL_GRID == "MISOMIP": "PPM_H4"
     MLE_USE_PBL_MLD:
         description: |

--- a/param_templates/MOM_input.yaml
+++ b/param_templates/MOM_input.yaml
@@ -2664,7 +2664,7 @@ Global:
         value:
             $OCN_GRID == "tx0.25v1": "MOM_channels_global_025"
             $OCN_GRID == "tx0.66v1": "MOM_channels_global_tx06v1"
-            $OCN_GRID == "tx2_3v2":  "MOM_channels_global_tx2_3v2"
+            $OCN_GRID == "tx2_3v2":  "MOM_channels_global_tx2_3v2_240501"
     SMAG_BI_CONST:
         description: |
             "[nondim] default = 0.0

--- a/param_templates/MOM_input.yaml
+++ b/param_templates/MOM_input.yaml
@@ -3558,8 +3558,8 @@ Global:
             "TODO"
         datatype: string
         value:
-            $OCN_GRID == "tx2_3v2": "PPM_CW"
             $MOM6_VERTICAL_GRID == "MISOMIP": "PPM_H4"
+            else: "PPM_CW"
     MLE_USE_PBL_MLD:
         description: |
             "TODO"

--- a/param_templates/MOM_input.yaml
+++ b/param_templates/MOM_input.yaml
@@ -2505,8 +2505,7 @@ Global:
         datatype: real
         units: nondim
         value:
-            $COMP_ATM == "cam": 0.10
-            else: 0.09
+            $OCN_GRID == "tx2_3v2": 0.09
     MEKE_KHTH_FAC:
         description: |
             "[nondim] default = 0.0

--- a/param_templates/MOM_input.yaml
+++ b/param_templates/MOM_input.yaml
@@ -666,6 +666,15 @@ Global:
             $OCN_GRID == "tx0.66v1": True
             $OCN_GRID == "tx2_3v2": True
             $OCN_GRID == "tx0.25v1": True
+    RESOLN_SCALED_KHTR:
+        description: |
+            "[Boolean] default = False
+            If true, the epipycnal tracer diffusivity is scaled away when the first
+            baroclinic deformation radius is well resolved."
+        datatype: logical
+        units: Boolean
+        value:
+            $OCN_GRID == "tx2_3v2": True
     USE_GM_WORK_BUG:
         description: |
             "[Boolean] default = True
@@ -2325,7 +2334,7 @@ Global:
             $OCN_GRID == "gx1v6": 0.0
             $OCN_GRID == "tx0.25v1": 1.0
             $OCN_GRID == "tx0.66v1": 0.0
-            $OCN_GRID == "tx2_3v2": 0.0
+            $OCN_GRID == "tx2_3v2": 1.0
     MEKE_BGSRC:
         description: |
             "[W kg-1] default = 0.0
@@ -2343,7 +2352,7 @@ Global:
         value:
             $OCN_GRID == "tx0.25v1": 1.0
             $OCN_GRID == "tx0.66v1": 0.5
-            $OCN_GRID == "tx2_3v2": 0.5
+            $OCN_GRID == "tx2_3v2": 0.75
             $OCN_GRID == "gx1v6": 0.5
     MEKE_VISCOSITY_COEFF_KU:
         description: |
@@ -2355,7 +2364,7 @@ Global:
         units: nondim
         value:
             $OCN_GRID == "tx0.66v1": 0.2
-            $OCN_GRID == "tx2_3v2": 0.2
+            $OCN_GRID == "tx2_3v2": 0.0
             $OCN_GRID == "gx1v6": 0.2
     MEKE_MIN_LSCALE:
         description: |
@@ -2434,7 +2443,16 @@ Global:
         units: nondim
         value:
             $OCN_GRID == "tx0.66v1": -1.0
-            $OCN_GRID == "tx2_3v2": -1.0
+            $OCN_GRID == "tx2_3v2": 0.3
+    USE_SIMPLER_EADY_GROWTH_RATE:
+        description: |
+            "[Boolean] default = False
+            If true, use a simpler method to calculate the Eady growth rate that avoids
+            division by layer thickness. Recommended."
+        datatype: logical
+        units: Boolean
+        value:
+            $OCN_GRID == "tx2_3v2": True
     KH_RES_SCALE_COEF:
         description: |
             "[nondim] default = 1.0
@@ -2444,8 +2462,18 @@ Global:
         units: nondim
         value:
             $OCN_GRID == "tx0.66v1": 0.4
-            $OCN_GRID == "tx2_3v2": 0.4
+            $OCN_GRID == "tx2_3v2": 0.9
             $OCN_GRID == "gx1v6": 0.4
+    KH_RES_FN_POWER:
+        description: |
+            "[nondim] default = 2
+            The power of dx/Ld in the Kh resolution function.  Any positive integer may be
+            used, although even integers are more efficient to calculate.  Setting this
+            greater than 100 results in a step-function being used."
+        datatype: integer
+        units: nondim
+        value:
+            $OCN_GRID == "tx2_3v2": 6
     VISC_RES_SCALE_COEF:
         description: |
             "[nondim] default = 1.0
@@ -2478,7 +2506,7 @@ Global:
         units: nondim
         value:
             $COMP_ATM == "cam": 0.10
-            else: 0.07
+            else: 0.09
     MEKE_KHTH_FAC:
         description: |
             "[nondim] default = 0.0
@@ -2499,6 +2527,32 @@ Global:
             $OCN_GRID == "tx0.66v1": 1.0
             $OCN_GRID == "tx2_3v2": 1.0
             $OCN_GRID == "gx1v6": 1.0
+    MEKE_CB:
+        description: |
+            "[nondim] default = 25.0
+            A coefficient in the expression for the ratio of bottom projected eddy energy
+            and mean column energy (see Jansen et al. 2015)."
+        datatype: real
+        units: nondim
+        value:
+            $OCN_GRID == "tx2_3v2": 100.0
+    MEKE_CDRAG:
+        description: |
+            "[nondim] default = 0.003
+            Drag coefficient relating the magnitude of the velocity field to the bottom
+            stress in MEKE."
+        datatype: real
+        units: nondim
+        value:
+            $OCN_GRID == "tx2_3v2": 0.0025
+    MEKE_MIN_GAMMA2:
+        description: |
+            "[nondim] default = 1.0E-04
+            The minimum allowed value of gamma_b^2."
+        datatype: real
+        units: nondim
+        value:
+            $OCN_GRID == "tx2_3v2": 1.0E-05
     MEKE_EQUILIBRIUM_ALT:
         description: |
             "[Boolean] default = False
@@ -2529,7 +2583,7 @@ Global:
         units: Boolean
         value:
             $OCN_GRID == "tx0.66v1": True
-            $OCN_GRID == "tx2_3v2": True
+            $OCN_GRID == "tx2_3v2": False
             $OCN_GRID == "gx1v6": True
     MEKE_RESTORING_TIMESCALE:
         description: |

--- a/param_templates/MOM_input.yaml
+++ b/param_templates/MOM_input.yaml
@@ -516,7 +516,7 @@ Global:
             PQM_IH4IH3  (4th-order accurate)
             PQM_IH6IH5  (5th-order accurate)"
         datatype: string
-        value: "PPM_H4"
+        value: "PPM_CW"
     INIT_LAYERS_FROM_Z_FILE:
         description: |
             "[Boolean] default = False
@@ -1568,6 +1568,7 @@ Global:
         datatype: real
         units: m2 s-1
         value:
+            $OCN_GRID == "tx2_3v2": 0.0
             $OCN_GRID == "tx0.25v1": 1.5E-05
             $OCN_GRID == "MISOMIP": 5.0E-05
             else: 2.0E-05
@@ -1602,7 +1603,7 @@ Global:
         value:
             $OCN_GRID == "gx1v6": 2.0E-06
             $OCN_GRID == "tx0.66v1": 2.0E-06
-            $OCN_GRID == "tx2_3v2": 2.0E-06
+            $OCN_GRID == "tx2_3v2":  2.0E-07
             $OCN_GRID == "tx0.25v1": 2.0E-06
     INT_TIDE_DECAY_SCALE:
         description: |
@@ -3174,6 +3175,15 @@ Global:
         units: m
         value:
             $OCN_GRID == "MISOMIP": 20.0
+    KV:
+        description: |
+            "[m2 s-1]
+            kinematic viscosity in the interior. The molecular value, ~1e-6
+            m2 s-1, may be used."
+        datatype: real
+        units: m2 s-1
+        value:
+            $OCN_GRID == "tx2_3v2": 0.0
     KV_BBL_MIN:
         description: |
             "[m2 s-1] default = 1.0E-04
@@ -3484,7 +3494,7 @@ Global:
             "TODO"
         datatype: string
         value:
-            $MOM6_VERTICAL_GRID == "hycom1" and $OCN_GRID != "tx0.25v1": "P1M_H2"
+            $MOM6_VERTICAL_GRID == "hycom1" and $OCN_GRID != "tx0.25v1": "PPM_CW"
             $MOM6_VERTICAL_GRID == "MISOMIP": "PPM_H4"
     MLE_USE_PBL_MLD:
         description: |

--- a/param_templates/MOM_input.yaml
+++ b/param_templates/MOM_input.yaml
@@ -110,7 +110,7 @@ Global:
         value:
             $MOM6_VERTICAL_GRID == "zstar_60L": 60
             $MOM6_VERTICAL_GRID == "zstar_65L": 65
-            $MOM6_VERTICAL_GRID == "hycom1": 75
+            $MOM6_VERTICAL_GRID == "hycom1" or $MOM6_VERTICAL_GRID == "zstar_75L": 75
             $MOM6_VERTICAL_GRID == "sigma_shelf_zstar": 36
     USE_LEGACY_DIABATIC_DRIVER:
         description: |
@@ -802,7 +802,7 @@ Global:
             ADAPTIVE - optimize for smooth neutral density surfaces"
         datatype: string
         value:
-            $MOM6_VERTICAL_GRID == "zstar_65L" or $MOM6_VERTICAL_GRID == "zstar_60L": "Z*"
+            $MOM6_VERTICAL_GRID == "zstar_65L" or $MOM6_VERTICAL_GRID == "zstar_60L" or $MOM6_VERTICAL_GRID == "zstar_75L": "Z*"
             $MOM6_VERTICAL_GRID == "hycom1": "HYCOM1"
             $MOM6_VERTICAL_GRID == "sigma_shelf_zstar": "SIGMA_SHELF_ZSTAR"
     ALE_COORDINATE_CONFIG:
@@ -824,6 +824,7 @@ Global:
             HYBRID:vgrid.nc,sigma2,dz"
         datatype: string
         value:
+            $MOM6_VERTICAL_GRID == "zstar_65L": '"FILE:zstar_75layer_2.5m_248.4m-2024-03-29.nc,dz"'
             $MOM6_VERTICAL_GRID == "zstar_65L": '"FILE:vgrid_65L_20200626.nc,dz"'
             $MOM6_VERTICAL_GRID == "zstar_60L": '"FILE:ocean_vgrid.nc,dz"'
             $MOM6_VERTICAL_GRID == "hycom1" and $OCN_GRID != "tx0.25v1": '"HYBRID:hybrid_75layer_zstar2.50m-2020-11-23.nc,sigma2,dz"'

--- a/param_templates/MOM_input.yaml
+++ b/param_templates/MOM_input.yaml
@@ -463,7 +463,7 @@ Global:
         value:
             $OCN_GRID == "gx1v6": "ocean_topog_230424.nc"
             $OCN_GRID == "tx0.66v1": "ocean_topog_200701.nc"
-            $OCN_GRID == "tx2_3v2": "ocean_topog_230413.nc"
+            $OCN_GRID == "tx2_3v2": "ocean_topo_tx2_3v2_240501.nc"
             $OCN_GRID == "tx0.25v1": "ocean_topog.nc"
     MAXIMUM_DEPTH:
         description: |
@@ -2602,7 +2602,7 @@ Global:
             $OCN_GRID == "gx1v6": "global_1deg"
             $OCN_GRID == "tx0.25v1": "list"
             $OCN_GRID == "tx0.66v1": "list"
-            $OCN_GRID == "tx2_3v2": "none"
+            $OCN_GRID == "tx2_3v2": "list"
     CHANNEL_LIST_FILE:
         description: |
             "default = MOM_channel_list
@@ -2611,6 +2611,7 @@ Global:
         value:
             $OCN_GRID == "tx0.25v1": "MOM_channels_global_025"
             $OCN_GRID == "tx0.66v1": "MOM_channels_global_tx06v1"
+            $OCN_GRID == "tx2_3v2":  "MOM_channels_global_tx2_3v2"
     SMAG_BI_CONST:
         description: |
             "[nondim] default = 0.0
@@ -3036,6 +3037,16 @@ Global:
         units: m
         value:
             $OCN_GRID == "MISOMIP": 1.0E-12
+    HYCOM1_ONLY_IMPROVES:
+        description: |
+            "[Boolean] default = False
+             When regridding, an interface is only moved if this improves the fit to the
+             target density."
+        datatype: logical
+        units: Boolean
+        value:
+        value:
+            $MOM6_VERTICAL_GRID == "hycom1" and $OCN_GRID == "tx2_3v2": True
     ISOMIP_TNUDG:
         description: |
             "default = 0.0 (days)

--- a/param_templates/json/MOM_input.json
+++ b/param_templates/json/MOM_input.json
@@ -493,6 +493,14 @@
             "$OCN_GRID == \"tx0.25v1\"": true
          }
       },
+      "RESOLN_SCALED_KHTR": {
+         "description": "\"[Boolean] default = False\nIf true, the epipycnal tracer diffusivity is scaled away when the first\nbaroclinic deformation radius is well resolved.\"\n",
+         "datatype": "logical",
+         "units": "Boolean",
+         "value": {
+            "$OCN_GRID == \"tx2_3v2\"": true
+         }
+      },
       "USE_GM_WORK_BUG": {
          "description": "\"[Boolean] default = True\nIf true, compute the top-layer work tendency on the u-grid with the incorrect\nsign, for legacy reproducibility.\"\n",
          "datatype": "logical",
@@ -1833,7 +1841,7 @@
             "$OCN_GRID == \"gx1v6\"": 0.0,
             "$OCN_GRID == \"tx0.25v1\"": 1.0,
             "$OCN_GRID == \"tx0.66v1\"": 0.0,
-            "$OCN_GRID == \"tx2_3v2\"": 0.0
+            "$OCN_GRID == \"tx2_3v2\"": 1.0
          }
       },
       "MEKE_BGSRC": {
@@ -1851,7 +1859,7 @@
          "value": {
             "$OCN_GRID == \"tx0.25v1\"": 1.0,
             "$OCN_GRID == \"tx0.66v1\"": 0.5,
-            "$OCN_GRID == \"tx2_3v2\"": 0.5,
+            "$OCN_GRID == \"tx2_3v2\"": 0.75,
             "$OCN_GRID == \"gx1v6\"": 0.5
          }
       },
@@ -1861,7 +1869,7 @@
          "units": "nondim",
          "value": {
             "$OCN_GRID == \"tx0.66v1\"": 0.2,
-            "$OCN_GRID == \"tx2_3v2\"": 0.2,
+            "$OCN_GRID == \"tx2_3v2\"": 0.0,
             "$OCN_GRID == \"gx1v6\"": 0.2
          }
       },
@@ -1933,7 +1941,15 @@
          "units": "nondim",
          "value": {
             "$OCN_GRID == \"tx0.66v1\"": -1.0,
-            "$OCN_GRID == \"tx2_3v2\"": -1.0
+            "$OCN_GRID == \"tx2_3v2\"": 0.3
+         }
+      },
+      "USE_SIMPLER_EADY_GROWTH_RATE": {
+         "description": "\"[Boolean] default = False\nIf true, use a simpler method to calculate the Eady growth rate that avoids\ndivision by layer thickness. Recommended.\"\n",
+         "datatype": "logical",
+         "units": "Boolean",
+         "value": {
+            "$OCN_GRID == \"tx2_3v2\"": true
          }
       },
       "KH_RES_SCALE_COEF": {
@@ -1942,8 +1958,16 @@
          "units": "nondim",
          "value": {
             "$OCN_GRID == \"tx0.66v1\"": 0.4,
-            "$OCN_GRID == \"tx2_3v2\"": 0.4,
+            "$OCN_GRID == \"tx2_3v2\"": 0.9,
             "$OCN_GRID == \"gx1v6\"": 0.4
+         }
+      },
+      "KH_RES_FN_POWER": {
+         "description": "\"[nondim] default = 2\nThe power of dx/Ld in the Kh resolution function.  Any positive integer may be\nused, although even integers are more efficient to calculate.  Setting this\ngreater than 100 results in a step-function being used.\"\n",
+         "datatype": "integer",
+         "units": "nondim",
+         "value": {
+            "$OCN_GRID == \"tx2_3v2\"": 6
          }
       },
       "VISC_RES_SCALE_COEF": {
@@ -1972,7 +1996,7 @@
          "units": "nondim",
          "value": {
             "$COMP_ATM == \"cam\"": 0.1,
-            "else": 0.07
+            "else": 0.09
          }
       },
       "MEKE_KHTH_FAC": {
@@ -1993,6 +2017,30 @@
             "$OCN_GRID == \"tx0.66v1\"": 1.0,
             "$OCN_GRID == \"tx2_3v2\"": 1.0,
             "$OCN_GRID == \"gx1v6\"": 1.0
+         }
+      },
+      "MEKE_CB": {
+         "description": "\"[nondim] default = 25.0\nA coefficient in the expression for the ratio of bottom projected eddy energy\nand mean column energy (see Jansen et al. 2015).\"\n",
+         "datatype": "real",
+         "units": "nondim",
+         "value": {
+            "$OCN_GRID == \"tx2_3v2\"": 100.0
+         }
+      },
+      "MEKE_CDRAG": {
+         "description": "\"[nondim] default = 0.003\nDrag coefficient relating the magnitude of the velocity field to the bottom\nstress in MEKE.\"\n",
+         "datatype": "real",
+         "units": "nondim",
+         "value": {
+            "$OCN_GRID == \"tx2_3v2\"": 0.0025
+         }
+      },
+      "MEKE_MIN_GAMMA2": {
+         "description": "\"[nondim] default = 1.0E-04\nThe minimum allowed value of gamma_b^2.\"\n",
+         "datatype": "real",
+         "units": "nondim",
+         "value": {
+            "$OCN_GRID == \"tx2_3v2\"": 1e-05
          }
       },
       "MEKE_EQUILIBRIUM_ALT": {
@@ -2021,7 +2069,7 @@
          "units": "Boolean",
          "value": {
             "$OCN_GRID == \"tx0.66v1\"": true,
-            "$OCN_GRID == \"tx2_3v2\"": true,
+            "$OCN_GRID == \"tx2_3v2\"": false,
             "$OCN_GRID == \"gx1v6\"": true
          }
       },

--- a/param_templates/json/MOM_input.json
+++ b/param_templates/json/MOM_input.json
@@ -326,7 +326,7 @@
          "value": {
             "$OCN_GRID == \"gx1v6\"": "ocean_topog_230424.nc",
             "$OCN_GRID == \"tx0.66v1\"": "ocean_topog_200701.nc",
-            "$OCN_GRID == \"tx2_3v2\"": "ocean_topog_230413.nc",
+            "$OCN_GRID == \"tx2_3v2\"": "ocean_topo_tx2_3v2_240501.nc",
             "$OCN_GRID == \"tx0.25v1\"": "ocean_topog.nc"
          }
       },
@@ -2069,7 +2069,7 @@
             "$OCN_GRID == \"gx1v6\"": "global_1deg",
             "$OCN_GRID == \"tx0.25v1\"": "list",
             "$OCN_GRID == \"tx0.66v1\"": "list",
-            "$OCN_GRID == \"tx2_3v2\"": "none"
+            "$OCN_GRID == \"tx2_3v2\"": "list"
          }
       },
       "CHANNEL_LIST_FILE": {
@@ -2077,7 +2077,8 @@
          "datatype": "string",
          "value": {
             "$OCN_GRID == \"tx0.25v1\"": "MOM_channels_global_025",
-            "$OCN_GRID == \"tx0.66v1\"": "MOM_channels_global_tx06v1"
+            "$OCN_GRID == \"tx0.66v1\"": "MOM_channels_global_tx06v1",
+            "$OCN_GRID == \"tx2_3v2\"": "MOM_channels_global_tx2_3v2"
          }
       },
       "SMAG_BI_CONST": {
@@ -2432,6 +2433,14 @@
          "units": "m",
          "value": {
             "$OCN_GRID == \"MISOMIP\"": 1e-12
+         }
+      },
+      "HYCOM1_ONLY_IMPROVES": {
+         "description": "\"[Boolean] default = False\n When regridding, an interface is only moved if this improves the fit to the\n target density.\"\n",
+         "datatype": "logical",
+         "units": "Boolean",
+         "value": {
+            "$MOM6_VERTICAL_GRID == \"hycom1\" and $OCN_GRID == \"tx2_3v2\"": true
          }
       },
       "ISOMIP_TNUDG": {

--- a/param_templates/json/MOM_input.json
+++ b/param_templates/json/MOM_input.json
@@ -2887,7 +2887,7 @@
          "description": "\"TODO\"\n",
          "datatype": "string",
          "value": {
-            "$MOM6_VERTICAL_GRID == \"hycom1\" and $OCN_GRID != \"tx0.25v1\"": "PPM_CW",
+            "$OCN_GRID == \"tx2_3v2\"": "PPM_CW",
             "$MOM6_VERTICAL_GRID == \"MISOMIP\"": "PPM_H4"
          }
       },

--- a/param_templates/json/MOM_input.json
+++ b/param_templates/json/MOM_input.json
@@ -62,7 +62,7 @@
          "value": {
             "$MOM6_VERTICAL_GRID == \"zstar_60L\"": 60,
             "$MOM6_VERTICAL_GRID == \"zstar_65L\"": 65,
-            "$MOM6_VERTICAL_GRID == \"hycom1\"": 75,
+            "$MOM6_VERTICAL_GRID == \"hycom1\" or $MOM6_VERTICAL_GRID == \"zstar_75L\"": 75,
             "$MOM6_VERTICAL_GRID == \"sigma_shelf_zstar\"": 36
          }
       },
@@ -598,7 +598,7 @@
          "description": "\"default = 'LAYER'\nCoordinate mode for vertical regridding.\nChoose among the following possibilities:\nLAYER - Isopycnal or stacked shallow water layers\nZSTAR, Z* - stetched geopotential z*\nSIGMA_SHELF_ZSTAR - stetched geopotential z* ignoring shelf\nSIGMA - terrain following coordinates\nRHO   - continuous isopycnal\nHYCOM1 - HyCOM-like hybrid coordinate\nSLIGHT - stretched coordinates above continuous isopycnal\nADAPTIVE - optimize for smooth neutral density surfaces\"\n",
          "datatype": "string",
          "value": {
-            "$MOM6_VERTICAL_GRID == \"zstar_65L\" or $MOM6_VERTICAL_GRID == \"zstar_60L\"": "Z*",
+            "$MOM6_VERTICAL_GRID == \"zstar_65L\" or $MOM6_VERTICAL_GRID == \"zstar_60L\" or $MOM6_VERTICAL_GRID == \"zstar_75L\"": "Z*",
             "$MOM6_VERTICAL_GRID == \"hycom1\"": "HYCOM1",
             "$MOM6_VERTICAL_GRID == \"sigma_shelf_zstar\"": "SIGMA_SHELF_ZSTAR"
          }

--- a/param_templates/json/MOM_input.json
+++ b/param_templates/json/MOM_input.json
@@ -366,7 +366,7 @@
       "REMAPPING_SCHEME": {
          "description": "\"default = 'PLM'\nThis sets the reconstruction scheme used\nfor vertical remapping for all variables.\nIt can be one of the following schemes:\nPCM         (1st-order accurate)\nPLM         (2nd-order accurate)\nPPM_H4      (3rd-order accurate)\nPPM_IH4     (3rd-order accurate)\nPQM_IH4IH3  (4th-order accurate)\nPQM_IH6IH5  (5th-order accurate)\"\n",
          "datatype": "string",
-         "value": "PPM_H4"
+         "value": "PPM_CW"
       },
       "INIT_LAYERS_FROM_Z_FILE": {
          "description": "\"[Boolean] default = False\nIf true, intialize the layer thicknesses, temperatures,\nand salnities from a Z-space file on a latitude-\nlongitude grid.\"\n",
@@ -809,10 +809,12 @@
          "value": "V_velocity_truncations"
       },
       "KV": {
-         "description": "\"[m2 s-1]\nThe background kinematic viscosity in the interior.\nThe molecular value, ~1e-6 m2 s-1, may be used.\"\n",
+         "description": "\"[m2 s-1]\nkinematic viscosity in the interior. The molecular value, ~1e-6\nm2 s-1, may be used.\"\n",
          "datatype": "real",
          "units": "m2 s-1",
-         "value": 0.0001
+         "value": {
+            "$OCN_GRID == \"tx2_3v2\"": 0.0
+         }
       },
       "MAXVEL": {
          "description": "\"[m s-1] default = 3.0E+08\nThe maximum velocity allowed before the velocity\ncomponents are truncated.\"\n",
@@ -1175,6 +1177,7 @@
          "datatype": "real",
          "units": "m2 s-1",
          "value": {
+            "$OCN_GRID == \"tx2_3v2\"": 0.0,
             "$OCN_GRID == \"tx0.25v1\"": 1.5e-05,
             "$OCN_GRID == \"MISOMIP\"": 5e-05,
             "else": 2e-05
@@ -1203,7 +1206,7 @@
          "value": {
             "$OCN_GRID == \"gx1v6\"": 2e-06,
             "$OCN_GRID == \"tx0.66v1\"": 2e-06,
-            "$OCN_GRID == \"tx2_3v2\"": 2e-06,
+            "$OCN_GRID == \"tx2_3v2\"": 2e-07,
             "$OCN_GRID == \"tx0.25v1\"": 2e-06
          }
       },
@@ -2828,7 +2831,7 @@
          "description": "\"TODO\"\n",
          "datatype": "string",
          "value": {
-            "$MOM6_VERTICAL_GRID == \"hycom1\" and $OCN_GRID != \"tx0.25v1\"": "P1M_H2",
+            "$MOM6_VERTICAL_GRID == \"hycom1\" and $OCN_GRID != \"tx0.25v1\"": "PPM_CW",
             "$MOM6_VERTICAL_GRID == \"MISOMIP\"": "PPM_H4"
          }
       },

--- a/param_templates/json/MOM_input.json
+++ b/param_templates/json/MOM_input.json
@@ -2887,8 +2887,8 @@
          "description": "\"TODO\"\n",
          "datatype": "string",
          "value": {
-            "$OCN_GRID == \"tx2_3v2\"": "PPM_CW",
-            "$MOM6_VERTICAL_GRID == \"MISOMIP\"": "PPM_H4"
+            "$MOM6_VERTICAL_GRID == \"MISOMIP\"": "PPM_H4",
+            "else": "PPM_CW"
          }
       },
       "MLE_USE_PBL_MLD": {

--- a/param_templates/json/MOM_input.json
+++ b/param_templates/json/MOM_input.json
@@ -2125,7 +2125,7 @@
          "value": {
             "$OCN_GRID == \"tx0.25v1\"": "MOM_channels_global_025",
             "$OCN_GRID == \"tx0.66v1\"": "MOM_channels_global_tx06v1",
-            "$OCN_GRID == \"tx2_3v2\"": "MOM_channels_global_tx2_3v2"
+            "$OCN_GRID == \"tx2_3v2\"": "MOM_channels_global_tx2_3v2_240501"
          }
       },
       "SMAG_BI_CONST": {

--- a/param_templates/json/MOM_input.json
+++ b/param_templates/json/MOM_input.json
@@ -1995,8 +1995,7 @@
          "datatype": "real",
          "units": "nondim",
          "value": {
-            "$COMP_ATM == \"cam\"": 0.1,
-            "else": 0.09
+            "$OCN_GRID == \"tx2_3v2\"": 0.09
          }
       },
       "MEKE_KHTH_FAC": {


### PR DESCRIPTION
* Update MEKE settings, `RESOLN_SCALED_KHTR=True` and `USE_SIMPLER_EADY_GROWTH_RATE=True` (https://github.com/NCAR/omwg_dev/discussions/30);

* Update topography and channel widths (https://github.com/NCAR/omwg_dev/discussions/41; https://github.com/NCAR/omwg_dev/discussions/36);

* Set `KV=KD=0` and `KD_MIN=2.0E-07`;

* Add an optional zstar 75 layer grid (`MOM6_VERTICAL_GRID == "zstar_75L"`).

* Set `HYCOM1_ONLY_IMPROVES=True`;

* Set` INTERPOLATION_SCHEME = REMAPPING_SCHEME = VELOCITY_REMAPPING_SCHEME = "PPM_CW"`;