### PR TITLE
Update CI in MOM_interface so that "check_standalone_mom_build_and_run_lightweight_examples" works on MOM_interface forks

### DIFF
--- a/.github/workflows/general-ci-tests.yml
+++ b/.github/workflows/general-ci-tests.yml
@@ -54,16 +54,16 @@ jobs:
           cd CESM
           ./bin/git-fleximod update
 
+      - name: Check submodule hash consistency (Seperate Test)
+        run: |
+          echo "Checking if .gitmodules and external hashes are consistent"
+          cd $GITHUB_WORKSPACE/CESM/components/mom/
+          ../../bin/git-fleximod test
+
       # Copy the correct MOM_interface Branch to the CESM
       - name: Copy MOM_interface over to the correct place in CESM
         run: |
           cp -r $GITHUB_WORKSPACE/MOM_interface_temp/* $GITHUB_WORKSPACE/CESM/components/mom/
-
-      - name: Check submodule hash consistency
-        run: |
-          echo "Checking if .gitmodules and external hashes are consistent"
-          cd $GITHUB_WORKSPACE/CESM/components/mom/
-#          ../../bin/git-fleximod test
 
       # Build the standalone mom using the ubuntu script. 
       - name: Build Standalone MOM

--- a/.github/workflows/general-ci-tests.yml
+++ b/.github/workflows/general-ci-tests.yml
@@ -32,31 +32,30 @@ jobs:
           sudo apt-get install linux-tools-common
           sudo apt-get install -y csh
           echo "::endgroup::"
-          
+      - name: Checkout MOM_interface to temp folder
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          path: MOM_interface_temp
       # Checkout CESM (default branch) and externals
-      - name: Checkout CESM and Externals
+      - name: Checkout CESM
+        uses: actions/checkout@v4
+        with:
+          repository: ESCOMP/CESM
+          path: CESM
+
+      # Run git-fleximod
+      - name: checkout CESM
+        env:
+          GIT_CLONE_PROTECTION_ACTIVE: false
         run: |
-          git clone https://github.com/ESCOMP/CESM.git 
           cd CESM
           ./bin/git-fleximod update
-          
-      # Checkout the correct MOM Branch
-      - name: Checkout initial event (Pull Request)
-        if: ${{ github.event_name == 'pull_request' }}
-        run: |
-          echo "Handling pull request"
-          cd $GITHUB_WORKSPACE/CESM/components/mom/
-          git fetch origin pull/${{ github.event.pull_request.number }}/head:pr-${{ github.event.pull_request.number }}
-          git checkout pr-${{ github.event.pull_request.number }}
-          git submodule update --init --recursive
 
-      - name: Checkout initial event (Push)
-        if: ${{ github.event_name == 'push' }}
+      # Copy the correct MOM Branch to the CESM
+      - name: Checkout initial event (Pull Request)
         run: |
-          echo "Handling push"
-          cd $GITHUB_WORKSPACE/CESM/components/mom/
-          git checkout ${{ github.sha }}
-          git submodule update --init --recursive
+          cp -r $GITHUB_WORKSPACE/MOM_interface_temp/* $GITHUB_WORKSPACE/CESM/components/mom/
 
       - name: Check submodule hash consistency
         run: |

--- a/.github/workflows/general-ci-tests.yml
+++ b/.github/workflows/general-ci-tests.yml
@@ -47,7 +47,7 @@ jobs:
           path: CESM
 
       # Run git-fleximod
-      - name: checkout CESM
+      - name: Checkout CESM Submodules
         env:
           GIT_CLONE_PROTECTION_ACTIVE: false
         run: |
@@ -61,7 +61,7 @@ jobs:
           ../../bin/git-fleximod test
 
       # Copy the correct MOM_interface Branch to the CESM
-      - name: Copy MOM_interface over to the correct place in CESM
+      - name: Copy the current MOM_interface to the correct place in CESM
         run: |
           cp -r $GITHUB_WORKSPACE/MOM_interface_temp/* $GITHUB_WORKSPACE/CESM/components/mom/
 

--- a/.github/workflows/general-ci-tests.yml
+++ b/.github/workflows/general-ci-tests.yml
@@ -32,11 +32,13 @@ jobs:
           sudo apt-get install linux-tools-common
           sudo apt-get install -y csh
           echo "::endgroup::"
+          
       - name: Checkout MOM_interface to temp folder
         uses: actions/checkout@v4
         with:
           submodules: recursive
           path: MOM_interface_temp
+
       # Checkout CESM (default branch) and externals
       - name: Checkout CESM
         uses: actions/checkout@v4
@@ -52,8 +54,8 @@ jobs:
           cd CESM
           ./bin/git-fleximod update
 
-      # Copy the correct MOM Branch to the CESM
-      - name: Checkout initial event (Pull Request)
+      # Copy the correct MOM_interface Branch to the CESM
+      - name: Copy MOM_interface over to the correct place in CESM
         run: |
           cp -r $GITHUB_WORKSPACE/MOM_interface_temp/* $GITHUB_WORKSPACE/CESM/components/mom/
 

--- a/.github/workflows/general-ci-tests.yml
+++ b/.github/workflows/general-ci-tests.yml
@@ -32,7 +32,7 @@ jobs:
           sudo apt-get install linux-tools-common
           sudo apt-get install -y csh
           echo "::endgroup::"
-          
+
       - name: Checkout MOM_interface to temp folder
         uses: actions/checkout@v4
         with:
@@ -63,7 +63,7 @@ jobs:
         run: |
           echo "Checking if .gitmodules and external hashes are consistent"
           cd $GITHUB_WORKSPACE/CESM/components/mom/
-          ../../bin/git-fleximod test
+#          ../../bin/git-fleximod test
 
       # Build the standalone mom using the ubuntu script. 
       - name: Build Standalone MOM


### PR DESCRIPTION
The `check_standalone_mom_build_and_run_lightweight_examples` previously worked by checking out the CESM, `cd` to the MOM_interface subfolder and checking out the active branch/pr. This logic of checking out MOM_interface does not work if the CI is on a different fork because the CESM only checks out ESCOMP/MOM_interface. The changes made here checks out the correct MOM_interface, and copies it over to the CESM for testing.

1. Add a step to check out MOM_interface to a temp folder
2. Replace the previous MOM_interface checkout with `cp` command to copy MOM_interface into the CESM folder.
3. Move the submodule consistency check before the MOM_interface checkout stage