### PR TITLE
Add SVN Install to the check_input_data_repo CI test 

### DIFF
--- a/.github/workflows/general-ci-tests.yml
+++ b/.github/workflows/general-ci-tests.yml
@@ -108,11 +108,11 @@ jobs:
     steps:
       # Checkout the repo
       - uses: actions/checkout@v4
-      
+
       # Run the test
       - name: Run the check_input_data_repo script
         run: |
-          apt-get install -y subversion
+          sudo apt-get install -y subversion
           pip install 'svn>=1,<1.1'
           python tests/check_input_data_repo.py
 

--- a/.github/workflows/general-ci-tests.yml
+++ b/.github/workflows/general-ci-tests.yml
@@ -1,5 +1,4 @@
 name: General MOM_interface CI
-
  
 # Please see Issue #138 for more information on this CI workflow
 
@@ -57,7 +56,7 @@ jobs:
           cd $GITHUB_WORKSPACE/CESM/components/mom/
           git checkout ${{ github.sha }}
 
-      # Build the standalone mom using the ubuntu script. build_examples-ncar doesn't work.    
+      # Build the standalone mom using the ubuntu script. 
       - name: Build Standalone MOM
         run: |
           cd $GITHUB_WORKSPACE/CESM/components/mom/standalone/build

--- a/.github/workflows/general-ci-tests.yml
+++ b/.github/workflows/general-ci-tests.yml
@@ -108,12 +108,11 @@ jobs:
     steps:
       # Checkout the repo
       - uses: actions/checkout@v4
-      - name: Setup upterm session
-        uses: lhotari/action-upterm@v1
       
       # Run the test
       - name: Run the check_input_data_repo script
         run: |
+          apt-get install -y subversion
           pip install 'svn>=1,<1.1'
           python tests/check_input_data_repo.py
 

--- a/.github/workflows/general-ci-tests.yml
+++ b/.github/workflows/general-ci-tests.yml
@@ -112,7 +112,7 @@ jobs:
       # Run the test
       - name: Run the check_input_data_repo script
         run: |
-          sudo apt-get install -y subversion
+          sudo apt-get update && sudo apt-get install -y subversion
           pip install 'svn>=1,<1.1'
           python tests/check_input_data_repo.py
 

--- a/.github/workflows/general-ci-tests.yml
+++ b/.github/workflows/general-ci-tests.yml
@@ -1,10 +1,7 @@
 name: General MOM_interface CI
 
-# This CI workflow tests against the following questions: 
-# 1. Does standalone mom build and run?
-# 2. Does it pass the tests/check_default_params.py test?
-# 3. Do the scripts in cime_config pass the black formatter? 
-# Please see Issue #138 for more information
+ 
+# Please see Issue #138 for more information on this CI workflow
 
 # Controls when the workflow will run
 on:
@@ -60,7 +57,7 @@ jobs:
           cd $GITHUB_WORKSPACE/CESM/components/mom/
           git checkout ${{ github.sha }}
 
-      # Build the standalone mom using the macos script. build_examples-ncar doesn't work.    
+      # Build the standalone mom using the ubuntu script. build_examples-ncar doesn't work.    
       - name: Build Standalone MOM
         run: |
           cd $GITHUB_WORKSPACE/CESM/components/mom/standalone/build
@@ -111,6 +108,8 @@ jobs:
     steps:
       # Checkout the repo
       - uses: actions/checkout@v4
+      - name: Setup upterm session
+        uses: lhotari/action-upterm@v1
       
       # Run the test
       - name: Run the check_input_data_repo script


### PR DESCRIPTION
Fixes https://github.com/ESCOMP/MOM_interface/issues/222

The check_input_data_repo CI test was always failing due to SVN missing from the runner (this may be a recent change: https://github.com/apache/beam/issues/32766 & https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md )

Changes:

1. Add a command to install svn in the check_input_data_repo job
2. Some minor commenting changes