### PR TITLE
Early warn users when NTASKS_OCN is infeasible

### DIFF
--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -34,6 +34,7 @@ from MARBL_settings import MARBL_settings_for_MOM
 from MARBL_diagnostics import MARBL_diagnostics_for_MOM
 from MOM_MARBL_diagnostics import write_MARBL_diagnostics_file, get_2D_vars_from_MARBL_diagnostics
 from MARBL_diags_to_diag_table import diagnostics_to_diag_table
+from tools.utils import MOM_define_layout, mpp_compute_extent
 
 logger = logging.getLogger(__name__)
 
@@ -247,6 +248,10 @@ def prep_input(case, inst_suffixes):
         FType_diag_table.resolve(
             unresolved_diag_table_confdir, diag_table_rundir, casename
         )
+    
+    # Sanity checks after all input files are generated.
+    postchecks(case, MOM_input_final)
+
 
 def init_MOM_override(rundir, inst_suffix):
     # Create an empty MOM_override:
@@ -392,6 +397,26 @@ def prechecks(case, inst_suffixes):
     if run_type in ["branch", "hybrid"] and not continue_run and not get_refcase:
         restart_file = os.path.join(rundir, f'./{run_refcase}.mom6.r.{run_refdate}-{run_reftod}.nc')
         assert os.path.exists(restart_file), f"Missing restart file {run_refcase}.mom6.r.{run_refdate}-{run_reftod}.nc in rundir."
+
+def postchecks(case,  MOM_input_final):
+    """Performs checks after input files are generated. To be called within prep_input() as a final step."""
+
+    ntasks_ocn = case.get_value("NTASKS_OCN")
+    niglobal = int(MOM_input_final._data["Global"]["NIGLOBAL"]['value'])
+    njglobal = int(MOM_input_final._data["Global"]["NJGLOBAL"]['value'])
+
+    # Check whether given NTASKS_OCN is feasible by attempting to compute domain decomposition
+    niproc, njproc = MOM_define_layout(niglobal, njglobal, ntasks_ocn)
+    try:
+        mpp_compute_extent(1, niglobal, niproc)
+        mpp_compute_extent(1, njglobal, njproc)
+    except AssertionError as e:
+        raise SystemExit(
+            f"ERROR: {e}\n"
+            f"  NTASKS_OCN={ntasks_ocn}, NIGLOBAL={niglobal}, NJGLOBAL={njglobal}\n"
+            f"  Domain decomposition: NIPROC={niproc}, NJPROC={njproc}\n"
+            f"  Unable to find a feasible MOM6 domain decomposition! Try a different NTASKS_OCN."
+        )
 
 # pylint: disable=unused-argument
 ###############################################################################

--- a/cime_config/tools/lbe.py
+++ b/cime_config/tools/lbe.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+
+import os
+import xarray as xr
+import numpy as np
+import argparse
+from utils import MOM_define_layout, mpp_compute_extent
+
+descr = """
+MOM6 land block elimination preprocessor module
+NOTE: this preprocessing module is no longer needed in practice (see AUTO_MASKTABLE option),
+      but kept in MOM_interface for prototyping and diagnostics purposes. Must have the
+      numpy and xarray packages installed.
+"""
+
+
+def determine_land_blocks(mask, nx, ny, idiv, jdiv, ibuf, jbuf):
+    """Given a mask array, number of partitions in x and y dir (idiv, jdiv, and
+    buffer widths, finds the list of blocks (partitions) that are all land cells.)
+
+    Parameters:
+    mask: 2D numpy array
+        Mask array with 1s for land cells and 0s for ocean cells.
+    nx: int
+        Number of cells in x direction.
+    ny: int
+        Number of cells in y direction.
+    idiv: int
+        Number of partitions in x direction.
+    jdiv: int
+        Number of partitions in y direction.
+    ibuf: int
+        Buffer width in x direction.
+    jbuf: int
+        Buffer width in y direction.
+
+    Returns:
+    --------
+    masktable: list of tuples
+        List of tuples containing the indices of the blocks that are all land cells.
+    """
+
+    # 1-based begin and end indices
+    ibegin, iend = mpp_compute_extent(1, nx, idiv)
+    jbegin, jend = mpp_compute_extent(1, ny, jdiv)
+
+    masktable = []
+
+    for i in range(idiv):
+        # NOTE: convert begin indices to zero-based indexing
+        # (no need to convert end indices due to the way slicing works in Python)
+        ib = ibegin[i] - 1
+        ie = iend[i] + 2 * ibuf
+        for j in range(jdiv):
+            jb = jbegin[j] - 1
+            je = jend[j] + 2 * jbuf
+
+            if (mask[jb:je, ib:ie] == 1.0).any():
+                continue
+            masktable.append((i + 1, j + 1))
+
+    return masktable
+
+
+def gen_auto_mask_table(
+    topo_file_path, npes, reentrant_x, reentrant_y, tripolar_n, output_dir
+):
+    """Generates the auto mask table for MOM6 based on the topography file and the number of PEs.
+
+    Parameters:
+    -----------
+    topo_file_path: str
+        Path to the topography file.
+    npes: int
+        Number of PEs.
+    reentrant_x: bool
+        Is the domain reentrant in x-dir?
+    reentrant_y: bool
+        Is the domain reentrant in y-dir?
+    tripolar_n: bool
+        Is the domain tripolar?
+    output_dir: str
+        Output directory to write the mask table.
+    """
+
+    ds_topog = xr.open_dataset(topo_file_path)
+    ny, nx = ds_topog.mask.shape
+
+    ibuf = 2
+    jbuf = 2
+    num_masked_blocks = 0
+
+    mask = np.zeros((ny + 2 * jbuf, nx + 2 * ibuf))
+
+    mask[jbuf : ny + jbuf, ibuf : nx + ibuf] = ds_topog.mask.data
+
+    # fill in buffer cells
+    if reentrant_x:
+        mask[:, :ibuf] = mask[:, nx : nx + ibuf]
+        mask[:, ibuf + nx :] = mask[:, ibuf : 2 * ibuf]
+
+    if reentrant_y:
+        mask[:jbuf, :] = mask[ny : ny + jbuf, :]
+        mask[jbuf + ny :, :] = mask[jbuf : 2 * jbuf, :]
+
+    if tripolar_n:
+        for j in range(jbuf):
+            for i in range(nx + 2 * ibuf):
+                mask[jbuf + ny + j, i] = mask[jbuf + ny - 1 - j, nx + 2 * ibuf - 1 - i]
+
+    # Tripolar Stitch Fix: In cases where masking is asymmetrical across the tripolar stitch, there's a possibility
+    # that certain unmasked blocks won't be able to obtain grid metrics from the halo points. This occurs when the
+    # neighboring block on the opposite side of the tripolar stitch is masked. As a consequence, certain metrics like
+    # dxT and dyT may be calculated through extrapolation (refer to extrapolate_metric), potentially leading to the
+    # generation of non-positive values. This can result in divide-by-zero errors elsewhere, e.g., in MOM_hor_visc.F90.
+    # Currently, the safest and most general solution is to prohibit masking along the tripolar stitch:
+    if tripolar_n:
+        mask[jbuf + ny - 1, :] = 1
+
+    # aspect ratio limit (>1) for a layout to be considered
+    r_extreme = 4.0
+
+    # ratio of ocean cells to total number of cells
+    glob_ocn_frac = mask[jbuf : ny + jbuf, ibuf : nx + ibuf].sum() / (ny * nx)
+
+    # Iteratively check for all possible division counts starting from the upper bound of npes/glob_ocn_frac,
+    # which is over-optimistic for realistic domains, but may be satisfied with idealized domains.
+    for p in range(int(np.ceil(npes / glob_ocn_frac)), npes, -1):
+
+        # compute the layout for the current division count, p
+        idiv, jdiv = MOM_define_layout(nx, ny, p)
+
+        # don't bother checking this p if the aspect ratio is extreme
+        r_p = (nx / idiv) / (ny / jdiv)
+        if r_p * r_extreme < 1.0 or r_extreme < r_p:
+            continue
+
+        # Get the number of masked_blocks for this particular division count
+        mask_table = determine_land_blocks(mask, nx, ny, idiv, jdiv, ibuf, jbuf)
+
+        # If we can eliminate enough blocks to reach the target npes, adopt
+        # this p (and the associated layout) and terminate the iteration.
+        num_masked_blocks = len(mask_table)
+        if p - num_masked_blocks <= npes:
+            print("Found the optimum layout for auto-masking. Terminating iteration...")
+            print(f"\t new ndivs: {p}, num_masked_blocks: {p-npes}")
+            break
+
+    if num_masked_blocks == 0:
+        raise RuntimeError(
+            "Couldn't auto-eliminate any land blocks. Try to increase the number"
+        )
+
+    # Call determine_land_blocks once again, this time to retrieve and write out the mask_table.
+    mask_table = determine_land_blocks(mask, nx, ny, idiv, jdiv, ibuf, jbuf)
+    write_auto_mask_file(mask_table, idiv, jdiv, npes, output_dir)
+
+
+def write_auto_mask_file(
+    mask_table, idiv, jdiv, npes, output_dir, filename="MOM_auto_mask_table"
+):
+    """Writes the auto mask table to a file.
+
+    Parameters:
+    -----------
+    mask_table: list of tuples
+        List of tuples containing the indices of the blocks that are all land cells.
+    idiv: int
+        Number of partitions in x direction.
+    jdiv: int
+        Number of partitions in y direction.
+    npes: int
+        Number of PEs.
+    output_dir: str
+        Output directory to write the mask table.
+    filename: str
+        Name of the mask table file.
+    """
+    # make sure that exactly npes tasks are active:
+    true_num_masked_blocks = idiv * jdiv - npes
+
+    mask_file_path = os.path.join(output_dir, filename)
+    with open(mask_file_path, "w") as f:
+        f.write(f"{true_num_masked_blocks}\n")  # nmask
+        f.write(f"{idiv},{jdiv}\n")  # layout
+        # mask list
+        for block in mask_table[:true_num_masked_blocks]:
+            f.write(f"{block[0]},{block[1]}\n")
+
+    print(f"\t mask_table written to: {mask_file_path}")
+
+    return idiv, jdiv
+
+
+if __name__ == "__main__":
+
+    parser = argparse.ArgumentParser(description=descr)
+    parser.add_argument(
+        "-t",
+        metavar="topofile",
+        type=str,
+        required=True,
+        help="MOM6 topography file path (TOPO_FILE)",
+    )
+    parser.add_argument(
+        "-n",
+        metavar="npes",
+        type=int,
+        required=True,
+        help="Number of MOM6 PEs (NTASKS_OCN)",
+    )
+    parser.add_argument(
+        "-rx",
+        default=False,
+        action="store_true",
+        help="Is the domain reentrant in x-dir?",
+    )
+    parser.add_argument(
+        "-ry",
+        default=False,
+        action="store_true",
+        help="Is the domain reentrant in y-dir?",
+    )
+    parser.add_argument(
+        "-tn", default=False, action="store_true", help="Is the domain tripolar?"
+    )
+    parser.add_argument(
+        "-o", metavar="output_dir", type=str, required=False, help="Output directory"
+    )
+    args = parser.parse_args()
+
+    output_dir = args.o or os.getcwd()
+    gen_auto_mask_table(args.t, args.n, args.rx, args.ry, args.tn, output_dir)

--- a/cime_config/tools/plot_lbe.py
+++ b/cime_config/tools/plot_lbe.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+
+import os
+import xarray as xr
+import argparse
+import matplotlib.pyplot as plt
+from matplotlib.patches import Rectangle
+
+
+from utils import MOM_define_layout, mpp_compute_extent
+
+descr = """
+MOM6 land block elimination preprocessor module
+NOTE: this preprocessing module is no longer needed in practice (see AUTO_MASKTABLE option),
+      but kept in MOM_interface for prototyping and diagnostics purposes. Must have the
+      matplotlib and xarray packages installed.
+"""
+
+
+def read_mask_table(mask_file_path):
+    """Reads the mask_table file and returns the layout and masked blocks.
+
+    Parameters:
+    ----------
+    mask_file_path: str
+        Path to the mask_table file.
+
+    Returns:
+    -------
+    layout: list
+        List containing the layout of the domain.
+    masked_blocks: list of tuples
+        List of tuples containing the indices of the blocks that are all land cells.
+    """
+
+    with open(mask_file_path, "r") as f:
+        num_masked_blocks = int(f.readline())
+        layout = [int(s) for s in f.readline().split(",")]
+        masked_blocks = []
+        for _ in range(num_masked_blocks):
+            masked_blocks.append((int(s) for s in f.readline().split(",")))
+        return layout, masked_blocks
+
+
+def plot_mask_table(topo_file_path, mask_file_path):
+    """Plots the mask table on top of the topography file.
+
+    Parameters:
+    ----------
+    topo_file_path: str
+        Path to the topography file.
+    mask_file_path: str
+        Path to the mask_table file.
+    """
+
+    ds_topog = xr.open_dataset(topo_file_path)
+    da_mask = ds_topog.mask
+    ny, nx = da_mask.shape
+
+    layout, masked_blocks = read_mask_table(mask_file_path)
+    ndivs = layout[0] * layout[1]
+    idiv, jdiv = MOM_define_layout(nx, ny, ndivs)
+    assert layout[0] == idiv
+    assert layout[1] == jdiv
+
+    ibegin, iend = mpp_compute_extent(1, nx, idiv)
+    jbegin, jend = mpp_compute_extent(1, ny, jdiv)
+
+    fig, ax = plt.subplots(figsize=(10, 8))
+
+    im1 = plt.imshow(da_mask, interpolation="nearest", origin="lower")
+
+    for j in jbegin:
+        plt.axhline(y=j - 1, color="r", linestyle="-")
+    for i in ibegin:
+        plt.axvline(x=i - 1, color="r", linestyle="-")
+
+    for i, j in masked_blocks:
+        i0, j0 = (
+            ibegin[i - 1],
+            jbegin[j - 1],
+        )
+        iw, jw = iend[i - 1] - i0, jend[j - 1] - j0
+        ax.add_patch(Rectangle((i0, jbegin[j - 1]), iw, jw))
+
+    fig.tight_layout()
+    plt.show()
+
+
+if __name__ == "__main__":
+
+    parser = argparse.ArgumentParser(description=descr)
+    parser.add_argument(
+        "-t",
+        metavar="topofile",
+        type=str,
+        required=True,
+        help="MOM6 topography file path (TOPO_FILE)",
+    )
+    parser.add_argument(
+        "-m",
+        metavar="masktable_file",
+        type=str,
+        required=True,
+        help="MOM6 mask_table file path to be visualized",
+    )
+    args = parser.parse_args()
+
+    plot_mask_table(args.t, args.m)

--- a/cime_config/tools/utils.py
+++ b/cime_config/tools/utils.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+
+import math
+
+"""Standalone utility functions for miscellaneous CESM-MOM6 infrastructure/superstructure tasks."""
+
+
+def MOM_define_layout(isz, jsz, ndivs):
+    """This function is a Python implementation of MOM_define_layout subroutine from
+    MOM_domains.F90. Given a global array size (isz x jsz) and a number of (logical)
+    processors (ndivs), provide a layout of the processors in the two directions where
+    the total number of processors is the product of the two layouts and number of points
+    in the partitioned arrays are as close as possible to an aspect ratio of 1.
+
+    Parameters:
+    -----------
+    isz: int
+        Global array size in the i-direction
+    jsz: int
+        Global array size in the j-direction
+    ndivs: int
+        Number of partitions
+
+    Returns:
+    --------
+    idiv: int
+        Number of partitions in the i-direction
+    jdiv: int
+        Number of partitions in the j-direction
+    """
+
+    # First try to divide ndivs to match the domain aspect ratio.  If this is not an even
+    # divisor of ndivs, reduce idiv until a factor is found.
+    idiv = max(int(round(math.sqrt((ndivs * isz) / jsz))), 1)
+    while ndivs % idiv != 0:
+        idiv -= 1
+    jdiv = ndivs // idiv
+
+    return idiv, jdiv
+
+
+def mpp_compute_extent(isg, ieg, ndivs):
+    """This function is a Python implementation of mpp_compute_extent from FMS
+    mpp_domains_define.inc to compute extents (along either x or y direction)
+    for a grid with the given indices and divisions.
+
+    Parameters:
+    -----------
+    isg: int
+        Starting index of the domain
+    ieg: int
+        Ending index of the domain
+    ndivs: int
+        Number of partitions along the direction.
+
+    Returns:
+    --------
+    ibegin: list
+        List of starting indices for each partition
+    iend: list
+        List of ending indices for each partition
+    """
+
+    def even(x):
+        assert isinstance(x, int)
+        return x % 2 == 0
+
+    def odd(x):
+        return not even(x)
+
+    ibegin = [None for i in range(ndivs)]
+    iend = [None for i in range(ndivs)]
+
+    is_ = isg
+
+    symmetrize = (
+        (even(ndivs) and even(ieg - isg + 1))
+        or (odd(ndivs) and odd(ieg - isg + 1))
+        or (odd(ndivs) and even(ieg - isg + 1) and ndivs < (ieg - isg + 1) / 2)
+    )
+
+    imax = ieg
+    ndmax = ndivs
+
+    for ndiv in range(ndivs):
+
+        # do bottom half of decomposition, going over the midpoint for odd ndivs
+        if ndiv < (ndivs - 1) // 2 + 1:
+            ie = is_ + int(math.ceil((imax - is_ + 1) / (ndmax - ndiv))) - 1
+            ndmirror = (ndivs - 1) - ndiv  # mirror domain
+            if ndmirror > ndiv and symmetrize:
+                # mirror extents, the max(,) is to eliminate overlaps
+                ibegin[ndmirror] = max(isg + ieg - ie, ie + 1)
+                iend[ndmirror] = max(isg + ieg - is_, ie + 1)
+                imax = ibegin[ndmirror] - 1
+                ndmax -= 1
+        else:
+            if symmetrize:
+                # do top half of decomposition by retrieving saved values
+                is_ = ibegin[ndiv]
+                ie = iend[ndiv]
+            else:
+                ie = is_ + int(math.ceil((imax - is_ + 1) / (ndmax - ndiv))) - 1
+
+        ibegin[ndiv] = is_
+        iend[ndiv] = ie
+
+        assert ie >= is_, "domain extents must be positive definite.'"
+        assert not (
+            ndiv == ndivs - 1 and iend[ndiv] != ieg
+        ), "domain extents do not span space completely"
+
+        is_ = ie + 1
+
+    assert None not in ibegin, "Error in mpp_compute_extent"
+    assert None not in iend, "Error in mpp_compute_extent"
+    return ibegin, iend


### PR DESCRIPTION
- Introduce a utils module including python versions of  MOM_define_layout and mpp_compute_extent functions. These are to be used to determine domain decomposition extents and whether NTASKS_OCN is feasible.
- Add a check to buildnmi to inform the user if NTASKS_OCN is feasible.
- Add auxiliary tools to generate an mask table, and to plot existing mask tables. These auxiliary tools require numpy, xarray, and matplotlib.