### PR TITLE
New defaults for cesm3.0 workhorse

### DIFF
--- a/cime_config/config_component.xml
+++ b/cime_config/config_component.xml
@@ -73,6 +73,7 @@
     <valid_values>zstar_75L,zstar_65L,hycom1,sigma_shelf_zstar</valid_values>
     <default_value>zstar_65L</default_value>
     <values>
+      <value grid="oi%tx2_3v2">hycom1</value>
       <value grid="oi%tx0.25v1">hycom1</value>
       <value grid="oi%MISOMIP">sigma_shelf_zstar</value>
     </values>

--- a/param_templates/MOM_input.yaml
+++ b/param_templates/MOM_input.yaml
@@ -2029,7 +2029,7 @@ Global:
         datatype: integer
         value:
             $OCN_GRID == "tx0.25v1": 3
-            $OCN_GRID == "tx2_3v2": 3
+            $OCN_GRID == "tx2_3v2": 2
     OPACITY_SCHEME:
         description: |
             "default = 'MANIZZA_05'

--- a/param_templates/MOM_input.yaml
+++ b/param_templates/MOM_input.yaml
@@ -952,7 +952,7 @@ Global:
             The list of maximum thickness for each layer."
         datatype: string
         value:
-            $MOM6_VERTICAL_GRID == "hybrid" and $OCN_GRID in ["tx2_3v2"]: |
+            $MOM6_VERTICAL_GRID == "hycom1" and $OCN_GRID in ["tx2_3v2"]: |
                   '"FILE:${DIN_LOC_ROOT}/ocn/mom/grid_indpt/dz_max_90th_quantile.nc,dz"'
             else: '"FNC1:400,31000.0,0.1,.01"'
     BOUND_CORIOLIS:

--- a/param_templates/MOM_input.yaml
+++ b/param_templates/MOM_input.yaml
@@ -614,7 +614,7 @@ Global:
         datatype: logical
         units: Boolean
         value:
-             $OCN_GRID == "tx2_3v2": True
+             $OCN_GRID == "tx2_3v2": False
     INIT_LAYERS_FROM_Z_FILE:
         description: |
             "[Boolean] default = False

--- a/param_templates/MOM_input.yaml
+++ b/param_templates/MOM_input.yaml
@@ -115,16 +115,6 @@ Global:
         units: Boolean
         value:
             $OCN_GRID == "tx2_3v2": False
-    DIABATIC_FIRST:
-        description: |
-            "[Boolean] default = False
-            If true, apply diabatic and thermodynamic processes,
-            including buoyancy forcing and mass gain or loss,
-            before stepping the dynamics forward."
-        datatype: logical
-        units: Boolean
-        value:
-            $OCN_GRID == "tx2_3v2": True
     USE_REGRIDDING:
         description: |
             "[Boolean] default = False
@@ -615,6 +605,16 @@ Global:
             PQM_IH6IH5  (5th-order accurate)"
         datatype: string
         value: "PPM_CW"
+    REMAP_VEL_CONSERVE_KE:
+        description: |
+            "[Boolean] default = False
+            If true, a correction is applied to the baroclinic component of velocity after
+            remapping so that total KE is conserved. KE may not be conserved when
+            (CS%BBL_h_vel_mask > 0.0) .and. (CS%h_vel_mask > 0.0)"
+        datatype: logical
+        units: Boolean
+        value:
+             $OCN_GRID == "tx2_3v2": True
     INIT_LAYERS_FROM_Z_FILE:
         description: |
             "[Boolean] default = False
@@ -662,6 +662,15 @@ Global:
         datatype: logical
         units: Boolean
         value: False
+    Z_INIT_REMAP_GENERAL:
+        description: |
+            "[Boolean] default = False
+            If false, only initializes to z* coordinates. If true, allows initialization
+            directly to general coordinates."
+        datatype: logical
+        units: Boolean
+        value:
+            $MOM6_VERTICAL_GRID == "hycom1" and $OCN_GRID in ["tx2_3v2"]: True
     USE_VARIABLE_MIXING:
         description: |
             "[Boolean] default = False
@@ -913,7 +922,7 @@ Global:
         datatype: real
         units: not defined
         value:
-            $MOM6_VERTICAL_GRID == "hycom1": 0.01
+            $MOM6_VERTICAL_GRID == "hycom1": 0.0
     MAXIMUM_INT_DEPTH_CONFIG:
         description: |
             "default = 'NONE'
@@ -943,7 +952,8 @@ Global:
             The list of maximum thickness for each layer."
         datatype: string
         value:
-            $MOM6_VERTICAL_GRID == "hycom1": '"FNC1:400,31000.0,0.1,.01"'
+            $MOM6_VERTICAL_GRID == "hybrid" and $OCN_GRID in ["tx2_3v2"]: '"FILE:dz_max_90th_quantile.nc,dz"'
+            else: '"FNC1:400,31000.0,0.1,.01"'
     BOUND_CORIOLIS:
         description: |
             "[Boolean] default = False
@@ -1366,6 +1376,24 @@ Global:
         value:
             $OCN_GRID == "tx2_3v2": 0.0
             $OCN_GRID == "MISOMIP": 0.0
+    KHTH_MIN:
+        description: |
+            "[m2 s-1] default = 0.0
+            The minimum horizontal thickness diffusivity"
+        datatype: real
+        units: m2 s-1
+        value:
+            $OCN_GRID == "tx2_3v2": 50.0
+    FULL_DEPTH_KHTH_MIN:
+        description: |
+            "[Boolean] default = False
+            KHTH_MIN is enforced throughout the whole water column. Otherwise,
+            KHTH_MIN is only enforced at the surface. This parameter is only available
+            when KHTH_USE_EBT_STRUCT=True and KHTH_MIN>0."
+        datatype: logical
+        units: Boolean
+        value:
+            $OCN_GRID == "tx2_3v2": True
     KHTH_MAX_CFL:
         description: |
             "[nondimensional] default = 0.8
@@ -2002,6 +2030,17 @@ Global:
         value:
             $OCN_GRID == "tx0.25v1": 3
             $OCN_GRID == "tx2_3v2": 3
+    OPACITY_SCHEME:
+        description: |
+            "default = 'MANIZZA_05'
+            This character string specifies how chlorophyll concentrations are translated
+            into opacities. Currently valid options include:
+                   MANIZZA_05 - Use Manizza et al., GRL, 2005.
+                   MOREL_88 - Use Morel, JGR, 1988.
+                   OHLMANN_03 - Use Ohlmann, J Clim, 2003."
+        datatype: string
+        value:
+            $OCN_GRID == "tx2_3v2": "OHLMANN_03"
     TRACER_ADVECTION_SCHEME:
         description: |
             "default = 'PLM'
@@ -2037,6 +2076,16 @@ Global:
         units: m2 s-1
         value:
             $OCN_GRID == "tx2_3v2": 50.0
+    FULL_DEPTH_KHTR_MIN:
+        description: |
+            "[Boolean] default = False
+            KHTR_MIN is enforced throughout the whole water column. Otherwise,
+            KHTR_MIN is only enforced at the surface. This parameter is only available
+            when KHTR_USE_EBT_STRUCT=True and KHTR_MIN>0."
+        datatype: logical
+        units: Boolean
+        value:
+            $OCN_GRID == "tx2_3v2": True
     DEBUG:
         description: |
             "If true, write out verbose debugging data."

--- a/param_templates/MOM_input.yaml
+++ b/param_templates/MOM_input.yaml
@@ -952,7 +952,8 @@ Global:
             The list of maximum thickness for each layer."
         datatype: string
         value:
-            $MOM6_VERTICAL_GRID == "hybrid" and $OCN_GRID in ["tx2_3v2"]: '"FILE:dz_max_90th_quantile.nc,dz"'
+            $MOM6_VERTICAL_GRID == "hybrid" and $OCN_GRID in ["tx2_3v2"]: |
+                  '"FILE:${DIN_LOC_ROOT}/ocn/mom/grid_indpt/dz_max_90th_quantile.nc,dz"'
             else: '"FNC1:400,31000.0,0.1,.01"'
     BOUND_CORIOLIS:
         description: |

--- a/param_templates/json/MOM_input.json
+++ b/param_templates/json/MOM_input.json
@@ -464,7 +464,7 @@
          "datatype": "logical",
          "units": "Boolean",
          "value": {
-            "$OCN_GRID == \"tx2_3v2\"": true
+            "$OCN_GRID == \"tx2_3v2\"": false
          }
       },
       "INIT_LAYERS_FROM_Z_FILE": {

--- a/param_templates/json/MOM_input.json
+++ b/param_templates/json/MOM_input.json
@@ -716,7 +716,7 @@
          "description": "\"default = 'NONE'\nDetermines how to specify the maximum layer thicknesses.\nValid options are:\nNONE        - there are no maximum layer thicknesses\nPARAM       - use the vector-parameter MAX_LAYER_THICKNESS\nFILE:string - read from a file. The string specifies\nthe filename and variable name, separated\nby a comma or space, e.g. FILE:lev.nc,Z\nFNC1:string - FNC1:dz_min,H_total,power,precision\nThe list of maximum thickness for each layer.\"\n",
          "datatype": "string",
          "value": {
-            "$MOM6_VERTICAL_GRID == \"hybrid\" and $OCN_GRID in [\"tx2_3v2\"]": "\"FILE:dz_max_90th_quantile.nc,dz\"",
+            "$MOM6_VERTICAL_GRID == \"hybrid\" and $OCN_GRID in [\"tx2_3v2\"]": "'\"FILE:${DIN_LOC_ROOT}/ocn/mom/grid_indpt/dz_max_90th_quantile.nc,dz\"'\n",
             "else": "\"FNC1:400,31000.0,0.1,.01\""
          }
       },

--- a/param_templates/json/MOM_input.json
+++ b/param_templates/json/MOM_input.json
@@ -1582,7 +1582,7 @@
          "datatype": "integer",
          "value": {
             "$OCN_GRID == \"tx0.25v1\"": 3,
-            "$OCN_GRID == \"tx2_3v2\"": 3
+            "$OCN_GRID == \"tx2_3v2\"": 2
          }
       },
       "OPACITY_SCHEME": {

--- a/param_templates/json/MOM_input.json
+++ b/param_templates/json/MOM_input.json
@@ -716,7 +716,7 @@
          "description": "\"default = 'NONE'\nDetermines how to specify the maximum layer thicknesses.\nValid options are:\nNONE        - there are no maximum layer thicknesses\nPARAM       - use the vector-parameter MAX_LAYER_THICKNESS\nFILE:string - read from a file. The string specifies\nthe filename and variable name, separated\nby a comma or space, e.g. FILE:lev.nc,Z\nFNC1:string - FNC1:dz_min,H_total,power,precision\nThe list of maximum thickness for each layer.\"\n",
          "datatype": "string",
          "value": {
-            "$MOM6_VERTICAL_GRID == \"hybrid\" and $OCN_GRID in [\"tx2_3v2\"]": "'\"FILE:${DIN_LOC_ROOT}/ocn/mom/grid_indpt/dz_max_90th_quantile.nc,dz\"'\n",
+            "$MOM6_VERTICAL_GRID == \"hycom1\" and $OCN_GRID in [\"tx2_3v2\"]": "'\"FILE:${DIN_LOC_ROOT}/ocn/mom/grid_indpt/dz_max_90th_quantile.nc,dz\"'\n",
             "else": "\"FNC1:400,31000.0,0.1,.01\""
          }
       },

--- a/param_templates/json/MOM_input.json
+++ b/param_templates/json/MOM_input.json
@@ -68,14 +68,6 @@
             "$OCN_GRID == \"tx2_3v2\"": false
          }
       },
-      "DIABATIC_FIRST": {
-         "description": "\"[Boolean] default = False\nIf true, apply diabatic and thermodynamic processes,\nincluding buoyancy forcing and mass gain or loss,\nbefore stepping the dynamics forward.\"\n",
-         "datatype": "logical",
-         "units": "Boolean",
-         "value": {
-            "$OCN_GRID == \"tx2_3v2\"": true
-         }
-      },
       "USE_REGRIDDING": {
          "description": "\"[Boolean] default = False\nIf True, use the ALE algorithm (regridding/remapping).\nIf False, use the layered isopycnal algorithm.\"\n",
          "datatype": "logical",
@@ -467,6 +459,14 @@
          "datatype": "string",
          "value": "PPM_CW"
       },
+      "REMAP_VEL_CONSERVE_KE": {
+         "description": "\"[Boolean] default = False\nIf true, a correction is applied to the baroclinic component of velocity after\nremapping so that total KE is conserved. KE may not be conserved when\n(CS%BBL_h_vel_mask > 0.0) .and. (CS%h_vel_mask > 0.0)\"\n",
+         "datatype": "logical",
+         "units": "Boolean",
+         "value": {
+            "$OCN_GRID == \"tx2_3v2\"": true
+         }
+      },
       "INIT_LAYERS_FROM_Z_FILE": {
          "description": "\"[Boolean] default = False\nIf true, intialize the layer thicknesses, temperatures,\nand salnities from a Z-space file on a latitude-\nlongitude grid.\"\n",
          "datatype": "logical",
@@ -504,6 +504,14 @@
          "datatype": "logical",
          "units": "Boolean",
          "value": false
+      },
+      "Z_INIT_REMAP_GENERAL": {
+         "description": "\"[Boolean] default = False\nIf false, only initializes to z* coordinates. If true, allows initialization\ndirectly to general coordinates.\"\n",
+         "datatype": "logical",
+         "units": "Boolean",
+         "value": {
+            "$MOM6_VERTICAL_GRID == \"hycom1\" and $OCN_GRID in [\"tx2_3v2\"]": true
+         }
       },
       "USE_VARIABLE_MIXING": {
          "description": "\"[Boolean] default = False\nIf true, the variable mixing code will be called.  This\nallows diagnostics to be created even if the scheme is\nnot used.  If KHTR_SLOPE_CFF>0 or  KhTh_Slope_Cff>0,\nthis is set to true regardless of what is in the\nparameter file.\"\n",
@@ -694,7 +702,7 @@
          "datatype": "real",
          "units": "not defined",
          "value": {
-            "$MOM6_VERTICAL_GRID == \"hycom1\"": 0.01
+            "$MOM6_VERTICAL_GRID == \"hycom1\"": 0.0
          }
       },
       "MAXIMUM_INT_DEPTH_CONFIG": {
@@ -708,7 +716,8 @@
          "description": "\"default = 'NONE'\nDetermines how to specify the maximum layer thicknesses.\nValid options are:\nNONE        - there are no maximum layer thicknesses\nPARAM       - use the vector-parameter MAX_LAYER_THICKNESS\nFILE:string - read from a file. The string specifies\nthe filename and variable name, separated\nby a comma or space, e.g. FILE:lev.nc,Z\nFNC1:string - FNC1:dz_min,H_total,power,precision\nThe list of maximum thickness for each layer.\"\n",
          "datatype": "string",
          "value": {
-            "$MOM6_VERTICAL_GRID == \"hycom1\"": "\"FNC1:400,31000.0,0.1,.01\""
+            "$MOM6_VERTICAL_GRID == \"hybrid\" and $OCN_GRID in [\"tx2_3v2\"]": "\"FILE:dz_max_90th_quantile.nc,dz\"",
+            "else": "\"FNC1:400,31000.0,0.1,.01\""
          }
       },
       "BOUND_CORIOLIS": {
@@ -1019,6 +1028,22 @@
          "value": {
             "$OCN_GRID == \"tx2_3v2\"": 0.0,
             "$OCN_GRID == \"MISOMIP\"": 0.0
+         }
+      },
+      "KHTH_MIN": {
+         "description": "\"[m2 s-1] default = 0.0\nThe minimum horizontal thickness diffusivity\"\n",
+         "datatype": "real",
+         "units": "m2 s-1",
+         "value": {
+            "$OCN_GRID == \"tx2_3v2\"": 50.0
+         }
+      },
+      "FULL_DEPTH_KHTH_MIN": {
+         "description": "\"[Boolean] default = False\nKHTH_MIN is enforced throughout the whole water column. Otherwise,\nKHTH_MIN is only enforced at the surface. This parameter is only available\nwhen KHTH_USE_EBT_STRUCT=True and KHTH_MIN>0.\"\n",
+         "datatype": "logical",
+         "units": "Boolean",
+         "value": {
+            "$OCN_GRID == \"tx2_3v2\"": true
          }
       },
       "KHTH_MAX_CFL": {
@@ -1560,6 +1585,13 @@
             "$OCN_GRID == \"tx2_3v2\"": 3
          }
       },
+      "OPACITY_SCHEME": {
+         "description": "\"default = 'MANIZZA_05'\nThis character string specifies how chlorophyll concentrations are translated\ninto opacities. Currently valid options include:\n       MANIZZA_05 - Use Manizza et al., GRL, 2005.\n       MOREL_88 - Use Morel, JGR, 1988.\n       OHLMANN_03 - Use Ohlmann, J Clim, 2003.\"\n",
+         "datatype": "string",
+         "value": {
+            "$OCN_GRID == \"tx2_3v2\"": "OHLMANN_03"
+         }
+      },
       "TRACER_ADVECTION_SCHEME": {
          "description": "\"default = 'PLM'\nThe horizontal transport scheme for tracers:\nPLM    - Piecewise Linear Method\nPPM:H3 - Piecewise Parabolic Method (Huyhn 3rd order)\"\n",
          "datatype": "string",
@@ -1590,6 +1622,14 @@
          "units": "m2 s-1",
          "value": {
             "$OCN_GRID == \"tx2_3v2\"": 50.0
+         }
+      },
+      "FULL_DEPTH_KHTR_MIN": {
+         "description": "\"[Boolean] default = False\nKHTR_MIN is enforced throughout the whole water column. Otherwise,\nKHTR_MIN is only enforced at the surface. This parameter is only available\nwhen KHTR_USE_EBT_STRUCT=True and KHTR_MIN>0.\"\n",
+         "datatype": "logical",
+         "units": "Boolean",
+         "value": {
+            "$OCN_GRID == \"tx2_3v2\"": true
          }
       },
       "DEBUG": {


### PR DESCRIPTION
```
KHTH_MIN = KHTR_MIN = 50
OPACITY_SCHEME = "OHLMANN"
PEN_SW_NBANDS = 2
DIABATIC_FIRST = False
REMAP_VEL_CONSERVE_KE = False (= True breaks the dimensional consistency tests)
FULL_DEPTH_KHTR_MIN = True
FULL_DEPTH_KHTH_MIN = True
KHTH_MIN = 50
MOM6_VERTICAL_GRID = hycom1
```

When the grid is hycom1:

```
REGRID_COMPRESSIBILITY_FRACTION = 0
MAX_LAYER_THICKNESS_CONFIG = "FILE:dz_max_90th_quantile.nc,dz"
Z_INIT_REMAP_GENERAL = True
```