### PR TITLE
Bump up  stochastic phys tag, update testlist

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,7 +9,7 @@
   path = externals/stochastic_physics
   url = https://github.com/iangrooms/stochastic_physics.git
   fxDONOTUSEurl = https://github.com/iangrooms/stochastic_physics.git
-    fxtag = ocn_skeb_240715
+    fxtag = ocn_skeb_240807
     fxrequired = AlwaysRequired
 
 [submodule "MARBL"]

--- a/cime_config/testdefs/testlist_mom.xml
+++ b/cime_config/testdefs/testlist_mom.xml
@@ -21,6 +21,15 @@
       <option name="wallclock">01:00:00</option>
     </options>
   </test>
+  <test name="SMS_D_Ld2" grid="T62_t232" compset="G">
+    <machines>
+      <machine name="derecho" compiler="gnu" category="aux_mom"/>
+      <machine name="derecho" compiler="gnu" category="pr_mom"/>
+    </machines>
+    <options>
+      <option name="wallclock">01:00:00</option>
+    </options>
+  </test>
   <test name="ERS" grid="TL319_t232" compset="GW_JRA" testmods="mom/debug">
     <machines>
       <machine name="derecho" compiler="gnu" category="aux_mom"/>
@@ -82,7 +91,7 @@
       <option name="wallclock">01:00:00</option>
     </options>
   </test>
-  <test name="SMS_Ld2" grid="f09_t232" compset="B1850" testmods="mom/bcompset">
+  <test name="SMS_Ld2" grid="ne30pg3_t232" compset="BLT1850" testmods="mom/bcompset">
     <machines>
       <machine name="derecho" compiler="intel" category="aux_mom"/>
       <machine name="derecho" compiler="intel" category="pr_mom"/>


### PR DESCRIPTION
Bump up  stochastic phys tag to fix  integer kind-related compilation failures
Update testlist to include a gnu debug test and fix B test definition.

Testing: pr_mom