### PR TITLE
Check submodule hash consistency

### DIFF
--- a/.github/workflows/general-ci-tests.yml
+++ b/.github/workflows/general-ci-tests.yml
@@ -48,6 +48,7 @@ jobs:
           cd $GITHUB_WORKSPACE/CESM/components/mom/
           git fetch origin pull/${{ github.event.pull_request.number }}/head:pr-${{ github.event.pull_request.number }}
           git checkout pr-${{ github.event.pull_request.number }}
+          git submodule update --init --recursive
 
       - name: Checkout initial event (Push)
         if: ${{ github.event_name == 'push' }}
@@ -55,6 +56,13 @@ jobs:
           echo "Handling push"
           cd $GITHUB_WORKSPACE/CESM/components/mom/
           git checkout ${{ github.sha }}
+          git submodule update --init --recursive
+
+      - name: Check submodule hash consistency
+        run: |
+          echo "Checking if .gitmodules and external hashes are consistent"
+          cd $GITHUB_WORKSPACE/CESM/components/mom/
+          git diff --exit-code
 
       # Build the standalone mom using the ubuntu script. 
       - name: Build Standalone MOM

--- a/.github/workflows/general-ci-tests.yml
+++ b/.github/workflows/general-ci-tests.yml
@@ -62,8 +62,7 @@ jobs:
         run: |
           echo "Checking if .gitmodules and external hashes are consistent"
           cd $GITHUB_WORKSPACE/CESM/components/mom/
-          ../../bin/git-fleximod update
-          git diff --exit-code
+          ../../bin/git-fleximod test
 
       # Build the standalone mom using the ubuntu script. 
       - name: Build Standalone MOM

--- a/.github/workflows/general-ci-tests.yml
+++ b/.github/workflows/general-ci-tests.yml
@@ -62,6 +62,7 @@ jobs:
         run: |
           echo "Checking if .gitmodules and external hashes are consistent"
           cd $GITHUB_WORKSPACE/CESM/components/mom/
+          ../../bin/git-fleximod update
           git diff --exit-code
 
       # Build the standalone mom using the ubuntu script. 


### PR DESCRIPTION
This PR add a new step in CI test to check if gitmodules and externals are inconsistent by simply running `git diff`.