### PR TITLE
More miscellaneous runtime parameter changes for beta05

### DIFF
--- a/param_templates/MOM_input.yaml
+++ b/param_templates/MOM_input.yaml
@@ -566,9 +566,8 @@ Global:
             The file from which to read a list of i,j,z topography overrides."
         datatype: string
         value:
-            $OCN_GRID == "tx2_3v2": "ocean_topo_tx2_3v2_240501.nc"
-            $OCN_GRID == "tx0.25v1": "ocean_topog.nc"
-
+            $OCN_GRID == "tx2_3v2": "topo_edits_tx2_3v2_250107.nc"
+            $OCN_GRID == "tx0.25v1": "All_edits.nc"
     MAXIMUM_DEPTH:
         description: |
             "[m]
@@ -2722,14 +2721,6 @@ Global:
         value:
             $OCN_GRID == "tx2_3v2": True
             $OCN_GRID == "tx0.25v1": True
-    TOPO_EDITS_FILE:
-        description: |
-            "default =
-            The file from which to read a list of i,j,z topography overrides."
-        datatype: string
-        value:
-            $OCN_GRID == "tx2_3v2": 'topo_edits_tx2_3v2_250107.nc'
-            else: ''
     PARALLEL_RESTARTFILES:
         description: |
             "[Boolean] default = False

--- a/param_templates/MOM_input.yaml
+++ b/param_templates/MOM_input.yaml
@@ -558,6 +558,15 @@ Global:
         value:
             $OCN_GRID == "tx2_3v2": "ocean_topo_tx2_3v2_240501.nc"
             $OCN_GRID == "tx0.25v1": "ocean_topog.nc"
+    TOPO_EDITS_FILE:
+        description: |
+            "default = ''
+            The file from which to read a list of i,j,z topography overrides."
+        datatype: string
+        value:
+            $OCN_GRID == "tx2_3v2": "ocean_topo_tx2_3v2_240501.nc"
+            $OCN_GRID == "tx0.25v1": "ocean_topog.nc"
+
     MAXIMUM_DEPTH:
         description: |
             "[m]
@@ -1050,10 +1059,12 @@ Global:
         value:
             $OCN_GRID == "tx0.25v1": 0.01
             $OCN_GRID == "MISOMIP": 0.001
-    LEITH_AH:
+    USE_LEITHY:
         description: |
             "[Boolean] default = False
-            If true, use a biharmonic Leith nonlinear eddy viscosity."
+            If true, use a modified version of the biharmonic Leith nonlinear
+            eddy viscosity. This implementation can include harmonic backscatter
+            when LEITHY_CK > 0."
         datatype: logical
         units: Boolean
         value:
@@ -1066,7 +1077,7 @@ Global:
         datatype: real
         units: nondim
         value:
-            $OCN_GRID == "tx2_3v2": 128.0
+            $OCN_GRID == "tx2_3v2": 90.0
     USE_LAND_MASK_FOR_HVISC:
         description: |
             "[Boolean] default = False
@@ -1500,8 +1511,22 @@ Global:
         datatype: real
         units: m
         value:
-            $OCN_GRID == "tx2_3v2": 1000.0
             $OCN_GRID == "tx0.25v1": 500.0
+    MLE_FRONT_LENGTH_FROM_FILE:
+        description: |
+            "[Boolean] default = False
+            If true, the MLE front-length scale is read from a file."
+        datatype: logical
+        units: Boolean
+        value:
+            $OCN_GRID == "tx2_3v2": True
+    MLE_FL_FILE:
+        description: |
+            "The path to the file containing the MLE
+            front-length scale.."
+        datatype: string
+        value:
+            $OCN_GRID == "tx2_3v2": "mle-lf-clim-tx2_3v2_20250108.nc"
     MLE_MLD_DECAY_TIME:
         description: |
             "[s] default = 0.0
@@ -1585,7 +1610,7 @@ Global:
         datatype: real
         units: m2 s-1
         value:
-            $OCN_GRID == "tx2_3v2": 0.0
+            $OCN_GRID == "tx2_3v2": 1.0E-07
             $OCN_GRID == "tx0.25v1": 1.5E-05
             $OCN_GRID == "MISOMIP": 5.0E-05
             else: 2.0E-05
@@ -1607,7 +1632,7 @@ Global:
         value: # KV/KD:
             $OCN_GRID == "tx0.25v1": = 1.0E-04 / 1.5E-05
             $OCN_GRID == "MISOMIP": = 1.0E-04 / 5.0E-05
-            else: = 1.0E-04 / 2.0E-05
+            else: = 1.0E-06 / 1.0E-07
     KD_MIN:
         description: |
             "[m2 s-1] default = 2.0E-07
@@ -1618,7 +1643,7 @@ Global:
         datatype: real
         units: m2 s-1
         value:
-            $OCN_GRID == "tx2_3v2":  2.0E-07
+            $OCN_GRID == "tx2_3v2":  1.0E-07
             else: 2.0E-06
     INT_TIDE_DECAY_SCALE:
         description: |
@@ -2581,7 +2606,7 @@ Global:
         datatype: string
         value:
             $OCN_GRID == "tx0.25v1": "MOM_channels_global_025"
-            $OCN_GRID == "tx2_3v2":  "MOM_channels_global_tx2_3v2_240501"
+            $OCN_GRID == "tx2_3v2":  "channels_tx2_3v2_250107.txt"
     SMAG_BI_CONST:
         description: |
             "[nondim] default = 0.0
@@ -2720,7 +2745,8 @@ Global:
             The file from which to read a list of i,j,z topography overrides."
         datatype: string
         value:
-            $OCN_GRID == "tx0.25v1": "All_edits.nc"
+            $OCN_GRID == "tx2_3v2": 'topo_edits_tx2_3v2_250107.nc'
+            else: ''
     PARALLEL_RESTARTFILES:
         description: |
             "[Boolean] default = False
@@ -3167,7 +3193,7 @@ Global:
         datatype: real
         units: m2 s-1
         value:
-            $OCN_GRID == "tx2_3v2": 0.0
+            $OCN_GRID == "tx2_3v2": 1.0E-06
             else: 1.0E-04
     KV_BBL_MIN:
         description: |
@@ -3715,6 +3741,13 @@ KPP:
             If True, use Stokes Similarity package.
         datatype: logical
         value:
-            $COMP_WAV == "ww3" and $WAV_GRID in ["wtx2_3v2", "wgx3v7"]: True    
-
+            $COMP_WAV == "ww3" and $WAV_GRID in ["wtx2_3v2", "wgx3v7"]: True
+    COMPUTE_MONIN_OBUKHOV:
+        description: |
+            default = False
+            If True, limit the OBL depth to be no deeper than Monin-Obukhov depth.
+        datatype: logical
+        units: Boolean
+        value:
+            $OCN_GRID == "tx2_3v2": True
 ...

--- a/param_templates/MOM_input.yaml
+++ b/param_templates/MOM_input.yaml
@@ -1078,7 +1078,15 @@ Global:
         datatype: real
         units: nondim
         value:
-            $OCN_GRID == "tx2_3v2": 90.0
+            $OCN_GRID == "tx2_3v2": 75.0
+    LEITHY_CK:
+        description: |
+            "[nondim] default = 1.0
+            Fraction of biharmonic dissipation that gets backscattered, in Leith+E."
+        datatype: real
+        units: nondim
+        value:
+            $OCN_GRID == "tx2_3v2": 0.0
     USE_LAND_MASK_FOR_HVISC:
         description: |
             "[Boolean] default = False

--- a/param_templates/MOM_input.yaml
+++ b/param_templates/MOM_input.yaml
@@ -1536,7 +1536,7 @@ Global:
             front-length scale.."
         datatype: string
         value:
-            $OCN_GRID == "tx2_3v2": "mle-lf-clim-tx2_3v2_20250108.nc"
+            $OCN_GRID == "tx2_3v2": "mle-lf-clim-tx2_3v2_20250115.nc"
     MLE_MLD_DECAY_TIME:
         description: |
             "[s] default = 0.0

--- a/param_templates/MOM_input.yaml
+++ b/param_templates/MOM_input.yaml
@@ -3724,4 +3724,13 @@ KPP:
         units: Boolean
         value:
             $OCN_GRID == "tx2_3v2": True
+    MINIMUM_OBL_DEPTH:
+        description: |
+            "[m] default = 0.0
+            If non-zero, a minimum depth to use for KPP OBL depth. Independent of this
+            parameter, the OBL depth is always at least as deep as the first layer."
+        datatype: real
+        value:
+           $OCN_GRID == "tx2_3v2": 2.5
 ...
+

--- a/param_templates/MOM_input.yaml
+++ b/param_templates/MOM_input.yaml
@@ -1090,6 +1090,15 @@ Global:
         datatype: logical
         units: Boolean
         value: True
+    FRICTWORK_BUG:
+        description: |
+            "[Boolean] default = True
+            If true, retain an answer-changing bug in calculating the FrictWork, which
+            cancels the h in thickness flux and the h at velocity point. This is not
+            recommended."
+        datatype: logical
+        units: Boolean
+        value: False
     HMIX_FIXED:
         description: |
             "[m]
@@ -2747,6 +2756,16 @@ Global:
         units: nondim
         value:
             $COMP_WAV == "ww3" and $MOM6_WW3_CPL_METHOD == "most": 2.0
+    VISC_REM_BUG:
+        description: |
+            "[Boolean] default = True
+            If true, visc_rem_[uv] in split mode is incorrectly calculated or accounted
+            for in two places. This parameter controls the defaults of two individual
+            flags, VISC_REM_TIMESTEP_BUG in MOM_dynamics_split_RK2(b) and
+            VISC_REM_BT_WEIGHT_BUG in MOM_barotropic."
+        datatype: logical
+        units: Boolean
+        value: False
 
     # MISOMIP-only variables:
 

--- a/param_templates/MOM_input.yaml
+++ b/param_templates/MOM_input.yaml
@@ -998,7 +998,9 @@ Global:
             If true, use a Laplacian horizontal viscosity."
         datatype: logical
         units: Boolean
-        value: True
+        value:
+            $OCN_GRID == "tx2_3v2": False
+            else: True
     KH:
         description: |
             "[m2 s-1] default = 0.0
@@ -1069,6 +1071,14 @@ Global:
         datatype: logical
         units: Boolean
         value:
+            $OCN_GRID == "tx2_3v2": False
+    LEITH_AH:
+        description: |
+            "[Boolean] default = False
+            If true, use a biharmonic Leith nonlinear eddy viscosity."
+        datatype: logical
+        units: Boolean
+        value:
             $OCN_GRID == "tx2_3v2": True
     LEITH_BI_CONST:
         description: |
@@ -1078,7 +1088,7 @@ Global:
         datatype: real
         units: nondim
         value:
-            $OCN_GRID == "tx2_3v2": 75.0
+            $OCN_GRID == "tx2_3v2": 128.0
     LEITHY_CK:
         description: |
             "[nondim] default = 1.0
@@ -1529,6 +1539,7 @@ Global:
         datatype: real
         units: m
         value:
+            $OCN_GRID == "tx2_3v2": 1000.0
             $OCN_GRID == "tx0.25v1": 500.0
     MLE_FRONT_LENGTH_FROM_FILE:
         description: |
@@ -1537,7 +1548,7 @@ Global:
         datatype: logical
         units: Boolean
         value:
-            $OCN_GRID == "tx2_3v2": True
+            $OCN_GRID == "tx2_3v2": False
     MLE_FL_FILE:
         description: |
             "The path to the file containing the MLE

--- a/param_templates/input_data_list.yaml
+++ b/param_templates/input_data_list.yaml
@@ -18,7 +18,7 @@ mom.input_data_list:
         $OCN_GRID == "tx2_3v2":  "${INPUTDIR}/ocean_topo_tx2_3v2_240501.nc"
         $OCN_GRID == "tx0.25v1": "${INPUTDIR}/ocean_topog.nc"
     TOPO_EDITS_FILE:
-        $OCN_GRID == "tx2_3v2": "${INPUTDIR}/ocean_topo_tx2_3v2_240501.nc"
+        $OCN_GRID == "tx2_3v2": "${INPUTDIR}/topo_edits_tx2_3v2_250107.nc"
         $OCN_GRID == "tx0.25v1": "${INPUTDIR}/All_edits.nc"
     TEMP_SALT_Z_INIT_FILE:
         $OCN_GRID in ["tx2_3v2", "tx0.25v1"]:

--- a/param_templates/input_data_list.yaml
+++ b/param_templates/input_data_list.yaml
@@ -44,7 +44,7 @@ mom.input_data_list:
         $OCN_GRID == "tx0.25v1": "${INPUTDIR}/seawifs-clim-1997-2010.1440x1080.v20180328.nc"
         $OCN_GRID == "tx2_3v2": "${INPUTDIR}/seawifs-clim-1997-2010-tx2_3v2.230416.nc"
     MLE_FL_FILE:
-        $OCN_GRID == "tx2_3v2": "${INPUTDIR}/mle-lf-clim-tx2_3v2_20250108.nc"
+        $OCN_GRID == "tx2_3v2": "${INPUTDIR}/mle-lf-clim-tx2_3v2_20250115.nc"
     CFC_BC_FILE: "${DIN_LOC_ROOT}/ocn/mom/grid_indpt/cfc_atm_20230310.nc"
     DIAG_COORD_DEF_RHO2:
         $OCN_GRID == "tx2_3v2":  "${INPUTDIR}/ocean_rho2_190917.nc"

--- a/param_templates/input_data_list.yaml
+++ b/param_templates/input_data_list.yaml
@@ -18,6 +18,7 @@ mom.input_data_list:
         $OCN_GRID == "tx2_3v2":  "${INPUTDIR}/ocean_topo_tx2_3v2_240501.nc"
         $OCN_GRID == "tx0.25v1": "${INPUTDIR}/ocean_topog.nc"
     TOPO_EDITS_FILE:
+        $OCN_GRID == "tx2_3v2": "${INPUTDIR}/ocean_topo_tx2_3v2_240501.nc"
         $OCN_GRID == "tx0.25v1": "${INPUTDIR}/All_edits.nc"
     TEMP_SALT_Z_INIT_FILE:
         $OCN_GRID in ["tx2_3v2", "tx0.25v1"]:
@@ -34,7 +35,7 @@ mom.input_data_list:
         $OCN_GRID == "tx2_3v2": "${INPUTDIR}/energy_new_tx2_3_conserve_230415_cdf5.nc"
         $OCN_GRID == "tx0.25v1": "${INPUTDIR}/tidal_amplitude.v20140616.nc"
     CHANNEL_LIST_FILE:
-        $OCN_GRID == "tx2_3v2": "${INPUTDIR}/MOM_channels_global_tx2_3v2_240501"
+        $OCN_GRID == "tx2_3v2": "${INPUTDIR}/channels_tx2_3v2_250107.txt"
         $OCN_GRID == "tx0.25v1": "${INPUTDIR}/MOM_channels_global_025"
     GEOTHERMAL_FILE:
         $OCN_GRID == "tx2_3v2": "${INPUTDIR}/geothermal_davies2013_tx2_3_20240318_cdf5.nc"
@@ -42,6 +43,8 @@ mom.input_data_list:
     CHL_FILE:
         $OCN_GRID == "tx0.25v1": "${INPUTDIR}/seawifs-clim-1997-2010.1440x1080.v20180328.nc"
         $OCN_GRID == "tx2_3v2": "${INPUTDIR}/seawifs-clim-1997-2010-tx2_3v2.230416.nc"
+    MLE_FL_FILE:
+        $OCN_GRID == "tx2_3v2": "${INPUTDIR}/mle-lf-clim-tx2_3v2_20250108.nc"
     CFC_BC_FILE: "${DIN_LOC_ROOT}/ocn/mom/grid_indpt/cfc_atm_20230310.nc"
     DIAG_COORD_DEF_RHO2:
         $OCN_GRID == "tx2_3v2":  "${INPUTDIR}/ocean_rho2_190917.nc"

--- a/param_templates/json/MOM_input.json
+++ b/param_templates/json/MOM_input.json
@@ -832,6 +832,12 @@
          "units": "Boolean",
          "value": true
       },
+      "FRICTWORK_BUG": {
+         "description": "\"[Boolean] default = True\nIf true, retain an answer-changing bug in calculating the FrictWork, which\ncancels the h in thickness flux and the h at velocity point. This is not\nrecommended.\"\n",
+         "datatype": "logical",
+         "units": "Boolean",
+         "value": false
+      },
       "HMIX_FIXED": {
          "description": "\"[m]\nThe prescribed depth over which the near-surface\nviscosity and diffusivity are elevated when the bulk\nmixed layer is not used.\"\n",
          "datatype": "real",
@@ -2184,6 +2190,12 @@
          "value": {
             "$COMP_WAV == \"ww3\" and $MOM6_WW3_CPL_METHOD == \"most\"": 2.0
          }
+      },
+      "VISC_REM_BUG": {
+         "description": "\"[Boolean] default = True\nIf true, visc_rem_[uv] in split mode is incorrectly calculated or accounted\nfor in two places. This parameter controls the defaults of two individual\nflags, VISC_REM_TIMESTEP_BUG in MOM_dynamics_split_RK2(b) and\nVISC_REM_BT_WEIGHT_BUG in MOM_barotropic.\"\n",
+         "datatype": "logical",
+         "units": "Boolean",
+         "value": false
       },
       "REENTRANT_X": {
          "description": "\"[Boolean] default = True\nIf true, the domain is zonally reentrant.\"\n",

--- a/param_templates/json/MOM_input.json
+++ b/param_templates/json/MOM_input.json
@@ -430,11 +430,11 @@
          }
       },
       "TOPO_EDITS_FILE": {
-         "description": "\"default =\nThe file from which to read a list of i,j,z topography overrides.\"\n",
+         "description": "\"default = ''\nThe file from which to read a list of i,j,z topography overrides.\"\n",
          "datatype": "string",
          "value": {
             "$OCN_GRID == \"tx2_3v2\"": "topo_edits_tx2_3v2_250107.nc",
-            "else": ""
+            "$OCN_GRID == \"tx0.25v1\"": "All_edits.nc"
          }
       },
       "MAXIMUM_DEPTH": {

--- a/param_templates/json/MOM_input.json
+++ b/param_templates/json/MOM_input.json
@@ -1157,7 +1157,7 @@
          "description": "\"The path to the file containing the MLE\nfront-length scale..\"\n",
          "datatype": "string",
          "value": {
-            "$OCN_GRID == \"tx2_3v2\"": "mle-lf-clim-tx2_3v2_20250108.nc"
+            "$OCN_GRID == \"tx2_3v2\"": "mle-lf-clim-tx2_3v2_20250115.nc"
          }
       },
       "MLE_MLD_DECAY_TIME": {

--- a/param_templates/json/MOM_input.json
+++ b/param_templates/json/MOM_input.json
@@ -823,7 +823,15 @@
          "datatype": "real",
          "units": "nondim",
          "value": {
-            "$OCN_GRID == \"tx2_3v2\"": 90.0
+            "$OCN_GRID == \"tx2_3v2\"": 75.0
+         }
+      },
+      "LEITHY_CK": {
+         "description": "\"[nondim] default = 1.0\nFraction of biharmonic dissipation that gets backscattered, in Leith+E.\"\n",
+         "datatype": "real",
+         "units": "nondim",
+         "value": {
+            "$OCN_GRID == \"tx2_3v2\"": 0.0
          }
       },
       "USE_LAND_MASK_FOR_HVISC": {

--- a/param_templates/json/MOM_input.json
+++ b/param_templates/json/MOM_input.json
@@ -426,6 +426,14 @@
             "$OCN_GRID == \"tx0.25v1\"": "ocean_topog.nc"
          }
       },
+      "TOPO_EDITS_FILE": {
+         "description": "\"default =\nThe file from which to read a list of i,j,z topography overrides.\"\n",
+         "datatype": "string",
+         "value": {
+            "$OCN_GRID == \"tx2_3v2\"": "topo_edits_tx2_3v2_250107.nc",
+            "else": ""
+         }
+      },
       "MAXIMUM_DEPTH": {
          "description": "\"[m]\nThe maximum depth of the ocean.\"\n",
          "datatype": "real",
@@ -799,8 +807,8 @@
             "$OCN_GRID == \"MISOMIP\"": 0.001
          }
       },
-      "LEITH_AH": {
-         "description": "\"[Boolean] default = False\nIf true, use a biharmonic Leith nonlinear eddy viscosity.\"\n",
+      "USE_LEITHY": {
+         "description": "\"[Boolean] default = False\nIf true, use a modified version of the biharmonic Leith nonlinear\neddy viscosity. This implementation can include harmonic backscatter\nwhen LEITHY_CK > 0.\"\n",
          "datatype": "logical",
          "units": "Boolean",
          "value": {
@@ -812,7 +820,7 @@
          "datatype": "real",
          "units": "nondim",
          "value": {
-            "$OCN_GRID == \"tx2_3v2\"": 128.0
+            "$OCN_GRID == \"tx2_3v2\"": 90.0
          }
       },
       "USE_LAND_MASK_FOR_HVISC": {
@@ -1125,8 +1133,22 @@
          "datatype": "real",
          "units": "m",
          "value": {
-            "$OCN_GRID == \"tx2_3v2\"": 1000.0,
             "$OCN_GRID == \"tx0.25v1\"": 500.0
+         }
+      },
+      "MLE_FRONT_LENGTH_FROM_FILE": {
+         "description": "\"[Boolean] default = False\nIf true, the MLE front-length scale is read from a file.\"\n",
+         "datatype": "logical",
+         "units": "Boolean",
+         "value": {
+            "$OCN_GRID == \"tx2_3v2\"": true
+         }
+      },
+      "MLE_FL_FILE": {
+         "description": "\"The path to the file containing the MLE\nfront-length scale..\"\n",
+         "datatype": "string",
+         "value": {
+            "$OCN_GRID == \"tx2_3v2\"": "mle-lf-clim-tx2_3v2_20250108.nc"
          }
       },
       "MLE_MLD_DECAY_TIME": {
@@ -1195,7 +1217,7 @@
          "datatype": "real",
          "units": "m2 s-1",
          "value": {
-            "$OCN_GRID == \"tx2_3v2\"": 0.0,
+            "$OCN_GRID == \"tx2_3v2\"": 1e-07,
             "$OCN_GRID == \"tx0.25v1\"": 1.5e-05,
             "$OCN_GRID == \"MISOMIP\"": 5e-05,
             "else": 2e-05
@@ -1214,7 +1236,7 @@
          "value": {
             "$OCN_GRID == \"tx0.25v1\"": "= 1.0E-04 / 1.5E-05",
             "$OCN_GRID == \"MISOMIP\"": "= 1.0E-04 / 5.0E-05",
-            "else": "= 1.0E-04 / 2.0E-05"
+            "else": "= 1.0E-06 / 1.0E-07"
          }
       },
       "KD_MIN": {
@@ -1222,7 +1244,7 @@
          "datatype": "real",
          "units": "m2 s-1",
          "value": {
-            "$OCN_GRID == \"tx2_3v2\"": 2e-07,
+            "$OCN_GRID == \"tx2_3v2\"": 1e-07,
             "else": 2e-06
          }
       },
@@ -2040,7 +2062,7 @@
          "datatype": "string",
          "value": {
             "$OCN_GRID == \"tx0.25v1\"": "MOM_channels_global_025",
-            "$OCN_GRID == \"tx2_3v2\"": "MOM_channels_global_tx2_3v2_240501"
+            "$OCN_GRID == \"tx2_3v2\"": "channels_tx2_3v2_250107.txt"
          }
       },
       "SMAG_BI_CONST": {
@@ -2151,13 +2173,6 @@
          "value": {
             "$OCN_GRID == \"tx2_3v2\"": true,
             "$OCN_GRID == \"tx0.25v1\"": true
-         }
-      },
-      "TOPO_EDITS_FILE": {
-         "description": "\"default =\nThe file from which to read a list of i,j,z topography overrides.\"\n",
-         "datatype": "string",
-         "value": {
-            "$OCN_GRID == \"tx0.25v1\"": "All_edits.nc"
          }
       },
       "PARALLEL_RESTARTFILES": {
@@ -2535,7 +2550,7 @@
          "datatype": "real",
          "units": "m2 s-1",
          "value": {
-            "$OCN_GRID == \"tx2_3v2\"": 0.0,
+            "$OCN_GRID == \"tx2_3v2\"": 1e-06,
             "else": 0.0001
          }
       },
@@ -3010,6 +3025,14 @@
          "datatype": "logical",
          "value": {
             "$COMP_WAV == \"ww3\" and $WAV_GRID in [\"wtx2_3v2\", \"wgx3v7\"]": true
+         }
+      },
+      "COMPUTE_MONIN_OBUKHOV": {
+         "description": "default = False\nIf True, limit the OBL depth to be no deeper than Monin-Obukhov depth.\n",
+         "datatype": "logical",
+         "units": "Boolean",
+         "value": {
+            "$OCN_GRID == \"tx2_3v2\"": true
          }
       }
    }

--- a/param_templates/json/MOM_input.json
+++ b/param_templates/json/MOM_input.json
@@ -755,7 +755,10 @@
          "description": "\"[Boolean] default = False\nIf true, use a Laplacian horizontal viscosity.\"\n",
          "datatype": "logical",
          "units": "Boolean",
-         "value": true
+         "value": {
+            "$OCN_GRID == \"tx2_3v2\"": false,
+            "else": true
+         }
       },
       "KH": {
          "description": "\"[m2 s-1] default = 0.0\nThe background Laplacian horizontal viscosity.\"\n",
@@ -815,6 +818,14 @@
          "datatype": "logical",
          "units": "Boolean",
          "value": {
+            "$OCN_GRID == \"tx2_3v2\"": false
+         }
+      },
+      "LEITH_AH": {
+         "description": "\"[Boolean] default = False\nIf true, use a biharmonic Leith nonlinear eddy viscosity.\"\n",
+         "datatype": "logical",
+         "units": "Boolean",
+         "value": {
             "$OCN_GRID == \"tx2_3v2\"": true
          }
       },
@@ -823,7 +834,7 @@
          "datatype": "real",
          "units": "nondim",
          "value": {
-            "$OCN_GRID == \"tx2_3v2\"": 75.0
+            "$OCN_GRID == \"tx2_3v2\"": 128.0
          }
       },
       "LEITHY_CK": {
@@ -1150,6 +1161,7 @@
          "datatype": "real",
          "units": "m",
          "value": {
+            "$OCN_GRID == \"tx2_3v2\"": 1000.0,
             "$OCN_GRID == \"tx0.25v1\"": 500.0
          }
       },
@@ -1158,7 +1170,7 @@
          "datatype": "logical",
          "units": "Boolean",
          "value": {
-            "$OCN_GRID == \"tx2_3v2\"": true
+            "$OCN_GRID == \"tx2_3v2\"": false
          }
       },
       "MLE_FL_FILE": {

--- a/param_templates/json/MOM_input.json
+++ b/param_templates/json/MOM_input.json
@@ -3020,6 +3020,13 @@
          "value": {
             "$OCN_GRID == \"tx2_3v2\"": true
          }
+      },
+      "MINIMUM_OBL_DEPTH": {
+         "description": "\"[m] default = 0.0\nIf non-zero, a minimum depth to use for KPP OBL depth. Independent of this\nparameter, the OBL depth is always at least as deep as the first layer.\"\n",
+         "datatype": "real",
+         "value": {
+            "$OCN_GRID == \"tx2_3v2\"": 2.5
+         }
       }
    }
 }

--- a/param_templates/json/input_data_list.json
+++ b/param_templates/json/input_data_list.json
@@ -22,7 +22,7 @@
          "$OCN_GRID == \"tx0.25v1\"": "${INPUTDIR}/ocean_topog.nc"
       },
       "TOPO_EDITS_FILE": {
-         "$OCN_GRID == \"tx2_3v2\"": "${INPUTDIR}/ocean_topo_tx2_3v2_240501.nc",
+         "$OCN_GRID == \"tx2_3v2\"": "${INPUTDIR}/topo_edits_tx2_3v2_250107.nc",
          "$OCN_GRID == \"tx0.25v1\"": "${INPUTDIR}/All_edits.nc"
       },
       "TEMP_SALT_Z_INIT_FILE": {

--- a/param_templates/json/input_data_list.json
+++ b/param_templates/json/input_data_list.json
@@ -22,6 +22,7 @@
          "$OCN_GRID == \"tx0.25v1\"": "${INPUTDIR}/ocean_topog.nc"
       },
       "TOPO_EDITS_FILE": {
+         "$OCN_GRID == \"tx2_3v2\"": "${INPUTDIR}/ocean_topo_tx2_3v2_240501.nc",
          "$OCN_GRID == \"tx0.25v1\"": "${INPUTDIR}/All_edits.nc"
       },
       "TEMP_SALT_Z_INIT_FILE": {
@@ -43,7 +44,7 @@
          "$OCN_GRID == \"tx0.25v1\"": "${INPUTDIR}/tidal_amplitude.v20140616.nc"
       },
       "CHANNEL_LIST_FILE": {
-         "$OCN_GRID == \"tx2_3v2\"": "${INPUTDIR}/MOM_channels_global_tx2_3v2_240501",
+         "$OCN_GRID == \"tx2_3v2\"": "${INPUTDIR}/channels_tx2_3v2_250107.txt",
          "$OCN_GRID == \"tx0.25v1\"": "${INPUTDIR}/MOM_channels_global_025"
       },
       "GEOTHERMAL_FILE": {
@@ -53,6 +54,9 @@
       "CHL_FILE": {
          "$OCN_GRID == \"tx0.25v1\"": "${INPUTDIR}/seawifs-clim-1997-2010.1440x1080.v20180328.nc",
          "$OCN_GRID == \"tx2_3v2\"": "${INPUTDIR}/seawifs-clim-1997-2010-tx2_3v2.230416.nc"
+      },
+      "MLE_FL_FILE": {
+         "$OCN_GRID == \"tx2_3v2\"": "${INPUTDIR}/mle-lf-clim-tx2_3v2_20250108.nc"
       },
       "CFC_BC_FILE": "${DIN_LOC_ROOT}/ocn/mom/grid_indpt/cfc_atm_20230310.nc",
       "DIAG_COORD_DEF_RHO2": {

--- a/param_templates/json/input_data_list.json
+++ b/param_templates/json/input_data_list.json
@@ -56,7 +56,7 @@
          "$OCN_GRID == \"tx2_3v2\"": "${INPUTDIR}/seawifs-clim-1997-2010-tx2_3v2.230416.nc"
       },
       "MLE_FL_FILE": {
-         "$OCN_GRID == \"tx2_3v2\"": "${INPUTDIR}/mle-lf-clim-tx2_3v2_20250108.nc"
+         "$OCN_GRID == \"tx2_3v2\"": "${INPUTDIR}/mle-lf-clim-tx2_3v2_20250115.nc"
       },
       "CFC_BC_FILE": "${DIN_LOC_ROOT}/ocn/mom/grid_indpt/cfc_atm_20230310.nc",
       "DIAG_COORD_DEF_RHO2": {


### PR DESCRIPTION
- Adds new topographic edits and updated channel list.  These lead to slightly improved circulation and hydrograph (https://github.com/NCAR/omwg_dev/discussions/55)
- Enabled COMPUTE_MONIN_OBUKHOV = True to improve the OBL seasonal cycle by limiting the OBL depth to no deeper than the Monin-Obukhov depth.  Because of this change, we now need to assure that OBL is always >= than the first thickness (dz) used in the model. This is done by setting `MINIMUM_OBL_DEPTH = 2.5`.
- Updated background mixing parameters:  
  - KV = 1.0E-06  
  - KD = 1.0E-07  
  - PRANDTL_BKGND = 10  
- Enable bug fixes introduced in https://github.com/mom-ocean/MOM6/pull/1647 

Fixes: https://github.com/ESCOMP/MOM_interface/issues/218, https://github.com/ESCOMP/MOM_interface/issues/213, https://github.com/ESCOMP/MOM_interface/issues/208, https://github.com/ESCOMP/MOM_interface/issues/220