### PR TITLE
Improvements in build_examples-ncar.sh script

### DIFF
--- a/standalone/build/build_examples-ncar.sh
+++ b/standalone/build/build_examples-ncar.sh
@@ -15,8 +15,26 @@ CESM_ROOT=`pwd -P`
 SHR_ROOT=${CESM_ROOT}/share
 FMS_ROOT=${CESM_ROOT}/libraries/FMS
 
-COMPILER=intel
+# Default compiler
+COMPILER="intel"
+
+# Parse command line arguments
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+        --compiler) COMPILER="$2"; shift ;;
+        *) echo "Unknown parameter passed: $1"; exit 1 ;;
+    esac
+    shift
+done
+echo "Using compiler: $COMPILER"
+
 TEMPLATE=${TEMPLATE_DIR}/ncar-${COMPILER}.mk
+
+# Throw error if template does not exist:
+if [ ! -f $TEMPLATE ]; then
+  echo "ERROR: Template file $TEMPLATE does not exist. Exiting."
+  exit 1
+fi
 
 if [ -e $1 ]; then
   BLD_ROOT=${COMPILER}

--- a/standalone/templates/ncar-gnu.mk
+++ b/standalone/templates/ncar-gnu.mk
@@ -21,7 +21,7 @@ MAKEFLAGS += --jobs=$(shell grep '^processor' /proc/cpuinfo | wc -l)
 
 FPPFLAGS :=
 
-FFLAGS := -fcray-pointer -fdefault-double-8 -fdefault-real-8 -Waliasing -ffree-line-length-none -fno-range-check
+FFLAGS := -fcray-pointer -fdefault-double-8 -fdefault-real-8 -Waliasing -ffree-line-length-none -fno-range-check -fallow-argument-mismatch
 FFLAGS += -I$(shell nc-config --includedir)
 FFLAGS += $(shell pkg-config --cflags-only-I mpich2-c)
 FFLAGS_OPT = -O3
@@ -79,7 +79,7 @@ ifeq ($(NETCDF),3)
   endif
 endif
 
-LIBS := $(shell nc-config --flibs) $(shell pkg-config --libs mpich2-f90)
+LIBS := $(shell nf-config --flibs) $(shell pkg-config --libs mpich2-f90)
 LDFLAGS += $(LIBS)
 
 #---------------------------------------------------------------------------


### PR DESCRIPTION
- Make compiler a command like argument, which defaults to `intel`. Users may instead specify, say, `gnu`, as follows:  `./build_examples-ncar.sh --compiler gnu`
- Updates in gnu makefile template for gcc/13. (tested on derecho using gcc/13.2.0)