### PR TITLE
Update git fleximod testing

### DIFF
--- a/.github/workflows/general-ci-tests.yml
+++ b/.github/workflows/general-ci-tests.yml
@@ -1,5 +1,5 @@
 name: General MOM_interface CI
- 
+
 # Please see Issue #138 for more information on this CI workflow
 
 # Controls when the workflow will run
@@ -11,13 +11,13 @@ on:
     branches: [ "main" ]
 
 jobs:
-  
+
   check_standalone_mom_build_and_run_lightweight_examples:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
 
     steps:
-    
+
     # Copied from NCAR/MOM6 - Install Basic Build Packages for MOM6
       - name: Install Ubuntu Linux packages
         shell: bash
@@ -32,14 +32,14 @@ jobs:
           sudo apt-get install linux-tools-common
           sudo apt-get install -y csh
           echo "::endgroup::"
-          
+
       # Checkout CESM (default branch) and externals
       - name: Checkout CESM and Externals
         run: |
-          git clone https://github.com/ESCOMP/CESM.git 
+          git clone https://github.com/ESCOMP/CESM.git
           cd CESM
           ./bin/git-fleximod update
-          
+
       # Checkout the correct MOM Branch
       - name: Checkout initial event (Pull Request)
         if: ${{ github.event_name == 'pull_request' }}
@@ -48,7 +48,7 @@ jobs:
           cd $GITHUB_WORKSPACE/CESM/components/mom/
           git fetch origin pull/${{ github.event.pull_request.number }}/head:pr-${{ github.event.pull_request.number }}
           git checkout pr-${{ github.event.pull_request.number }}
-          git submodule update --init --recursive
+          ../../bin/git-fleximod update
 
       - name: Checkout initial event (Push)
         if: ${{ github.event_name == 'push' }}
@@ -56,20 +56,20 @@ jobs:
           echo "Handling push"
           cd $GITHUB_WORKSPACE/CESM/components/mom/
           git checkout ${{ github.sha }}
-          git submodule update --init --recursive
+          ../../bin/git-fleximod update
 
       - name: Check submodule hash consistency
         run: |
           echo "Checking if .gitmodules and external hashes are consistent"
           cd $GITHUB_WORKSPACE/CESM/components/mom/
-          ../../bin/git-fleximod test
+          git diff --exit-code
 
-      # Build the standalone mom using the ubuntu script. 
+      # Build the standalone mom using the ubuntu script.
       - name: Build Standalone MOM
         run: |
           cd $GITHUB_WORKSPACE/CESM/components/mom/standalone/build
           ./build_examples.sh --compiler gnu --machine ubuntu
-          
+
       # CD into a couple MOM examples and run MOM in them. These are very light weight and quick.
       - name: Run Double Gyre Test
         run: |
@@ -79,39 +79,39 @@ jobs:
         run: |
           cd $GITHUB_WORKSPACE/CESM/components/mom/standalone/examples/single_column/KPP
           $GITHUB_WORKSPACE/CESM/components/mom/standalone/build/gnu/MOM6/MOM6
-          
+
 
   # Job to run the check_default_params script, which is a test
   check_default_params:
-    
+
     runs-on: ubuntu-latest
-    
+
     steps:
       # Checkout the repo
       - uses: actions/checkout@v4
-      
+
       # Run the test
       - name: Run the check_default_params script
         run: python tests/check_default_params.py
-  
+
   # Job to run check_input_data_list script
   check_input_data_list:
-    
+
     runs-on: ubuntu-latest
-    
+
     steps:
       # Checkout the repo
       - uses: actions/checkout@v4
-      
+
       # Run the test
       - name: Run the check_input_data_list script
         run: python tests/check_input_data_list.py
 
   # Job to run check_input_data_repo script
   check_input_data_repo:
-    
+
     runs-on: ubuntu-latest
-    
+
     steps:
       # Checkout the repo
       - uses: actions/checkout@v4
@@ -125,19 +125,15 @@ jobs:
 
   # Job to run the black formatter for cime_config, see black documentation for more info
   check_black_format_for_cime_config:
-    
+
     runs-on: ubuntu-latest
-    
+
     steps:
       # Checkout the repo
       - uses: actions/checkout@v4
-      
+
       # Run black check
       - uses: psf/black@stable
         with:
           options: "--check --verbose"
           src: "./cime_config"
-      
-      
-
-  


### PR DESCRIPTION
Instead of running `git submodule update --init --recursive` and then relying on `git fleximod test` to make sure the submodules match what git fleximod expects, the test now runs `git fleximod update` and then uses `git diff --exit-code` to see if that's different than what git submodules expect. This is a "six of one, half dozen of the other" type change, but is consistent with what was discussed at a CSEG meeting.

I also cleaned up some white space.