### PR TITLE
diag_table updates:

### DIFF
--- a/param_templates/diag_table.yaml
+++ b/param_templates/diag_table.yaml
@@ -59,6 +59,8 @@ FieldLists:
 
     - &cfc_2d  ["cfc11_flux", "cfc12_flux", "ice_fraction", "u10_sqr"]
 
+    - &geothermal  ["Geo_heat"]
+
 ###############################################################################
 # Section 2: File lists:
 #   List of files to be added in diag_table
@@ -230,6 +232,9 @@ Files:
             module:   "ocean_model"   # native
             packing: = 1 if $TEST else 2
             lists:    [ *static_flds ]
+            lists2:
+                $DO_GEOTHERMAL == "True":
+                    [ *geothermal ]
 
 
     # Sections ------------------------------------

--- a/param_templates/diag_table.yaml
+++ b/param_templates/diag_table.yaml
@@ -4,21 +4,27 @@
 ###############################################################################
 ---
 FieldLists:
-    - &prognostic       ["uo", "vo", "h", "e", "thetao", "so", "KE", "rhopot0"]
+    - &prognostic       ["uo", "vo", "h", "e", "thetao", "so", "KE", "MEKE", "rhopot0"]
 
     - &prognostic_z     ["uo", "vo", "h", "thetao", "so", "agessc", "rhopot0", "N2_int"]
 
     - &prognostic_rho2  ["thetao", "so", "agessc"]
 
-    - &hist_additional  ["soga", "thetaoga", "uh", "vh", "vhbt", "uhbt"]
+    - &hist_additional  ["soga", "thetaoga", "uh", "vh", "vhbt", "uhbt", "rsdo"]
 
     - &tracers          ["agessc", "T_ady_2d", "T_adx_2d", "T_diffy_2d", "T_diffx_2d",
                          "T_hbd_diffx_2d", 'T_hbd_diffy_2d']
 
-    - &surface_flds     ["SSH", "tos", "sos", "SSU", "SSV", "mass_wt", "opottempmint",
-                         "somint", "Rd_dx", "speed", "mlotst"]
+    - &surface_flds_common ["tos", "tos:tos_min:min", "tos:tos_max:max", 
+                         "sos", "sos:sos_min:min", "sos:sos_max:max", 
+                         "SSU", "SSV", "opottempmint", "somint", "Rd_dx", "speed",
+                         "mlotst", "mlotst:mlots_min:min", "mlotst:mlots_max:max"]
+    
+    - &surface_flds_daily ["zos", "zossq"]
 
-    - &kpp_diags        ["KPP_OBLdepth:oml"]
+    - &surface_flds_monthly ["sst_global", "sss_global", "SSH", "mass_wt"]
+
+    - &kpp_diags        ["KPP_OBLdepth:oml", "KPP_OBLdepth:oml_min:min", "KPP_OBLdepth:oml_max:max"]
 
     - &forcing_flds     ["tauuo", "tauvo", "friver", "prsn", "prlq", "evs", "hfsso", "rlntds",
                          "hfsnthermds", "sfdsi", "rsntds", "hfds", "ustar",
@@ -41,7 +47,7 @@ FieldLists:
     - &static_flds      ["geolon", "geolat", "geolon_c", "geolat_c", "geolon_u", "geolat_u",
                          "geolon_v", "geolat_v", "deptho", "wet", "wet_c", "wet_u",
                          "wet_v", "Coriolis", "areacello", "areacello_cu", "areacello_cv",
-                         "areacello_bu", "sin_rot", "cos_rot"]
+                         "areacello_bu", "sin_rot", "cos_rot", "C_P", "Rho_0"]
 
     - &transports       ["volcello", "vmo", "vhGM", "vhml", "umo", "uhGM", "uhml"]
 
@@ -115,7 +121,8 @@ Files:
                           *kpp_diags,
                           *forcing_flds,
                           *enthalpy_flds,
-                          *surface_flds]
+                          *surface_flds_common,
+                          *surface_flds_monthly]
                 lists3:
                     $USE_CFC_CAP == "True":
                         [ *cfc_2d ]
@@ -166,7 +173,8 @@ Files:
             $OCN_DIAG_MODE != "none" and $TEST is not True :
                 module:   "ocean_model"    # native
                 packing: = 1 if $TEST else 2
-                lists:    [ *surface_flds,
+                lists:    [ *surface_flds_common,
+                            *surface_flds_daily,
                             *kpp_diags ]
     forcing_avg:
         suffix: 

--- a/param_templates/json/diag_table.json
+++ b/param_templates/json/diag_table.json
@@ -8,6 +8,7 @@
          "thetao",
          "so",
          "KE",
+         "MEKE",
          "rhopot0"
       ],
       [
@@ -31,7 +32,8 @@
          "uh",
          "vh",
          "vhbt",
-         "uhbt"
+         "uhbt",
+         "rsdo"
       ],
       [
          "agessc",
@@ -43,20 +45,36 @@
          "T_hbd_diffy_2d"
       ],
       [
-         "SSH",
          "tos",
+         "tos:tos_min:min",
+         "tos:tos_max:max",
          "sos",
+         "sos:sos_min:min",
+         "sos:sos_max:max",
          "SSU",
          "SSV",
-         "mass_wt",
          "opottempmint",
          "somint",
          "Rd_dx",
          "speed",
-         "mlotst"
+         "mlotst",
+         "mlotst:mlots_min:min",
+         "mlotst:mlots_max:max"
       ],
       [
-         "KPP_OBLdepth:oml"
+         "zos",
+         "zossq"
+      ],
+      [
+         "sst_global",
+         "sss_global",
+         "SSH",
+         "mass_wt"
+      ],
+      [
+         "KPP_OBLdepth:oml",
+         "KPP_OBLdepth:oml_min:min",
+         "KPP_OBLdepth:oml_max:max"
       ],
       [
          "tauuo",
@@ -135,7 +153,9 @@
          "areacello_cv",
          "areacello_bu",
          "sin_rot",
-         "cos_rot"
+         "cos_rot",
+         "C_P",
+         "Rho_0"
       ],
       [
          "volcello",
@@ -250,7 +270,8 @@
                      "uh",
                      "vh",
                      "vhbt",
-                     "uhbt"
+                     "uhbt",
+                     "rsdo"
                   ],
                   [
                      "agessc",
@@ -287,10 +308,13 @@
                         "thetao",
                         "so",
                         "KE",
+                        "MEKE",
                         "rhopot0"
                      ],
                      [
-                        "KPP_OBLdepth:oml"
+                        "KPP_OBLdepth:oml",
+                        "KPP_OBLdepth:oml_min:min",
+                        "KPP_OBLdepth:oml_max:max"
                      ],
                      [
                         "tauuo",
@@ -327,17 +351,27 @@
                         "heat_content_evap"
                      ],
                      [
-                        "SSH",
                         "tos",
+                        "tos:tos_min:min",
+                        "tos:tos_max:max",
                         "sos",
+                        "sos:sos_min:min",
+                        "sos:sos_max:max",
                         "SSU",
                         "SSV",
-                        "mass_wt",
                         "opottempmint",
                         "somint",
                         "Rd_dx",
                         "speed",
-                        "mlotst"
+                        "mlotst",
+                        "mlotst:mlots_min:min",
+                        "mlotst:mlots_max:max"
+                     ],
+                     [
+                        "sst_global",
+                        "sss_global",
+                        "SSH",
+                        "mass_wt"
                      ]
                   ]
                },
@@ -432,20 +466,30 @@
                "packing": "= 1 if $TEST else 2",
                "lists": [
                   [
-                     "SSH",
                      "tos",
+                     "tos:tos_min:min",
+                     "tos:tos_max:max",
                      "sos",
+                     "sos:sos_min:min",
+                     "sos:sos_max:max",
                      "SSU",
                      "SSV",
-                     "mass_wt",
                      "opottempmint",
                      "somint",
                      "Rd_dx",
                      "speed",
-                     "mlotst"
+                     "mlotst",
+                     "mlotst:mlots_min:min",
+                     "mlotst:mlots_max:max"
                   ],
                   [
-                     "KPP_OBLdepth:oml"
+                     "zos",
+                     "zossq"
+                  ],
+                  [
+                     "KPP_OBLdepth:oml",
+                     "KPP_OBLdepth:oml_min:min",
+                     "KPP_OBLdepth:oml_max:max"
                   ]
                ]
             }
@@ -584,7 +628,9 @@
                   "areacello_cv",
                   "areacello_bu",
                   "sin_rot",
-                  "cos_rot"
+                  "cos_rot",
+                  "C_P",
+                  "Rho_0"
                ]
             ]
          }

--- a/param_templates/json/diag_table.json
+++ b/param_templates/json/diag_table.json
@@ -189,6 +189,9 @@
          "cfc12_flux",
          "ice_fraction",
          "u10_sqr"
+      ],
+      [
+         "Geo_heat"
       ]
    ],
    "Files": {
@@ -632,7 +635,14 @@
                   "C_P",
                   "Rho_0"
                ]
-            ]
+            ],
+            "lists2": {
+               "$DO_GEOTHERMAL == \"True\"": [
+                  [
+                     "Geo_heat"
+                  ]
+               ]
+            }
          }
       },
       "Agulhas": {


### PR DESCRIPTION
 - introduce feature to specify field-specific reduction method.
 - changes in field list: 
 - [x] min/max mlotst and oml in both daily (sfc) and monthly (native) 
 - [x] sst_global, sss_global in monthly 
 - [x] zos and zossq in daily (sfc) 
 - [x] Drop SSH in daily (sfc) and keep it in the monthly (native)
 - [x] Drop mass_wt in daily and keep it in the monthly (native)
 - [x] Add tos and sos  min/max in daily (sfc) and monthly (native)
 - [x] Add MEKE in monthly (native)
 - [x] C_P and Rho_0 add to static 
 - [x] Geo_heat (when turned on) add to static
 - [x] Add penetrating solar flux (3D. Diag variable) rsdo