### PR TITLE
Update MOM6 to latest tag

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,7 +2,7 @@
   path = MOM6
   url = https://github.com/NCAR/MOM6.git
   fxDONOTUSEurl = https://github.com/NCAR/MOM6.git
-    fxtag = dev/ncar_240802
+    fxtag = dev/ncar_240903
     fxrequired = AlwaysRequired
 
 [submodule "stochastic_physics"]


### PR DESCRIPTION
On MOM6 side:

* clean up write statements
* merge mom-ocean/main (July 30, 2024)
* enforce KHTR_MIN and KHTH_MIN in the whole water column
* Modify NUOPC cap to accept separate glc runoff fluxes
* Convert salt_flux to tracer_flux (used for DIC and ALK fluxes)