### PR TITLE
stochastic_physics external is in ESCOMP org

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,8 +7,8 @@
 
 [submodule "stochastic_physics"]
   path = externals/stochastic_physics
-  url = https://github.com/iangrooms/stochastic_physics.git
-  fxDONOTUSEurl = https://github.com/iangrooms/stochastic_physics.git
+  url = https://github.com/ESCOMP/stochastic_physics.git
+  fxDONOTUSEurl = https://github.com/ESCOMP/stochastic_physics.git
     fxtag = ocn_skeb_240807
     fxrequired = AlwaysRequired
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -16,6 +16,6 @@
   path = externals/MARBL
   url = https://github.com/marbl-ecosys/MARBL.git
   fxDONOTUSEurl = https://github.com/marbl-ecosys/MARBL.git
-    fxtag = marbl0.47.0
+    fxtag = marbl0.47.1
     fxrequired = AlwaysRequired
 


### PR DESCRIPTION
We no longer need to point to Ian's fork of `stochastic_physics`, the same tag has been moved to ESCOMP