### PR TITLE
Fix diag_table file suffixes and freqeuncies for test runs

### DIFF
--- a/param_templates/diag_table.yaml
+++ b/param_templates/diag_table.yaml
@@ -61,7 +61,9 @@ FieldLists:
 Files:
     # sigma2
     sigma2_hist:
-        suffix: "h.rho2%4yr-%2mo"
+        suffix: 
+            $TEST == True: "h.rho2%4yr-%2mo-%2dy" 
+            else: "h.rho2%4yr-%2mo"
         output_freq: 1
         output_freq_units:
             $TEST == True : "days"
@@ -84,7 +86,9 @@ Files:
                         [ *cfc_3d ]
     # native grid
     hist:
-        suffix: "h.native%4yr-%2mo"
+        suffix: 
+            $TEST == True: "h.native%4yr-%2mo-%2dy" 
+            else: "h.native%4yr-%2mo"
         output_freq: 1
         output_freq_units:
             $TEST == True : "days"
@@ -118,7 +122,9 @@ Files:
 
     # essential variable mapped to z_space
     hist_z_space:
-        suffix: "h.z%4yr-%2mo"
+        suffix: 
+            $TEST == True: "h.z%4yr-%2mo-%2dy"
+            else: "h.z%4yr-%2mo"
         output_freq: 1
         output_freq_units:
             $TEST == True : "days"
@@ -142,14 +148,18 @@ Files:
                         [ *cfc_3d ]
 
     surface_avg:
-        suffix: "h.sfc%4yr-%2mo"
+        suffix: 
+            $TEST == True: "h.sfc%4yr-%2mo-2dy"
+            else: "h.sfc%4yr-%2mo"
         output_freq:
             $OCN_DIAG_MODE == "spinup": 5
             else: 1
         output_freq_units: "days"
         time_axis_units: "days"
         new_file_freq: 1
-        new_file_freq_units: "months"
+        new_file_freq_units:
+            $TEST == True: "days"
+            else: "months"
         reduction_method: "mean"    # time average
         regional_section: "none"    # global
         fields:
@@ -159,12 +169,18 @@ Files:
                 lists:    [ *surface_flds,
                             *kpp_diags ]
     forcing_avg:
-        suffix: "h.frc%4yr-%2mo"
+        suffix: 
+            $TEST == True: "h.frc%4yr-%2mo-%2dy"
+            else: "h.frc%4yr-%2mo"
         output_freq: 1
-        output_freq_units: "months"
+        output_freq_units:
+            $TEST == True : "days"
+            else: "months"
         time_axis_units: "days"
         new_file_freq: 1
-        new_file_freq_units: "months"
+        new_file_freq_units:
+            $TEST == True: "days"
+            else: "months"
         reduction_method: "mean"    # time average
         regional_section: "none"    # global
         fields:
@@ -175,12 +191,18 @@ Files:
                             *forcing_flds_dev ]
 
     visc_and_diff_daily_avg:
-        suffix: "h.visc%4yr-%2mo"
+        suffix:
+            $TEST == True: "h.visc%4yr-%2mo"
+            else: "h.visc%4yr-%2mo"
         output_freq: 1
-        output_freq_units: "months"
+        output_freq_units:
+            $TEST == True : "days"
+            else: "months"
         time_axis_units: "days"
         new_file_freq: 1
-        new_file_freq_units: "months"
+        new_file_freq_units:
+            $TEST == True: "days"
+            else: "months"
         reduction_method: "mean"    # time average
         regional_section: "none"    # global
         fields:

--- a/param_templates/json/diag_table.json
+++ b/param_templates/json/diag_table.json
@@ -173,7 +173,10 @@
    ],
    "Files": {
       "sigma2_hist": {
-         "suffix": "h.rho2%4yr-%2mo",
+         "suffix": {
+            "$TEST == True": "h.rho2%4yr-%2mo-%2dy",
+            "else": "h.rho2%4yr-%2mo"
+         },
          "output_freq": 1,
          "output_freq_units": {
             "$TEST == True": "days",
@@ -219,7 +222,10 @@
          }
       },
       "hist": {
-         "suffix": "h.native%4yr-%2mo",
+         "suffix": {
+            "$TEST == True": "h.native%4yr-%2mo-%2dy",
+            "else": "h.native%4yr-%2mo"
+         },
          "output_freq": 1,
          "output_freq_units": {
             "$TEST == True": "days",
@@ -349,7 +355,10 @@
          }
       },
       "hist_z_space": {
-         "suffix": "h.z%4yr-%2mo",
+         "suffix": {
+            "$TEST == True": "h.z%4yr-%2mo-%2dy",
+            "else": "h.z%4yr-%2mo"
+         },
          "output_freq": 1,
          "output_freq_units": {
             "$TEST == True": "days",
@@ -400,7 +409,10 @@
          }
       },
       "surface_avg": {
-         "suffix": "h.sfc%4yr-%2mo",
+         "suffix": {
+            "$TEST == True": "h.sfc%4yr-%2mo-2dy",
+            "else": "h.sfc%4yr-%2mo"
+         },
          "output_freq": {
             "$OCN_DIAG_MODE == \"spinup\"": 5,
             "else": 1
@@ -408,7 +420,10 @@
          "output_freq_units": "days",
          "time_axis_units": "days",
          "new_file_freq": 1,
-         "new_file_freq_units": "months",
+         "new_file_freq_units": {
+            "$TEST == True": "days",
+            "else": "months"
+         },
          "reduction_method": "mean",
          "regional_section": "none",
          "fields": {
@@ -437,12 +452,21 @@
          }
       },
       "forcing_avg": {
-         "suffix": "h.frc%4yr-%2mo",
+         "suffix": {
+            "$TEST == True": "h.frc%4yr-%2mo-%2dy",
+            "else": "h.frc%4yr-%2mo"
+         },
          "output_freq": 1,
-         "output_freq_units": "months",
+         "output_freq_units": {
+            "$TEST == True": "days",
+            "else": "months"
+         },
          "time_axis_units": "days",
          "new_file_freq": 1,
-         "new_file_freq_units": "months",
+         "new_file_freq_units": {
+            "$TEST == True": "days",
+            "else": "months"
+         },
          "reduction_method": "mean",
          "regional_section": "none",
          "fields": {
@@ -497,12 +521,21 @@
          }
       },
       "visc_and_diff_daily_avg": {
-         "suffix": "h.visc%4yr-%2mo",
+         "suffix": {
+            "$TEST == True": "h.visc%4yr-%2mo",
+            "else": "h.visc%4yr-%2mo"
+         },
          "output_freq": 1,
-         "output_freq_units": "months",
+         "output_freq_units": {
+            "$TEST == True": "days",
+            "else": "months"
+         },
          "time_axis_units": "days",
          "new_file_freq": 1,
-         "new_file_freq_units": "months",
+         "new_file_freq_units": {
+            "$TEST == True": "days",
+            "else": "months"
+         },
          "reduction_method": "mean",
          "regional_section": "none",
          "fields": {


### PR DESCRIPTION
Currently, for **test** runs, diagnostics are being output daily, but the files are created as monthly (and overriden each day). This also causes a mismatch between the datestamps in the filenames (monthly) and the data inside them (daily).

Changes Introduced by this PR for test runs:

- Diagnostics output files are now created daily.
- Each file corresponds to a single day, ensuring that the datestamp in the filename matches the actual data within the file.

Fixes: #171.