### PR TITLE
config_pes.xml updates

### DIFF
--- a/cime_config/config_component.xml
+++ b/cime_config/config_component.xml
@@ -83,6 +83,26 @@
     </desc>
   </entry>
 
+  <entry id="MOM6_WW3_CPL_METHOD">
+    <type>char</type>
+    <valid_values>none,legacy,most</valid_values>
+    <default_value>most</default_value>
+    <values>
+      <value grid="w%ww3a">legacy</value>
+      <value compset="_SWAV|_DWAV">none</value>
+    </values>
+    <group>run_component_mom</group>
+    <file>env_run.xml</file>
+    <desc> This variable determines the method used to couple MOM6 to WW3.
+           The method "most" corresponds to the newest coupling method 
+           that turns on FPMix parameterization, Stokes_Bands coupling,
+           and Stokes similarity package. The method "legacy" corresponds to
+           the older coupling method based on receiving a Langmuir number from
+           WW3 and passing it to CVMix. When set to "none", no wave
+           parameterization is used.
+    </desc>
+  </entry>
+
   <entry id="OCN_DIAG_MODE">
     <type>char</type>
     <valid_values>spinup,production,development,none</valid_values>

--- a/cime_config/config_pes.xml
+++ b/cime_config/config_pes.xml
@@ -41,7 +41,7 @@
     </mach>
   </grid>
 
-  <grid name="a%T62.+oi%(tx0.66v1|tx2_3v2)">
+  <grid name="a%(TL319|T62).+oi%tx2_3v2">
     <mach name="any">
       <pes pesize="any" compset="any">
         <comment>none</comment>
@@ -184,7 +184,7 @@
           <ntasks_rof>128</ntasks_rof>
           <ntasks_cpl>128</ntasks_cpl>
           <ntasks_ice>128</ntasks_ice>
-          <ntasks_ocn>384</ntasks_ocn>
+          <ntasks_ocn>1024</ntasks_ocn>
           <ntasks_lnd>1</ntasks_lnd>
           <ntasks_wav>256</ntasks_wav>
           <ntasks_glc>1</ntasks_glc>
@@ -204,9 +204,9 @@
           <rootpe_rof>0</rootpe_rof>
           <rootpe_cpl>0</rootpe_cpl>
           <rootpe_ice>0</rootpe_ice>
-          <rootpe_ocn>256</rootpe_ocn>
+          <rootpe_ocn>384</rootpe_ocn>
           <rootpe_lnd>0</rootpe_lnd>
-          <rootpe_wav>0</rootpe_wav>
+          <rootpe_wav>128</rootpe_wav>
           <rootpe_glc>0</rootpe_glc>
         </rootpe>
       </pes>
@@ -380,245 +380,7 @@
     </mach>
   </grid>
 
-  <grid name="a%TL319.+oi%(tx0.66v1|tx2_3v2)">
-    <mach name="any">
-      <pes pesize="any" compset="_DATM.+_DICE.+_SWAV">
-        <comment>none</comment>
-        <ntasks>
-          <ntasks_atm>48</ntasks_atm>
-          <ntasks_rof>48</ntasks_rof>
-          <ntasks_cpl>48</ntasks_cpl>
-          <ntasks_ice>48</ntasks_ice>
-          <ntasks_ocn>144</ntasks_ocn>
-          <ntasks_lnd>1</ntasks_lnd>
-          <ntasks_wav>1</ntasks_wav>
-          <ntasks_glc>1</ntasks_glc>
-        </ntasks>
-        <nthrds>
-          <nthrds_atm>1</nthrds_atm>
-          <nthrds_lnd>1</nthrds_lnd>
-          <nthrds_rof>1</nthrds_rof>
-          <nthrds_ice>1</nthrds_ice>
-          <nthrds_ocn>1</nthrds_ocn>
-          <nthrds_glc>1</nthrds_glc>
-          <nthrds_wav>1</nthrds_wav>
-          <nthrds_cpl>1</nthrds_cpl>
-        </nthrds>
-        <rootpe>
-          <rootpe_atm>0</rootpe_atm>
-          <rootpe_rof>0</rootpe_rof>
-          <rootpe_cpl>0</rootpe_cpl>
-          <rootpe_ice>0</rootpe_ice>
-          <rootpe_ocn>48</rootpe_ocn>
-          <rootpe_lnd>0</rootpe_lnd>
-          <rootpe_wav>0</rootpe_wav>
-          <rootpe_glc>0</rootpe_glc>
-        </rootpe>
-      </pes>
-      <pes pesize="any" compset="_DATM.+_CICE.*_MOM6(?!.*%MARBL-BIO).+_SWAV">
-        <comment>none</comment>
-        <ntasks>
-          <ntasks_atm>96</ntasks_atm>
-          <ntasks_rof>96</ntasks_rof>
-          <ntasks_cpl>96</ntasks_cpl>
-          <ntasks_ice>96</ntasks_ice>
-          <ntasks_ocn>144</ntasks_ocn>
-          <ntasks_lnd>1</ntasks_lnd>
-          <ntasks_wav>1</ntasks_wav>
-          <ntasks_glc>1</ntasks_glc>
-        </ntasks>
-        <nthrds>
-          <nthrds_atm>1</nthrds_atm>
-          <nthrds_lnd>1</nthrds_lnd>
-          <nthrds_rof>1</nthrds_rof>
-          <nthrds_ice>1</nthrds_ice>
-          <nthrds_ocn>1</nthrds_ocn>
-          <nthrds_glc>1</nthrds_glc>
-          <nthrds_wav>1</nthrds_wav>
-          <nthrds_cpl>1</nthrds_cpl>
-        </nthrds>
-        <rootpe>
-          <rootpe_atm>0</rootpe_atm>
-          <rootpe_rof>0</rootpe_rof>
-          <rootpe_cpl>0</rootpe_cpl>
-          <rootpe_ice>0</rootpe_ice>
-          <rootpe_ocn>96</rootpe_ocn>
-          <rootpe_lnd>0</rootpe_lnd>
-          <rootpe_wav>0</rootpe_wav>
-          <rootpe_glc>0</rootpe_glc>
-        </rootpe>
-      </pes>
-    </mach>
-    <mach name="derecho">
-      <pes pesize="any" compset="_DATM.+_DICE.*_MOM6(?!.*%MARBL-BIO).+_SWAV">
-        <comment>none</comment>
-        <ntasks>
-          <ntasks_atm>128</ntasks_atm>
-          <ntasks_rof>128</ntasks_rof>
-          <ntasks_cpl>128</ntasks_cpl>
-          <ntasks_ice>128</ntasks_ice>
-          <ntasks_ocn>896</ntasks_ocn>
-          <ntasks_lnd>1</ntasks_lnd>
-          <ntasks_wav>1</ntasks_wav>
-          <ntasks_glc>1</ntasks_glc>
-        </ntasks>
-        <nthrds>
-          <nthrds_atm>1</nthrds_atm>
-          <nthrds_lnd>1</nthrds_lnd>
-          <nthrds_rof>1</nthrds_rof>
-          <nthrds_ice>1</nthrds_ice>
-          <nthrds_ocn>1</nthrds_ocn>
-          <nthrds_glc>1</nthrds_glc>
-          <nthrds_wav>1</nthrds_wav>
-          <nthrds_cpl>1</nthrds_cpl>
-        </nthrds>
-        <rootpe>
-          <rootpe_atm>0</rootpe_atm>
-          <rootpe_rof>0</rootpe_rof>
-          <rootpe_cpl>0</rootpe_cpl>
-          <rootpe_ice>0</rootpe_ice>
-          <rootpe_ocn>128</rootpe_ocn>
-          <rootpe_lnd>0</rootpe_lnd>
-          <rootpe_wav>0</rootpe_wav>
-          <rootpe_glc>0</rootpe_glc>
-        </rootpe>
-      </pes>
-      <pes pesize="any" compset="_DATM.+_DICE.*_MOM6%[^_]*MARBL-BIO.+_SWAV">
-        <comment>none</comment>
-        <ntasks>
-          <ntasks_atm>128</ntasks_atm>
-          <ntasks_rof>128</ntasks_rof>
-          <ntasks_cpl>128</ntasks_cpl>
-          <ntasks_ice>128</ntasks_ice>
-          <ntasks_ocn>2560</ntasks_ocn>
-          <ntasks_lnd>1</ntasks_lnd>
-          <ntasks_wav>1</ntasks_wav>
-          <ntasks_glc>1</ntasks_glc>
-        </ntasks>
-        <nthrds>
-          <nthrds_atm>1</nthrds_atm>
-          <nthrds_lnd>1</nthrds_lnd>
-          <nthrds_rof>1</nthrds_rof>
-          <nthrds_ice>1</nthrds_ice>
-          <nthrds_ocn>1</nthrds_ocn>
-          <nthrds_glc>1</nthrds_glc>
-          <nthrds_wav>1</nthrds_wav>
-          <nthrds_cpl>1</nthrds_cpl>
-        </nthrds>
-        <rootpe>
-          <rootpe_atm>0</rootpe_atm>
-          <rootpe_rof>0</rootpe_rof>
-          <rootpe_cpl>0</rootpe_cpl>
-          <rootpe_ice>0</rootpe_ice>
-          <rootpe_ocn>128</rootpe_ocn>
-          <rootpe_lnd>0</rootpe_lnd>
-          <rootpe_wav>0</rootpe_wav>
-          <rootpe_glc>0</rootpe_glc>
-        </rootpe>
-      </pes>
-      <pes pesize="any" compset="_DATM.+_CICE.*_MOM6(?!.*%MARBL-BIO).+_SWAV">
-        <comment>none</comment>
-        <ntasks>
-          <ntasks_atm>128</ntasks_atm>
-          <ntasks_rof>128</ntasks_rof>
-          <ntasks_cpl>128</ntasks_cpl>
-          <ntasks_ice>128</ntasks_ice>
-          <ntasks_ocn>896</ntasks_ocn>
-          <ntasks_lnd>1</ntasks_lnd>
-          <ntasks_wav>1</ntasks_wav>
-          <ntasks_glc>1</ntasks_glc>
-        </ntasks>
-        <nthrds>
-          <nthrds_atm>1</nthrds_atm>
-          <nthrds_lnd>1</nthrds_lnd>
-          <nthrds_rof>1</nthrds_rof>
-          <nthrds_ice>1</nthrds_ice>
-          <nthrds_ocn>1</nthrds_ocn>
-          <nthrds_glc>1</nthrds_glc>
-          <nthrds_wav>1</nthrds_wav>
-          <nthrds_cpl>1</nthrds_cpl>
-        </nthrds>
-        <rootpe>
-          <rootpe_atm>0</rootpe_atm>
-          <rootpe_rof>0</rootpe_rof>
-          <rootpe_cpl>0</rootpe_cpl>
-          <rootpe_ice>0</rootpe_ice>
-          <rootpe_ocn>128</rootpe_ocn>
-          <rootpe_lnd>0</rootpe_lnd>
-          <rootpe_wav>0</rootpe_wav>
-          <rootpe_glc>0</rootpe_glc>
-        </rootpe>
-      </pes>
-      <pes pesize="any" compset="_DATM.+_CICE.*_MOM6%[^_]*MARBL-BIO.+_SWAV">
-        <comment>none</comment>
-        <ntasks>
-          <ntasks_atm>128</ntasks_atm>
-          <ntasks_rof>128</ntasks_rof>
-          <ntasks_cpl>128</ntasks_cpl>
-          <ntasks_ice>128</ntasks_ice>
-          <ntasks_ocn>2560</ntasks_ocn>
-          <ntasks_lnd>1</ntasks_lnd>
-          <ntasks_wav>1</ntasks_wav>
-          <ntasks_glc>1</ntasks_glc>
-        </ntasks>
-        <nthrds>
-          <nthrds_atm>1</nthrds_atm>
-          <nthrds_lnd>1</nthrds_lnd>
-          <nthrds_rof>1</nthrds_rof>
-          <nthrds_ice>1</nthrds_ice>
-          <nthrds_ocn>1</nthrds_ocn>
-          <nthrds_glc>1</nthrds_glc>
-          <nthrds_wav>1</nthrds_wav>
-          <nthrds_cpl>1</nthrds_cpl>
-        </nthrds>
-        <rootpe>
-          <rootpe_atm>0</rootpe_atm>
-          <rootpe_rof>0</rootpe_rof>
-          <rootpe_cpl>0</rootpe_cpl>
-          <rootpe_ice>0</rootpe_ice>
-          <rootpe_ocn>128</rootpe_ocn>
-          <rootpe_lnd>0</rootpe_lnd>
-          <rootpe_wav>0</rootpe_wav>
-          <rootpe_glc>0</rootpe_glc>
-        </rootpe>
-      </pes>
-      <pes pesize="any" compset="DATM.+CICE.+WW3">
-        <comment>none</comment>
-        <ntasks>
-          <ntasks_atm>128</ntasks_atm>
-          <ntasks_rof>128</ntasks_rof>
-          <ntasks_cpl>128</ntasks_cpl>
-          <ntasks_ice>128</ntasks_ice>
-          <ntasks_ocn>384</ntasks_ocn>
-          <ntasks_lnd>1</ntasks_lnd>
-          <ntasks_wav>256</ntasks_wav>
-          <ntasks_glc>1</ntasks_glc>
-        </ntasks>
-        <nthrds>
-          <nthrds_atm>1</nthrds_atm>
-          <nthrds_lnd>1</nthrds_lnd>
-          <nthrds_rof>1</nthrds_rof>
-          <nthrds_ice>1</nthrds_ice>
-          <nthrds_ocn>1</nthrds_ocn>
-          <nthrds_glc>1</nthrds_glc>
-          <nthrds_wav>1</nthrds_wav>
-          <nthrds_cpl>1</nthrds_cpl>
-        </nthrds>
-        <rootpe>
-          <rootpe_atm>0</rootpe_atm>
-          <rootpe_rof>0</rootpe_rof>
-          <rootpe_cpl>0</rootpe_cpl>
-          <rootpe_ice>0</rootpe_ice>
-          <rootpe_ocn>256</rootpe_ocn>
-          <rootpe_lnd>0</rootpe_lnd>
-          <rootpe_wav>0</rootpe_wav>
-          <rootpe_glc>0</rootpe_glc>
-        </rootpe>
-      </pes>
-    </mach>
-  </grid>
-
-  <grid name="a%T62.+oi%tx0.25v1">
+  <grid name="a%(TL319|T62).+oi%tx0.25v1">
     <mach name="derecho">
       <pes pesize="any" compset="any">
         <comment>none</comment>
@@ -627,7 +389,7 @@
           <ntasks_rof>128</ntasks_rof>
           <ntasks_cpl>128</ntasks_cpl>
           <ntasks_ice>128</ntasks_ice>
-          <ntasks_ocn>896</ntasks_ocn>
+          <ntasks_ocn>1024</ntasks_ocn>
           <ntasks_lnd>1</ntasks_lnd>
           <ntasks_wav>1</ntasks_wav>
           <ntasks_glc>1</ntasks_glc>
@@ -660,7 +422,7 @@
           <ntasks_rof>128</ntasks_rof>
           <ntasks_cpl>128</ntasks_cpl>
           <ntasks_ice>256</ntasks_ice>
-          <ntasks_ocn>512</ntasks_ocn>
+          <ntasks_ocn>1024</ntasks_ocn>
           <ntasks_lnd>1</ntasks_lnd>
           <ntasks_wav>1</ntasks_wav>
           <ntasks_glc>1</ntasks_glc>
@@ -689,41 +451,4 @@
     </mach>
   </grid>
 
-  <grid name="oi%tx0.66v1.+w%wtx0.66v1">
-    <mach name="derecho">
-      <pes pesize="any" compset="any">
-        <comment>none</comment>
-        <ntasks>
-          <ntasks_atm>128</ntasks_atm>
-          <ntasks_rof>128</ntasks_rof>
-          <ntasks_cpl>128</ntasks_cpl>
-          <ntasks_ice>128</ntasks_ice>
-          <ntasks_ocn>512</ntasks_ocn>
-          <ntasks_lnd>1</ntasks_lnd>
-          <ntasks_wav>128</ntasks_wav>
-          <ntasks_glc>1</ntasks_glc>
-        </ntasks>
-        <nthrds>
-          <nthrds_atm>1</nthrds_atm>
-          <nthrds_lnd>1</nthrds_lnd>
-          <nthrds_rof>1</nthrds_rof>
-          <nthrds_ice>1</nthrds_ice>
-          <nthrds_ocn>1</nthrds_ocn>
-          <nthrds_glc>1</nthrds_glc>
-          <nthrds_wav>1</nthrds_wav>
-          <nthrds_cpl>1</nthrds_cpl>
-        </nthrds>
-        <rootpe>
-          <rootpe_atm>0</rootpe_atm>
-          <rootpe_rof>0</rootpe_rof>
-          <rootpe_cpl>0</rootpe_cpl>
-          <rootpe_ice>0</rootpe_ice>
-          <rootpe_ocn>256</rootpe_ocn>
-          <rootpe_lnd>0</rootpe_lnd>
-          <rootpe_wav>128</rootpe_wav>
-          <rootpe_glc>0</rootpe_glc>
-        </rootpe>
-      </pes>
-    </mach>
-  </grid>
 </config_pes>

--- a/cime_config/config_pes.xml
+++ b/cime_config/config_pes.xml
@@ -184,7 +184,7 @@
           <ntasks_rof>128</ntasks_rof>
           <ntasks_cpl>128</ntasks_cpl>
           <ntasks_ice>128</ntasks_ice>
-          <ntasks_ocn>1024</ntasks_ocn>
+          <ntasks_ocn>896</ntasks_ocn>
           <ntasks_lnd>1</ntasks_lnd>
           <ntasks_wav>256</ntasks_wav>
           <ntasks_glc>1</ntasks_glc>
@@ -389,7 +389,7 @@
           <ntasks_rof>128</ntasks_rof>
           <ntasks_cpl>128</ntasks_cpl>
           <ntasks_ice>128</ntasks_ice>
-          <ntasks_ocn>1024</ntasks_ocn>
+          <ntasks_ocn>896</ntasks_ocn>
           <ntasks_lnd>1</ntasks_lnd>
           <ntasks_wav>1</ntasks_wav>
           <ntasks_glc>1</ntasks_glc>
@@ -422,7 +422,7 @@
           <ntasks_rof>128</ntasks_rof>
           <ntasks_cpl>128</ntasks_cpl>
           <ntasks_ice>256</ntasks_ice>
-          <ntasks_ocn>1024</ntasks_ocn>
+          <ntasks_ocn>896</ntasks_ocn>
           <ntasks_lnd>1</ntasks_lnd>
           <ntasks_wav>1</ntasks_wav>
           <ntasks_glc>1</ntasks_glc>

--- a/param_templates/MOM_input.yaml
+++ b/param_templates/MOM_input.yaml
@@ -220,7 +220,9 @@ Global:
              for backward compatibility but ideally should be 0."
         datatype: real
         units: PPT
-        value: 0.0
+        value: 
+            $COMP_ATM == "cam": 1.0e-6
+            else: 0.0
     BOUND_SALINITY:
         description: |
             "[Boolean] default = False
@@ -988,7 +990,9 @@ Global:
             If true, use a Laplacian horizontal viscosity."
         datatype: logical
         units: Boolean
-        value: True
+        value:
+            $OCN_GRID == "tx2_3v2": False
+            else: True
     KH:
         description: |
             "[m2 s-1] default = 0.0
@@ -2331,7 +2335,6 @@ Global:
         units: nondim
         value:
             $OCN_GRID == "tx0.25v1": 0.15
-            $OCN_GRID == "tx2_3v2": 1.0
     MEKE_ALPHA_EADY:
         description: |
             "[nondim] default = 0.05
@@ -2342,33 +2345,6 @@ Global:
         value:
             $OCN_GRID == "tx0.25v1": 0.15
             $OCN_GRID == "tx2_3v2": 1.0
-    MEKE_ALPHA_DEFORM:
-        description: |
-            "[nondim] default = 0.0
-            If positive, is a coefficient weighting the deformation scale in the
-            expression for mixing length used in MEKE-derived diffusivity."
-        datatype: real
-        units: nondim
-        value:
-            $OCN_GRID == "tx2_3v2": 1.0
-    MEKE_ALPHA_FRICT:
-        description: |
-            "[nondim] default = 0.0
-            If positive, is a coefficient weighting the frictional arrest scale in the
-            expression for mixing length used in MEKE-derived diffusivity."
-        datatype: real
-        units: nondim
-        value:
-            $OCN_GRID == "tx2_3v2": 1.0
-    MEKE_ALPHA_GRID:
-        description: |
-            "[nondim] default = 0.0
-            If positive, is a coefficient weighting the grid-spacing as a scale in the
-            expression for mixing length used in MEKE-derived diffusivity."
-        datatype: real
-        units: nondim
-        value:
-            $OCN_GRID == "tx2_3v2": 1.0
     MEKE_FRCOEFF:
         description: |
             "[nondim] default = -1.0
@@ -2378,6 +2354,15 @@ Global:
         units: nondim
         value:
             $OCN_GRID == "tx2_3v2": 0.3
+    MEKE_CT:
+        description: |
+            "[nondim] default = 50.0
+            ! A coefficient in the expression for the ratio of barotropic eddy energy and
+            ! mean column energy (see Jansen et al. 2015)."
+        datatype: real
+        units: nondim
+        value:
+            $OCN_GRID == "tx2_3v2": 0.0
     MEKE_POSITIVE:
         description: |
             "[Boolean] default = False
@@ -2738,7 +2723,7 @@ Global:
         datatype: logical
         units: Boolean
         value:
-            $COMP_WAV == "ww3" and $WAV_GRID in ["wtx2_3v2", "wgx3v7"]: True
+            $COMP_WAV == "ww3" and $MOM6_WW3_CPL_METHOD == "most": True
     CEMP_NL:
         description: |
             "default = 3.6
@@ -2746,7 +2731,7 @@ Global:
         datatype: real
         units: nondim
         value:
-            $COMP_WAV == "ww3" and $WAV_GRID in ["wtx2_3v2", "wgx3v7"]: 2.0
+            $COMP_WAV == "ww3" and $MOM6_WW3_CPL_METHOD == "most": 2.0
 
     # MISOMIP-only variables:
 
@@ -3541,7 +3526,7 @@ Global:
             If true, enables surface wave modules."
         datatype: logical
         value:
-            $COMP_WAV == "ww3": True
+            $COMP_WAV == "ww3" and $MOM6_WW3_CPL_METHOD != "none": True
     WAVE_METHOD:
         description: |
             "Choice of wave method, valid options include:
@@ -3552,8 +3537,8 @@ Global:
              EFACTOR       - Applies an enhancement factor to the KPP...""
         datatype: string
         value:
-            $COMP_WAV == "ww3" and $WAV_GRID == "ww3a" : "EFACTOR"
-            $COMP_WAV == "ww3" and $WAV_GRID in ["wtx2_3v2", "wgx3v7"]: "SURFACE_BANDS"
+            $COMP_WAV == "ww3" and $MOM6_WW3_CPL_METHOD == "legacy" : "EFACTOR"
+            $COMP_WAV == "ww3" and $MOM6_WW3_CPL_METHOD == "most": "SURFACE_BANDS"
     SURFBAND_SOURCE:
         description: |
             Choice of SURFACE_BANDS data mode, valid options include:
@@ -3562,28 +3547,28 @@ Global:
             INPUT         - Testing with fixed values.
         datatype: string
         value:
-            $COMP_WAV == "ww3" and $WAV_GRID in ["wtx2_3v2", "wgx3v7"]: "COUPLER"
+            $COMP_WAV == "ww3" and $MOM6_WW3_CPL_METHOD == "most": "COUPLER"
     STOKES_DDT:
         description: |
             default = False
             Flag to use Stokes d/dt
         datatype: string
         value:
-            $COMP_WAV == "ww3" and $WAV_GRID in ["wtx2_3v2", "wgx3v7"]: True
+            $COMP_WAV == "ww3" and $MOM6_WW3_CPL_METHOD == "most": True
     STOKES_VF:
         description: |
             default = False
             Flag to use Stokes vortex force
         datatype: string
         value:
-            $COMP_WAV == "ww3" and $WAV_GRID in ["wtx2_3v2", "wgx3v7"]: True
+            $COMP_WAV == "ww3" and $MOM6_WW3_CPL_METHOD == "most": True
     STOKES_PGF:
         description: |
             default = False
             Flag to use Stokes pressure gradient force
         datatype: string
         value:
-            $COMP_WAV == "ww3" and $WAV_GRID in ["wtx2_3v2", "wgx3v7"]: True
+            $COMP_WAV == "ww3" and $MOM6_WW3_CPL_METHOD == "most": True
     STK_BAND_COUPLER:
         description: |
             default = 1
@@ -3592,14 +3577,14 @@ Global:
             will fail.
         datatype: int
         value:
-            $COMP_WAV == "ww3" and $WAV_GRID in ["wtx2_3v2", "wgx3v7"]: 3
+            $COMP_WAV == "ww3" and $MOM6_WW3_CPL_METHOD == "most": 3
     SURFBAND_WAVENUMBERS:
         description: |
             [rad/m] default = 0.12566
             Central wavenumbers for surface Stokes drift bands.
         datatype: string
         value:
-            $COMP_WAV == "ww3" and $WAV_GRID in ["wtx2_3v2", "wgx3v7"]: "0.04, 0.11, 0.33"
+            $COMP_WAV == "ww3" and $MOM6_WW3_CPL_METHOD == "most": "0.04, 0.11, 0.33"
     IO_LAYOUT:
         description: |
             The processor layout to be used, or 0,0 to automatically set the io_layout to
@@ -3679,7 +3664,7 @@ KPP:
         datatype: logical
         units: Boolean
         value:
-            $COMP_WAV == "ww3" and $WAV_GRID == "ww3a" : True
+            $COMP_WAV == "ww3" and $MOM6_WW3_CPL_METHOD == "legacy": True
     USE_KPP_LT_VT2:
         description: |
             default = False
@@ -3687,7 +3672,7 @@ KPP:
         datatype: logical
         units: Boolean
         value:
-            $COMP_WAV == "ww3" and $WAV_GRID == "ww3a" : True
+            $COMP_WAV == "ww3" and $MOM6_WW3_CPL_METHOD == "legacy": True
     KPP_LT_K_METHOD:
         description: |
             default = "CONSTANT"
@@ -3715,6 +3700,6 @@ KPP:
             If True, use Stokes Similarity package.
         datatype: logical
         value:
-            $COMP_WAV == "ww3" and $WAV_GRID in ["wtx2_3v2", "wgx3v7"]: True    
+            $COMP_WAV == "ww3" and $MOM6_WW3_CPL_METHOD == "most": True    
 
 ...

--- a/param_templates/json/MOM_input.json
+++ b/param_templates/json/MOM_input.json
@@ -140,7 +140,10 @@
          "description": "\"[PPT] default = 0.01\n The minimum value of salinity when BOUND_SALINITY=True. The default is 0.01\n for backward compatibility but ideally should be 0.\"\n",
          "datatype": "real",
          "units": "PPT",
-         "value": 0.0
+         "value": {
+            "$COMP_ATM == \"cam\"": 1e-06,
+            "else": 0.0
+         }
       },
       "BOUND_SALINITY": {
          "description": "\"[Boolean] default = False\nIf true, limit salinity to being positive. (The sea-ice\nmodel may ask for more salt than is available and\ndrive the salinity negative otherwise.)\"\n",
@@ -744,7 +747,10 @@
          "description": "\"[Boolean] default = False\nIf true, use a Laplacian horizontal viscosity.\"\n",
          "datatype": "logical",
          "units": "Boolean",
-         "value": true
+         "value": {
+            "$OCN_GRID == \"tx2_3v2\"": false,
+            "else": true
+         }
       },
       "KH": {
          "description": "\"[m2 s-1] default = 0.0\nThe background Laplacian horizontal viscosity.\"\n",
@@ -1831,8 +1837,7 @@
          "datatype": "real",
          "units": "nondim",
          "value": {
-            "$OCN_GRID == \"tx0.25v1\"": 0.15,
-            "$OCN_GRID == \"tx2_3v2\"": 1.0
+            "$OCN_GRID == \"tx0.25v1\"": 0.15
          }
       },
       "MEKE_ALPHA_EADY": {
@@ -1844,36 +1849,20 @@
             "$OCN_GRID == \"tx2_3v2\"": 1.0
          }
       },
-      "MEKE_ALPHA_DEFORM": {
-         "description": "\"[nondim] default = 0.0\nIf positive, is a coefficient weighting the deformation scale in the\nexpression for mixing length used in MEKE-derived diffusivity.\"\n",
-         "datatype": "real",
-         "units": "nondim",
-         "value": {
-            "$OCN_GRID == \"tx2_3v2\"": 1.0
-         }
-      },
-      "MEKE_ALPHA_FRICT": {
-         "description": "\"[nondim] default = 0.0\nIf positive, is a coefficient weighting the frictional arrest scale in the\nexpression for mixing length used in MEKE-derived diffusivity.\"\n",
-         "datatype": "real",
-         "units": "nondim",
-         "value": {
-            "$OCN_GRID == \"tx2_3v2\"": 1.0
-         }
-      },
-      "MEKE_ALPHA_GRID": {
-         "description": "\"[nondim] default = 0.0\nIf positive, is a coefficient weighting the grid-spacing as a scale in the\nexpression for mixing length used in MEKE-derived diffusivity.\"\n",
-         "datatype": "real",
-         "units": "nondim",
-         "value": {
-            "$OCN_GRID == \"tx2_3v2\"": 1.0
-         }
-      },
       "MEKE_FRCOEFF": {
          "description": "\"[nondim] default = -1.0\nIf positive, is a coefficient weighting the grid-spacing as a scale in the\nexpression for mixing length used in MEKE-derived diffusivity.\"\n",
          "datatype": "real",
          "units": "nondim",
          "value": {
             "$OCN_GRID == \"tx2_3v2\"": 0.3
+         }
+      },
+      "MEKE_CT": {
+         "description": "\"[nondim] default = 50.0\n! A coefficient in the expression for the ratio of barotropic eddy energy and\n! mean column energy (see Jansen et al. 2015).\"\n",
+         "datatype": "real",
+         "units": "nondim",
+         "value": {
+            "$OCN_GRID == \"tx2_3v2\"": 0.0
          }
       },
       "MEKE_POSITIVE": {
@@ -2173,7 +2162,7 @@
          "datatype": "logical",
          "units": "Boolean",
          "value": {
-            "$COMP_WAV == \"ww3\" and $WAV_GRID in [\"wtx2_3v2\", \"wgx3v7\"]": true
+            "$COMP_WAV == \"ww3\" and $MOM6_WW3_CPL_METHOD == \"most\"": true
          }
       },
       "CEMP_NL": {
@@ -2181,7 +2170,7 @@
          "datatype": "real",
          "units": "nondim",
          "value": {
-            "$COMP_WAV == \"ww3\" and $WAV_GRID in [\"wtx2_3v2\", \"wgx3v7\"]": 2.0
+            "$COMP_WAV == \"ww3\" and $MOM6_WW3_CPL_METHOD == \"most\"": 2.0
          }
       },
       "REENTRANT_X": {
@@ -2869,57 +2858,57 @@
          "description": "\"default = False\nIf true, enables surface wave modules.\"\n",
          "datatype": "logical",
          "value": {
-            "$COMP_WAV == \"ww3\"": true
+            "$COMP_WAV == \"ww3\" and $MOM6_WW3_CPL_METHOD != \"none\"": true
          }
       },
       "WAVE_METHOD": {
          "description": "\"Choice of wave method, valid options include:\n TEST_PROFILE  - Prescribed from surface Stokes drift...\n SURFACE_BANDS - Computed from multiple surface values...\n DHH85         - Uses Donelan et al. 1985 empirical...\n LF17          - Infers Stokes drift profile from wind...\n EFACTOR       - Applies an enhancement factor to the KPP...\"\"\n",
          "datatype": "string",
          "value": {
-            "$COMP_WAV == \"ww3\" and $WAV_GRID == \"ww3a\"": "EFACTOR",
-            "$COMP_WAV == \"ww3\" and $WAV_GRID in [\"wtx2_3v2\", \"wgx3v7\"]": "SURFACE_BANDS"
+            "$COMP_WAV == \"ww3\" and $MOM6_WW3_CPL_METHOD == \"legacy\"": "EFACTOR",
+            "$COMP_WAV == \"ww3\" and $MOM6_WW3_CPL_METHOD == \"most\"": "SURFACE_BANDS"
          }
       },
       "SURFBAND_SOURCE": {
          "description": "Choice of SURFACE_BANDS data mode, valid options include:\nDATAOVERRIDE  - Read from NetCDF using FMS DataOverride.\nCOUPLER       - Look for variables from coupler pass\nINPUT         - Testing with fixed values.\n",
          "datatype": "string",
          "value": {
-            "$COMP_WAV == \"ww3\" and $WAV_GRID in [\"wtx2_3v2\", \"wgx3v7\"]": "COUPLER"
+            "$COMP_WAV == \"ww3\" and $MOM6_WW3_CPL_METHOD == \"most\"": "COUPLER"
          }
       },
       "STOKES_DDT": {
          "description": "default = False\nFlag to use Stokes d/dt\n",
          "datatype": "string",
          "value": {
-            "$COMP_WAV == \"ww3\" and $WAV_GRID in [\"wtx2_3v2\", \"wgx3v7\"]": true
+            "$COMP_WAV == \"ww3\" and $MOM6_WW3_CPL_METHOD == \"most\"": true
          }
       },
       "STOKES_VF": {
          "description": "default = False\nFlag to use Stokes vortex force\n",
          "datatype": "string",
          "value": {
-            "$COMP_WAV == \"ww3\" and $WAV_GRID in [\"wtx2_3v2\", \"wgx3v7\"]": true
+            "$COMP_WAV == \"ww3\" and $MOM6_WW3_CPL_METHOD == \"most\"": true
          }
       },
       "STOKES_PGF": {
          "description": "default = False\nFlag to use Stokes pressure gradient force\n",
          "datatype": "string",
          "value": {
-            "$COMP_WAV == \"ww3\" and $WAV_GRID in [\"wtx2_3v2\", \"wgx3v7\"]": true
+            "$COMP_WAV == \"ww3\" and $MOM6_WW3_CPL_METHOD == \"most\"": true
          }
       },
       "STK_BAND_COUPLER": {
          "description": "default = 1\nSTK_BAND_COUPLER is the number of Stokes drift bands in the coupler. This has\nto be consistent with the number of Stokes drift bands in WW3, or the model\nwill fail.\n",
          "datatype": "int",
          "value": {
-            "$COMP_WAV == \"ww3\" and $WAV_GRID in [\"wtx2_3v2\", \"wgx3v7\"]": 3
+            "$COMP_WAV == \"ww3\" and $MOM6_WW3_CPL_METHOD == \"most\"": 3
          }
       },
       "SURFBAND_WAVENUMBERS": {
          "description": "[rad/m] default = 0.12566\nCentral wavenumbers for surface Stokes drift bands.\n",
          "datatype": "string",
          "value": {
-            "$COMP_WAV == \"ww3\" and $WAV_GRID in [\"wtx2_3v2\", \"wgx3v7\"]": "0.04, 0.11, 0.33"
+            "$COMP_WAV == \"ww3\" and $MOM6_WW3_CPL_METHOD == \"most\"": "0.04, 0.11, 0.33"
          }
       },
       "AUTO_MASKTABLE": {
@@ -2980,7 +2969,7 @@
          "datatype": "logical",
          "units": "Boolean",
          "value": {
-            "$COMP_WAV == \"ww3\" and $WAV_GRID == \"ww3a\"": true
+            "$COMP_WAV == \"ww3\" and $MOM6_WW3_CPL_METHOD == \"legacy\"": true
          }
       },
       "USE_KPP_LT_VT2": {
@@ -2988,7 +2977,7 @@
          "datatype": "logical",
          "units": "Boolean",
          "value": {
-            "$COMP_WAV == \"ww3\" and $WAV_GRID == \"ww3a\"": true
+            "$COMP_WAV == \"ww3\" and $MOM6_WW3_CPL_METHOD == \"legacy\"": true
          }
       },
       "KPP_LT_K_METHOD": {
@@ -3009,7 +2998,7 @@
          "description": "default = False\nIf True, use Stokes Similarity package.\n",
          "datatype": "logical",
          "value": {
-            "$COMP_WAV == \"ww3\" and $WAV_GRID in [\"wtx2_3v2\", \"wgx3v7\"]": true
+            "$COMP_WAV == \"ww3\" and $MOM6_WW3_CPL_METHOD == \"most\"": true
          }
       }
    }


### PR DESCRIPTION
- remove unnecessary blocks: no need to distinguish between T62 and TL319 .
- increase NTASKS_OCN for cases with WW3.
- remove tx0.66v1

Partially fixes: https://github.com/ESCOMP/MOM_interface/issues/211
(We still need to update PEs for fully coupled cases)