### PR TITLE
Add pe layout for G compset with MARBL and WW3

### DIFF
--- a/cime_config/config_compsets.xml
+++ b/cime_config/config_compsets.xml
@@ -110,4 +110,14 @@
     <lname>1850_DATM%JRA-1p5-2023_SLND_CICE_MOM6%MARBL-ABIO_DROF%JRA-1p5-2023_SGLC_SWAV</lname>
   </compset>
 
+  <compset>
+    <alias>GW1850MARBL_JRA</alias>
+    <lname>1850_DATM%JRA-1p5-2023_SLND_CICE_MOM6%MARBL-BIO_DROF%JRA-1p5-2023_SGLC_WW3</lname>
+  </compset>
+
+  <compset>
+    <alias>GW1850ABIOMARBL_JRA</alias>
+    <lname>1850_DATM%JRA-1p5-2023_SLND_CICE_MOM6%MARBL-ABIO_DROF%JRA-1p5-2023_SGLC_WW3</lname>
+  </compset>
+
 </compsets>

--- a/cime_config/config_pes.xml
+++ b/cime_config/config_pes.xml
@@ -171,7 +171,7 @@
           <rootpe_rof>0</rootpe_rof>
           <rootpe_cpl>0</rootpe_cpl>
           <rootpe_ice>128</rootpe_ice>
-          <rootpe_ocn>2560</rootpe_ocn>
+          <rootpe_ocn>256</rootpe_ocn>
           <rootpe_lnd>0</rootpe_lnd>
           <rootpe_wav>0</rootpe_wav>
           <rootpe_glc>0</rootpe_glc>
@@ -185,6 +185,39 @@
           <ntasks_cpl>128</ntasks_cpl>
           <ntasks_ice>128</ntasks_ice>
           <ntasks_ocn>896</ntasks_ocn>
+          <ntasks_lnd>1</ntasks_lnd>
+          <ntasks_wav>256</ntasks_wav>
+          <ntasks_glc>1</ntasks_glc>
+        </ntasks>
+        <nthrds>
+          <nthrds_atm>1</nthrds_atm>
+          <nthrds_lnd>1</nthrds_lnd>
+          <nthrds_rof>1</nthrds_rof>
+          <nthrds_ice>1</nthrds_ice>
+          <nthrds_ocn>1</nthrds_ocn>
+          <nthrds_glc>1</nthrds_glc>
+          <nthrds_wav>1</nthrds_wav>
+          <nthrds_cpl>1</nthrds_cpl>
+        </nthrds>
+        <rootpe>
+          <rootpe_atm>0</rootpe_atm>
+          <rootpe_rof>0</rootpe_rof>
+          <rootpe_cpl>0</rootpe_cpl>
+          <rootpe_ice>0</rootpe_ice>
+          <rootpe_ocn>384</rootpe_ocn>
+          <rootpe_lnd>0</rootpe_lnd>
+          <rootpe_wav>128</rootpe_wav>
+          <rootpe_glc>0</rootpe_glc>
+        </rootpe>
+      </pes>
+      <pes pesize="any" compset="_DATM.+_CICE.*_MOM6%[^_]*MARBL-BIO.+_WW3">
+        <comment>none</comment>
+        <ntasks>
+          <ntasks_atm>128</ntasks_atm>
+          <ntasks_rof>128</ntasks_rof>
+          <ntasks_cpl>128</ntasks_cpl>
+          <ntasks_ice>128</ntasks_ice>
+          <ntasks_ocn>2560</ntasks_ocn>
           <ntasks_lnd>1</ntasks_lnd>
           <ntasks_wav>256</ntasks_wav>
           <ntasks_glc>1</ntasks_glc>

--- a/cime_config/config_pes.xml
+++ b/cime_config/config_pes.xml
@@ -219,7 +219,7 @@
           <ntasks_ice>128</ntasks_ice>
           <ntasks_ocn>2560</ntasks_ocn>
           <ntasks_lnd>1</ntasks_lnd>
-          <ntasks_wav>256</ntasks_wav>
+          <ntasks_wav>128</ntasks_wav>
           <ntasks_glc>1</ntasks_glc>
         </ntasks>
         <nthrds>
@@ -237,7 +237,7 @@
           <rootpe_rof>0</rootpe_rof>
           <rootpe_cpl>0</rootpe_cpl>
           <rootpe_ice>0</rootpe_ice>
-          <rootpe_ocn>384</rootpe_ocn>
+          <rootpe_ocn>256</rootpe_ocn>
           <rootpe_lnd>0</rootpe_lnd>
           <rootpe_wav>128</rootpe_wav>
           <rootpe_glc>0</rootpe_glc>

--- a/cime_config/config_pes.xml
+++ b/cime_config/config_pes.xml
@@ -186,7 +186,7 @@
           <ntasks_ice>128</ntasks_ice>
           <ntasks_ocn>896</ntasks_ocn>
           <ntasks_lnd>1</ntasks_lnd>
-          <ntasks_wav>256</ntasks_wav>
+          <ntasks_wav>128</ntasks_wav>
           <ntasks_glc>1</ntasks_glc>
         </ntasks>
         <nthrds>
@@ -204,7 +204,7 @@
           <rootpe_rof>0</rootpe_rof>
           <rootpe_cpl>0</rootpe_cpl>
           <rootpe_ice>0</rootpe_ice>
-          <rootpe_ocn>384</rootpe_ocn>
+          <rootpe_ocn>256</rootpe_ocn>
           <rootpe_lnd>0</rootpe_lnd>
           <rootpe_wav>128</rootpe_wav>
           <rootpe_glc>0</rootpe_glc>


### PR DESCRIPTION
Use the same layout as G compset with WW3 but not MARBL, except I bump `NTASKS_OCN` up to 2560.

I also fixed a bug where G compset with MARBL and SWAV was letting 2304 cores sit idle (`ROOTPE_OCN` was 2560 instead of 256)

fixes #232 