### PR TITLE
Add 2D heat transport terms due to horizontal boundary diffusion

### DIFF
--- a/param_templates/diag_table.yaml
+++ b/param_templates/diag_table.yaml
@@ -12,7 +12,8 @@ FieldLists:
 
     - &hist_additional  ["soga", "thetaoga", "uh", "vh", "vhbt", "uhbt"]
 
-    - &tracers          ["agessc", "T_ady_2d", "T_adx_2d", "T_diffy_2d", "T_diffx_2d"]
+    - &tracers          ["agessc", "T_ady_2d", "T_adx_2d", "T_diffy_2d", "T_diffx_2d",
+                         "T_hbd_diffx_2d", 'T_hbd_diffy_2d']
 
     - &surface_flds     ["SSH", "tos", "sos", "SSU", "SSV", "mass_wt", "opottempmint",
                          "somint", "Rd_dx", "speed", "mlotst"]

--- a/param_templates/json/diag_table.json
+++ b/param_templates/json/diag_table.json
@@ -38,7 +38,9 @@
          "T_ady_2d",
          "T_adx_2d",
          "T_diffy_2d",
-         "T_diffx_2d"
+         "T_diffx_2d",
+         "T_hbd_diffx_2d",
+         "T_hbd_diffy_2d"
       ],
       [
          "SSH",
@@ -249,7 +251,9 @@
                      "T_ady_2d",
                      "T_adx_2d",
                      "T_diffy_2d",
-                     "T_diffx_2d"
+                     "T_diffx_2d",
+                     "T_hbd_diffx_2d",
+                     "T_hbd_diffy_2d"
                   ],
                   [
                      "diftrelo",


### PR DESCRIPTION
These two terms (`T_hbd_diffx_2d` and `T_hbd_diffy_2d`) were missing in the diag_table, and this PR adds them.

