### PR TITLE
update ocean_geometry entry in config_archive.xml for multiinstance runs

### DIFF
--- a/cime_config/config_archive.xml
+++ b/cime_config/config_archive.xml
@@ -7,7 +7,7 @@
     <!-- match filenames of the form
          h.static[._optional instance number].nc[.optional tile number] -->
     <hist_file_extension>h\.static(\._\d*)?\.nc(\.\d*)?$</hist_file_extension>
-    <hist_file_extension>h\.ocean_geometry\.nc(\.\d*)?$</hist_file_extension>
+    <hist_file_extension>h\.ocean_geometry(\._\d*)?\.nc(\.\d*)?$</hist_file_extension>
     <!-- Match hist extension (i.e., stream name), used to identify last file
          in each stream in baseline generation within testing -->
     <hist_file_ext_regex>\w+\.\w+(\._\d*)?</hist_file_ext_regex>


### PR DESCRIPTION
Update ocean_geometry entry in config_archive.xml for multiinstance runs. This is needed due to https://github.com/NCAR/MOM6/pull/284