### PR TITLE
CI test for input_data_list

### DIFF
--- a/.github/workflows/general-ci-tests.yml
+++ b/.github/workflows/general-ci-tests.yml
@@ -89,6 +89,19 @@ jobs:
       # Run the test
       - name: Run the check_default_params script
         run: python tests/check_default_params.py
+  
+  # Job to run check_input_data_list script
+  check_input_data_list:
+    
+    runs-on: ubuntu-latest
+    
+    steps:
+      # Checkout the repo
+      - uses: actions/checkout@v4
+      
+      # Run the test
+      - name: Run the check_input_data_list script
+        run: python tests/check_input_data_list.py
         
   # Job to run the black formatter for cime_config, see black documentation for more info
   check_black_format_for_cime_config:

--- a/.github/workflows/general-ci-tests.yml
+++ b/.github/workflows/general-ci-tests.yml
@@ -114,7 +114,9 @@ jobs:
       
       # Run the test
       - name: Run the check_input_data_repo script
-        run: python tests/check_input_data_repo.py
+        run: |
+          pip install 'svn>=1,<1.1'
+          python tests/check_input_data_repo.py
 
   # Job to run the black formatter for cime_config, see black documentation for more info
   check_black_format_for_cime_config:

--- a/.github/workflows/general-ci-tests.yml
+++ b/.github/workflows/general-ci-tests.yml
@@ -104,7 +104,7 @@ jobs:
         run: python tests/check_input_data_list.py
 
   # Job to run check_input_data_repo script
-  check_input_data_list:
+  check_input_data_repo:
     
     runs-on: ubuntu-latest
     

--- a/.github/workflows/general-ci-tests.yml
+++ b/.github/workflows/general-ci-tests.yml
@@ -102,7 +102,20 @@ jobs:
       # Run the test
       - name: Run the check_input_data_list script
         run: python tests/check_input_data_list.py
-        
+
+  # Job to run check_input_data_repo script
+  check_input_data_list:
+    
+    runs-on: ubuntu-latest
+    
+    steps:
+      # Checkout the repo
+      - uses: actions/checkout@v4
+      
+      # Run the test
+      - name: Run the check_input_data_repo script
+        run: python tests/check_input_data_repo.py
+
   # Job to run the black formatter for cime_config, see black documentation for more info
   check_black_format_for_cime_config:
     

--- a/param_templates/MOM_input.yaml
+++ b/param_templates/MOM_input.yaml
@@ -2765,9 +2765,7 @@ Global:
             "default = 'MOM_IC'
             The file into which to write the initial conditions."
         datatype: string
-        value:
-            $OCN_GRID == "MISOMIP": "MISOMIP_IC"
-            else: = "${CASE}.mom6.ic.${RUN_STARTDATE}.nc"
+        value: = "${CASE}.mom6.ic.${RUN_STARTDATE}.nc"
     TRIMMING_USES_REMAPPING:
         description: |
             "[Boolean] default = False

--- a/param_templates/input_data_list.yaml
+++ b/param_templates/input_data_list.yaml
@@ -1,56 +1,67 @@
 # The list of input files to be checked out from inputdata
 ---
 mom.input_data_list:
-    ocean_hgrid:
+    GRID_FILE:
         $OCN_GRID == "tx2_3v2":  "${INPUTDIR}/ocean_hgrid_221123.nc"
         $OCN_GRID == "tx0.25v1": "${INPUTDIR}/ocean_hgrid.nc"
-    ocean_vgrid1:
-        $OCN_GRID == "tx2_3v2":   "${INPUTDIR}/vgrid_65L_20200626.nc"
+    ALE_COORDINATE_CONFIG:
+        $MOM6_VERTICAL_GRID == "zstar_75L": "${INPUTDIR}/zstar_75layer_2.5m_248.4m-2024-03-29.nc"
+        $MOM6_VERTICAL_GRID == "zstar_65L": "${INPUTDIR}/vgrid_65L_20200626.nc"
+        $MOM6_VERTICAL_GRID == "hycom1" and $OCN_GRID != "tx0.25v1": "${INPUTDIR}/hybrid_75layer_zstar2.50m-2020-11-23.nc"
+        $MOM6_VERTICAL_GRID == "hycom1" and $OCN_GRID == "tx0.25v1": "${INPUTDIR}/hycom1_75_800m.nc"
         $OCN_GRID == "tx0.25v1": "${INPUTDIR}/hycom1_75_800m.nc"
-    ocean_vgrid2:
+    DIAG_COORD_DEF_Z:
         $OCN_GRID == "tx0.25v1": "${INPUTDIR}/interpolate_zgrid_40L.nc"
-    ocean_vgrid3:
+    COORD_FILE:
         $OCN_GRID == "tx0.25v1": "${INPUTDIR}/layer_coord.nc"
-    ocean_topog:
-        $OCN_GRID == "tx2_3v2":  "${INPUTDIR}/ocean_topog_230413.nc"
+    TOPO_FILE:
+        $OCN_GRID == "tx2_3v2":  "${INPUTDIR}/ocean_topo_tx2_3v2_240501.nc"
         $OCN_GRID == "tx0.25v1": "${INPUTDIR}/ocean_topog.nc"
-    ocean_topo_edit:
+    TOPO_EDITS_FILE:
         $OCN_GRID == "tx0.25v1": "${INPUTDIR}/All_edits.nc"
-    tempsalt:
+    TEMP_SALT_Z_INIT_FILE:
         $OCN_GRID in ["tx2_3v2", "tx0.25v1"]:
             $INIT_LAYERS_FROM_Z_FILE == "True":
                 "${INPUTDIR}/${TEMP_SALT_Z_INIT_FILE}"
-    saltrestore:
+    MAX_LAYER_THICKNESS_CONFIG:
+        $MOM6_VERTICAL_GRID == "hycom1" and $OCN_GRID in ["tx2_3v2"]:
+                  "${DIN_LOC_ROOT}/ocn/mom/grid_indpt/dz_max_90th_quantile.nc"
+    SURFACE_PRESSURE_FILE:
+        $OCN_GRID == "MISOMIP": "${INPUTDIR}/MISOMIP_181108.nc"
+    SALT_RESTORE_FILE:
         $OCN_GRID == "tx2_3v2":  "${INPUTDIR}/state_restore_tx2_3_20230416.nc"
-    tidal:
+    TIDAL_ENERGY_FILE:
+        $OCN_GRID == "tx2_3v2": "${INPUTDIR}/energy_new_tx2_3_conserve_230415_cdf5.nc"
         $OCN_GRID == "tx0.25v1": "${INPUTDIR}/tidal_amplitude.v20140616.nc"
-    ocean_channel:
+    CHANNEL_LIST_FILE:
+        $OCN_GRID == "tx2_3v2": "${INPUTDIR}/MOM_channels_global_tx2_3v2_240501"
         $OCN_GRID == "tx0.25v1": "${INPUTDIR}/MOM_channels_global_025"
-    ocean_geothermal:
+    GEOTHERMAL_FILE:
+        $OCN_GRID == "tx2_3v2": "${INPUTDIR}/geothermal_davies2013_tx2_3_20240318_cdf5.nc"
         $OCN_GRID == "tx0.25v1": "${INPUTDIR}/geothermal_davies2013_v1.nc"
-    ocean_seaw:
+    CHL_FILE:
         $OCN_GRID == "tx0.25v1": "${INPUTDIR}/seawifs-clim-1997-2010.1440x1080.v20180328.nc"
         $OCN_GRID == "tx2_3v2": "${INPUTDIR}/seawifs-clim-1997-2010-tx2_3v2.230416.nc"
-    cfcs_forcing: "${DIN_LOC_ROOT}/ocn/mom/grid_indpt/cfc_atm_20230310.nc"
-    diag_coord_def_rho2:
+    CFC_BC_FILE: "${DIN_LOC_ROOT}/ocn/mom/grid_indpt/cfc_atm_20230310.nc"
+    DIAG_COORD_DEF_RHO2:
         $OCN_GRID == "tx2_3v2":  "${INPUTDIR}/ocean_rho2_190917.nc"
-    marbl_tracers_ic_file:
-        $MARBL_CONFIG == "latest": "${INPUTDIR}/ecosys_jan_IC_omip_latlon_1x1_180W_c231221.nc"
+    MARBL_TRACERS_IC_FILE:
+        $MARBL_CONFIG == "latest": "${INPUTDIR}/ecosys_jan_IC_omip_latlon_1x1_180W_c230331.nc"
         $MARBL_CONFIG == "latest+4p2z": "${INPUTDIR}/ecosys_jan_IC_omip_latlon_1x1_180W_c231221.nc"
-    marbl_fesedflux_file:
+    MARBL_FESEDFLUX_FILE:
         '"BASE_BIO_ON=TRUE" in $MARBL_TRACER_OPTS':
             $OCN_GRID == "tx2_3v2": "${INPUTDIR}/fesedflux_total_reduce_oxic_tx2_3v2.c231205.nc"
-    marbl_feventflux_file:
+    MARBL_FEVENTFLUX_FILE:
         '"BASE_BIO_ON=TRUE" in $MARBL_TRACER_OPTS':
             $OCN_GRID == "tx2_3v2": "${INPUTDIR}/feventflux_5gmol_tx2_3v2.c231205.nc"
-    riv_flux_file:
+    RIV_FLUX_FILE:
         '"BASE_BIO_ON=TRUE" in $MARBL_TRACER_OPTS':
             '$ROF_GRID == "JRA025" and $OCN_GRID == "tx2_3v2"': "${INPUTDIR}/riv_nut.gnews_gnm.rJRA025_to_tx2_3v2_nnsm_e333r100_230415.20240202.nc"
             '$ROF_GRID == "r05" and $OCN_GRID == "tx2_3v2"': "${INPUTDIR}/riv_nut.gnews_gnm.r05_to_tx2_3v2_nnsm_e250r250_230914.20240202.nc"
-    d14c_file_1:
+    MARBL_D14C_FILE_1:
         '"ABIO_DIC_ON=TRUE" in $MARBL_TRACER_OPTS': "${DIN_LOC_ROOT}/ocn/mom/grid_indpt/atm_delta_C14_CMIP6_sector1_global_1850-2015_yearly_v2.0_c240202.nc"
-    d14c_file_2:
+    MARBL_D14C_FILE_2:
         '"ABIO_DIC_ON=TRUE" in $MARBL_TRACER_OPTS': "${DIN_LOC_ROOT}/ocn/mom/grid_indpt/atm_delta_C14_CMIP6_sector2_global_1850-2015_yearly_v2.0_c240202.nc"
-    d14c_file_3:
+    MARBL_D14C_FILE_3:
         '"ABIO_DIC_ON=TRUE" in $MARBL_TRACER_OPTS': "${DIN_LOC_ROOT}/ocn/mom/grid_indpt/atm_delta_C14_CMIP6_sector3_global_1850-2015_yearly_v2.0_c240202.nc"
 ...

--- a/param_templates/json/MOM_input.json
+++ b/param_templates/json/MOM_input.json
@@ -2195,10 +2195,7 @@
       "IC_OUTPUT_FILE": {
          "description": "\"default = 'MOM_IC'\nThe file into which to write the initial conditions.\"\n",
          "datatype": "string",
-         "value": {
-            "$OCN_GRID == \"MISOMIP\"": "MISOMIP_IC",
-            "else": "= \"${CASE}.mom6.ic.${RUN_STARTDATE}.nc\""
-         }
+         "value": "= \"${CASE}.mom6.ic.${RUN_STARTDATE}.nc\""
       },
       "TRIMMING_USES_REMAPPING": {
          "description": "\"[Boolean] default = False\nWhen trimming the column, also remap T and S.\"\n",

--- a/param_templates/json/input_data_list.json
+++ b/param_templates/json/input_data_list.json
@@ -1,78 +1,90 @@
 {
    "mom.input_data_list": {
-      "ocean_hgrid": {
+      "GRID_FILE": {
          "$OCN_GRID == \"tx2_3v2\"": "${INPUTDIR}/ocean_hgrid_221123.nc",
          "$OCN_GRID == \"tx0.25v1\"": "${INPUTDIR}/ocean_hgrid.nc"
       },
-      "ocean_vgrid1": {
-         "$OCN_GRID == \"tx2_3v2\"": "${INPUTDIR}/vgrid_65L_20200626.nc",
+      "ALE_COORDINATE_CONFIG": {
+         "$MOM6_VERTICAL_GRID == \"zstar_75L\"": "${INPUTDIR}/zstar_75layer_2.5m_248.4m-2024-03-29.nc",
+         "$MOM6_VERTICAL_GRID == \"zstar_65L\"": "${INPUTDIR}/vgrid_65L_20200626.nc",
+         "$MOM6_VERTICAL_GRID == \"hycom1\" and $OCN_GRID != \"tx0.25v1\"": "${INPUTDIR}/hybrid_75layer_zstar2.50m-2020-11-23.nc",
+         "$MOM6_VERTICAL_GRID == \"hycom1\" and $OCN_GRID == \"tx0.25v1\"": "${INPUTDIR}/hycom1_75_800m.nc",
          "$OCN_GRID == \"tx0.25v1\"": "${INPUTDIR}/hycom1_75_800m.nc"
       },
-      "ocean_vgrid2": {
+      "DIAG_COORD_DEF_Z": {
          "$OCN_GRID == \"tx0.25v1\"": "${INPUTDIR}/interpolate_zgrid_40L.nc"
       },
-      "ocean_vgrid3": {
+      "COORD_FILE": {
          "$OCN_GRID == \"tx0.25v1\"": "${INPUTDIR}/layer_coord.nc"
       },
-      "ocean_topog": {
-         "$OCN_GRID == \"tx2_3v2\"": "${INPUTDIR}/ocean_topog_230413.nc",
+      "TOPO_FILE": {
+         "$OCN_GRID == \"tx2_3v2\"": "${INPUTDIR}/ocean_topo_tx2_3v2_240501.nc",
          "$OCN_GRID == \"tx0.25v1\"": "${INPUTDIR}/ocean_topog.nc"
       },
-      "ocean_topo_edit": {
+      "TOPO_EDITS_FILE": {
          "$OCN_GRID == \"tx0.25v1\"": "${INPUTDIR}/All_edits.nc"
       },
-      "tempsalt": {
+      "TEMP_SALT_Z_INIT_FILE": {
          "$OCN_GRID in [\"tx2_3v2\", \"tx0.25v1\"]": {
             "$INIT_LAYERS_FROM_Z_FILE == \"True\"": "${INPUTDIR}/${TEMP_SALT_Z_INIT_FILE}"
          }
       },
-      "saltrestore": {
+      "MAX_LAYER_THICKNESS_CONFIG": {
+         "$MOM6_VERTICAL_GRID == \"hycom1\" and $OCN_GRID in [\"tx2_3v2\"]": "${DIN_LOC_ROOT}/ocn/mom/grid_indpt/dz_max_90th_quantile.nc"
+      },
+      "SURFACE_PRESSURE_FILE": {
+         "$OCN_GRID == \"MISOMIP\"": "${INPUTDIR}/MISOMIP_181108.nc"
+      },
+      "SALT_RESTORE_FILE": {
          "$OCN_GRID == \"tx2_3v2\"": "${INPUTDIR}/state_restore_tx2_3_20230416.nc"
       },
-      "tidal": {
+      "TIDAL_ENERGY_FILE": {
+         "$OCN_GRID == \"tx2_3v2\"": "${INPUTDIR}/energy_new_tx2_3_conserve_230415_cdf5.nc",
          "$OCN_GRID == \"tx0.25v1\"": "${INPUTDIR}/tidal_amplitude.v20140616.nc"
       },
-      "ocean_channel": {
+      "CHANNEL_LIST_FILE": {
+         "$OCN_GRID == \"tx2_3v2\"": "${INPUTDIR}/MOM_channels_global_tx2_3v2_240501",
          "$OCN_GRID == \"tx0.25v1\"": "${INPUTDIR}/MOM_channels_global_025"
       },
-      "ocean_geothermal": {
+      "GEOTHERMAL_FILE": {
+         "$OCN_GRID == \"tx2_3v2\"": "${INPUTDIR}/geothermal_davies2013_tx2_3_20240318_cdf5.nc",
          "$OCN_GRID == \"tx0.25v1\"": "${INPUTDIR}/geothermal_davies2013_v1.nc"
       },
-      "ocean_seaw": {
+      "CHL_FILE": {
          "$OCN_GRID == \"tx0.25v1\"": "${INPUTDIR}/seawifs-clim-1997-2010.1440x1080.v20180328.nc",
          "$OCN_GRID == \"tx2_3v2\"": "${INPUTDIR}/seawifs-clim-1997-2010-tx2_3v2.230416.nc"
       },
-      "cfcs_forcing": "${DIN_LOC_ROOT}/ocn/mom/grid_indpt/cfc_atm_20230310.nc",
-      "diag_coord_def_rho2": {
+      "CFC_BC_FILE": "${DIN_LOC_ROOT}/ocn/mom/grid_indpt/cfc_atm_20230310.nc",
+      "DIAG_COORD_DEF_RHO2": {
          "$OCN_GRID == \"tx2_3v2\"": "${INPUTDIR}/ocean_rho2_190917.nc"
       },
-      "marbl_tracers_ic_file": {
-         "$MARBL_CONFIG == \"latest\"": "${INPUTDIR}/ecosys_jan_IC_omip_latlon_1x1_180W_c231221.nc",
+      "MARBL_TRACERS_IC_FILE": {
+         "$MARBL_CONFIG == \"latest\"": "${INPUTDIR}/ecosys_jan_IC_omip_latlon_1x1_180W_c230331.nc",
          "$MARBL_CONFIG == \"latest+4p2z\"": "${INPUTDIR}/ecosys_jan_IC_omip_latlon_1x1_180W_c231221.nc"
       },
-      "marbl_fesedflux_file": {
+      "MARBL_FESEDFLUX_FILE": {
          "\"BASE_BIO_ON=TRUE\" in $MARBL_TRACER_OPTS": {
             "$OCN_GRID == \"tx2_3v2\"": "${INPUTDIR}/fesedflux_total_reduce_oxic_tx2_3v2.c231205.nc"
          }
       },
-      "marbl_feventflux_file": {
+      "MARBL_FEVENTFLUX_FILE": {
          "\"BASE_BIO_ON=TRUE\" in $MARBL_TRACER_OPTS": {
             "$OCN_GRID == \"tx2_3v2\"": "${INPUTDIR}/feventflux_5gmol_tx2_3v2.c231205.nc"
          }
       },
-      "riv_flux_file": {
+      "RIV_FLUX_FILE": {
          "\"BASE_BIO_ON=TRUE\" in $MARBL_TRACER_OPTS": {
             "$ROF_GRID == \"JRA025\" and $OCN_GRID == \"tx2_3v2\"": "${INPUTDIR}/riv_nut.gnews_gnm.rJRA025_to_tx2_3v2_nnsm_e333r100_230415.20240202.nc",
             "$ROF_GRID == \"r05\" and $OCN_GRID == \"tx2_3v2\"": "${INPUTDIR}/riv_nut.gnews_gnm.r05_to_tx2_3v2_nnsm_e250r250_230914.20240202.nc"
          }
       },
-      "d14c_file_1": {
+      "MARBL_D14C_FILE_1": {
          "\"ABIO_DIC_ON=TRUE\" in $MARBL_TRACER_OPTS": "${DIN_LOC_ROOT}/ocn/mom/grid_indpt/atm_delta_C14_CMIP6_sector1_global_1850-2015_yearly_v2.0_c240202.nc"
       },
-      "d14c_file_2": {
+      "MARBL_D14C_FILE_2": {
          "\"ABIO_DIC_ON=TRUE\" in $MARBL_TRACER_OPTS": "${DIN_LOC_ROOT}/ocn/mom/grid_indpt/atm_delta_C14_CMIP6_sector2_global_1850-2015_yearly_v2.0_c240202.nc"
       },
-      "d14c_file_3": {
+      "MARBL_D14C_FILE_3": {
          "\"ABIO_DIC_ON=TRUE\" in $MARBL_TRACER_OPTS": "${DIN_LOC_ROOT}/ocn/mom/grid_indpt/atm_delta_C14_CMIP6_sector3_global_1850-2015_yearly_v2.0_c240202.nc"
       }
    }

--- a/tests/check_input_data_list.py
+++ b/tests/check_input_data_list.py
@@ -56,7 +56,7 @@ def get_input_files_in_MOM_input():
     To do so, it looks for all parameters ending with _FILE and all parameters with values of the form '*.FILE: ...'.
     """
 
-    MOM_input_yaml = yaml.safe_load(open("../param_templates/MOM_input.yaml", "r"))
+    MOM_input_yaml = yaml.safe_load(open("./param_templates/MOM_input.yaml", "r"))
 
     files = set()
 
@@ -103,7 +103,7 @@ def get_input_data_list_files():
             yield d
 
     input_data_list_yaml = yaml.safe_load(
-        open("../param_templates/input_data_list.yaml", "r")
+        open("./param_templates/input_data_list.yaml", "r")
     )
     input_data_list = input_data_list_yaml["mom.input_data_list"]
 

--- a/tests/check_input_data_list.py
+++ b/tests/check_input_data_list.py
@@ -37,7 +37,7 @@ def filter_files(func):
         # Remove all remaining files with expandable variables, since they most likely correspond to output file names
         files = {f for f in files if "$" not in f}
 
-        # For entries corresponding to relative or absolute paths, extract the file name:
+        # For entries corresponding to relative or absolute paths, retrieve only the file name:
         files = {f.split("/")[-1] for f in files}
 
         # Filter out known exceptions:
@@ -122,9 +122,10 @@ if __name__ == "__main__":
     # If not, print the missing files and raise an error
     missing_files = mom_input_files - input_data_list_files
     if missing_files:
-        print(
-            "The following files are in MOM_input.yaml but not in input_data_list.yaml:"
+        raise ValueError(
+            "Below parameter value(s) in MOM_input.yaml are suspected to be input file name(s), "
+            "but are not present in input_data_list.yaml. If these are indeed input files, "
+            "please add them to input_data_list.yaml. If not, please update this CI test module "
+            "to exclude them from the check e.g., by adding them to the EXCEPTIONS list.\n\n  "
+            + "\n  ".join(missing_files)
         )
-        for file in missing_files:
-            print(file)
-        raise ValueError("Above files are missing in input_data_list.yaml")

--- a/tests/check_input_data_list.py
+++ b/tests/check_input_data_list.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python
+
+import yaml
+import re
+
+
+# List of regex patterns to exclude known non-input files
+EXCEPTIONS = ["._velocity_truncations"]
+
+
+def filter_files(func):
+    """This decorator function filters out all non-input file names from the set of file names
+    returned by the decorated function. The decorator function removes all entries that are not
+    strings, all entries that contain expandable variables other than $DIN_LOC_ROOT and $INPUTDIR.
+    It also extracts only the file name from entries that contain relative or absolute paths.
+    Finally, it filters out known exceptions.
+    """
+
+    def wrapper():
+
+        files = func()
+
+        # Remove all entries that are not strings
+        files = {f for f in files if isinstance(f, str)}
+
+        # In file names, replace all occurrences of DIN_LOC_ROOT:
+        files = {
+            f.replace("${DIN_LOC_ROOT}/", "").replace("{$DIN_LOC_ROOT}/", "")
+            for f in files
+        }
+
+        # In file names, replace all occurrences of INPUTDIR:
+        files = {
+            f.replace("${INPUTDIR}/", "").replace("{$INPUTDIR}/", "") for f in files
+        }
+
+        # Remove all remaining files with expandable variables, since they most likely correspond to output file names
+        files = {f for f in files if "$" not in f}
+
+        # For entries corresponding to relative or absolute paths, extract the file name:
+        files = {f.split("/")[-1] for f in files}
+
+        # Filter out known exceptions:
+        for pattern in EXCEPTIONS:
+            files = {f for f in files if not re.match(pattern, f)}
+
+        return files
+
+    return wrapper
+
+
+@filter_files
+def get_input_files_in_MOM_input():
+    """
+    This function reads the MOM_input.yaml file and extracts all input file names that it can detect.
+    To do so, it looks for all parameters ending with _FILE and all parameters with values of the form '*.FILE: ...'.
+    """
+
+    MOM_input_yaml = yaml.safe_load(open("../param_templates/MOM_input.yaml", "r"))
+
+    files = set()
+
+    # Part 1 - Find all input parameters ending with _FILE
+    for module in MOM_input_yaml:
+        for varname in MOM_input_yaml[module]:
+            if varname.endswith("_FILE"):
+                value = MOM_input_yaml[module][varname]["value"]
+                if isinstance(value, str):
+                    files.add(value)
+                elif isinstance(value, dict):
+                    for key in value:
+                        files.add(value[key])
+                else:
+                    raise ValueError("Unexpected value type: {}".format(type(value)))
+
+    # Part 2 - Go through all parameters and gather those with values '*.FILE: ...'
+    extract_filename = lambda x: x.split("FILE:")[1].split(",")[0]
+    for module in MOM_input_yaml:
+        for varname in MOM_input_yaml[module]:
+            value = MOM_input_yaml[module][varname]["value"]
+            if isinstance(value, str) and "FILE:" in value:
+                files.add(extract_filename(value))
+            elif isinstance(value, dict):
+                for key in value:
+                    if isinstance(value[key], str) and "FILE:" in value[key]:
+                        files.add(extract_filename(value[key]))
+
+    return files
+
+
+@filter_files
+def get_input_data_list_files():
+    """
+    This function reads the input_data_list.yaml file and extracts all input file names in it.
+    """
+
+    # a recursive function to extract all values from a nested dictionary:
+    def extract_values(d):
+        if isinstance(d, dict):
+            for key in d:
+                yield from extract_values(d[key])
+        else:
+            yield d
+
+    input_data_list_yaml = yaml.safe_load(
+        open("../param_templates/input_data_list.yaml", "r")
+    )
+    input_data_list = input_data_list_yaml["mom.input_data_list"]
+
+    files = {
+        v for file in input_data_list for v in extract_values(input_data_list[file])
+    }
+
+    return files
+
+
+if __name__ == "__main__":
+    mom_input_files = get_input_files_in_MOM_input()
+    input_data_list_files = get_input_data_list_files()
+
+    # Check if all files in input_data_list.yaml are also in MOM_input.yaml
+    # If not, print the missing files and raise an error
+    missing_files = mom_input_files - input_data_list_files
+    if missing_files:
+        print(
+            "The following files are in MOM_input.yaml but not in input_data_list.yaml:"
+        )
+        for file in missing_files:
+            print(file)
+        raise ValueError("Above files are missing in input_data_list.yaml")

--- a/tests/check_input_data_list.py
+++ b/tests/check_input_data_list.py
@@ -23,6 +23,11 @@ def filter_files(func):
         # Remove all entries that are not strings
         files = {f for f in files if isinstance(f, str)}
 
+        # Remove all entries that contain expandable variables other than DIN_LOC_ROOT and INPUTDIR:
+        files = {
+            f for f in files if "$" not in f or "DIN_LOC_ROOT" in f or "INPUTDIR" in f
+        }
+
         # In file names, replace all occurrences of DIN_LOC_ROOT:
         files = {
             f.replace("${DIN_LOC_ROOT}/", "").replace("{$DIN_LOC_ROOT}/", "")
@@ -33,9 +38,6 @@ def filter_files(func):
         files = {
             f.replace("${INPUTDIR}/", "").replace("{$INPUTDIR}/", "") for f in files
         }
-
-        # Remove all remaining files with expandable variables, since they most likely correspond to output file names
-        files = {f for f in files if "$" not in f}
 
         # For entries corresponding to relative or absolute paths, retrieve only the file name:
         files = {f.split("/")[-1] for f in files}
@@ -129,3 +131,5 @@ if __name__ == "__main__":
             "to exclude them from the check e.g., by adding them to the EXCEPTIONS list.\n\n  "
             + "\n  ".join(missing_files)
         )
+
+    print("All input files in MOM_input.yaml are present in input_data_list.yaml.")

--- a/tests/check_input_data_repo.py
+++ b/tests/check_input_data_repo.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python
+
+import yaml
+import svn.remote as sr
+from check_input_data_list import (
+    get_input_files_in_MOM_input,
+    get_input_data_list_files,
+)
+
+if __name__ == "__main__":
+
+    # Read in the MOM_input.yaml file and extract all input file names
+    MOM_input_yaml = yaml.safe_load(open("./param_templates/MOM_input.yaml", "r"))
+    MOM_input_files = get_input_files_in_MOM_input(MOM_input_yaml)
+
+    # Read in the input_data_list.yaml file and extract all input file names
+    input_data_list_yaml = yaml.safe_load(
+        open("./param_templates/input_data_list.yaml", "r")
+    )
+    input_data_list_files = get_input_data_list_files(
+        input_data_list_yaml, MOM_input_files
+    )
+
+    # all mom input file names in svn inputdata repository
+    r = sr.RemoteClient(
+        "https://svn-ccsm-inputdata.cgd.ucar.edu/trunk/inputdata/ocn/mom/"
+    )
+    repo_files = {f["name"] for relpath, f in r.list_recursive() if f["kind"] == "file"}
+
+    # File names missing in the svn repository
+    missing_files = (
+        set(
+            filename
+            for filelist in input_data_list_files.values()
+            for filename in filelist
+        )
+        - repo_files
+    )
+    if missing_files:
+        raise ValueError(
+            "Below file names are listed in input_data_list.yaml but are missing "
+            "in the svn inputdata repository. If these files are not needed, "
+            "please remove them from input_data_list.yaml. If they are needed, "
+            "please import them to the svn repository.\n\n  "
+            + "\n  ".join(missing_files)
+        )
+    else:
+        print("All files in input_data_list.yaml are present in the svn repository.")


### PR DESCRIPTION
introduces two CI tests
 1. Check whether any input file names in `MOM_input.yaml` is missing in `input_data_list.yaml`.
 2. Check whether any input files listed in `input_data_list.yaml` is missing in svn inputdata repository.

Limitation: This CI test only checks filenames and not absolute/relative paths.

Fixes: #194, #195

Current ` check_input_data_list.py` output:

```
ValueError: Below parameter value(s) in MOM_input.yaml are suspected to be input file name(s), but are not present in input_data_list.yaml. If these are indeed input files, please add them to input_data_list.yaml. If not, please update this CI test module to exclude them from the check e.g., by adding them to the EXCEPTIONS list.

  MISOMIP_181108.nc
  dz_max_90th_quantile.nc
  ecosys_jan_IC_omip_latlon_1x1_180W_c230331.nc
  MOM_channels_global_025
  energy_new_tx2_3_conserve_230415_cdf5.nc
  MISOMIP_IC
  zstar_75layer_2.5m_248.4m-2024-03-29.nc
  MOM_channels_global_tx2_3v2_240501
  geothermal_davies2013_tx2_3_20240318_cdf5.nc
  ocean_topo_tx2_3v2_240501.nc
  hybrid_75layer_zstar2.50m-2020-11-23.nc
```

Current ` check_input_data_repo.py` output (if input_data_list were completed).

```
ValueError: Below file names are listed in input_data_list.yaml but are missing in the svn inputdata repository. If these files are not needed, please remove them from input_data_list.yaml. If they are needed, please import them to the svn repository.

  ecosys_jan_IC_omip_latlon_1x1_180W_c230331.nc
  hybrid_75layer_zstar2.50m-2020-11-23.nc
  riv_nut.gnews_gnm.r05_to_tx2_3v2_nnsm_e250r250_230914.20240202.nc
```