### PR TITLE
Enable auto IO LAYOUT 

### DIFF
--- a/param_templates/MOM_input.yaml
+++ b/param_templates/MOM_input.yaml
@@ -3650,6 +3650,15 @@ Global:
         datatype: list
         value:
             $OCN_GRID in ["tx2_3v2", "tx0.25v1"]: True
+    TARGET_IO_PES:
+        description: |
+            When AUTO_MASKTABLE is enabled, target number of IO PEs. If the given target
+            number of IO PEs is not achievable, the target number of IO PEs is set to the
+            nearest smaller number of PEs that is achievable.
+        datatype: integer
+        value:
+            $OCN_GRID == "tx2_3v2": = - ( - $NTASKS_OCN // 256) 
+            $OCN_GRID == "tx0.25v1": = - ( - $NTASKS_OCN // 128) 
     GEOM_FILE:
         description: |
             default = ocean_geometry.nc

--- a/param_templates/input_nml.yaml
+++ b/param_templates/input_nml.yaml
@@ -47,6 +47,10 @@ diag_manager_nml:
             else: 30
     max_axes:
         values: 90
+    auto_merge_nc:
+        values:
+            $OCN_GRID in ["tx2_3v2", "tx0.25v1"]: .true.
+            else: .false.
 
 mpp_io_nml:
     cf_compliance:

--- a/param_templates/json/MOM_input.json
+++ b/param_templates/json/MOM_input.json
@@ -2959,6 +2959,14 @@
             "$OCN_GRID in [\"tx2_3v2\", \"tx0.25v1\"]": true
          }
       },
+      "TARGET_IO_PES": {
+         "description": "When AUTO_MASKTABLE is enabled, target number of IO PEs. If the given target\nnumber of IO PEs is not achievable, the target number of IO PEs is set to the\nnearest smaller number of PEs that is achievable.\n",
+         "datatype": "integer",
+         "value": {
+            "$OCN_GRID == \"tx2_3v2\"": "= - ( - $NTASKS_OCN // 256)",
+            "$OCN_GRID == \"tx0.25v1\"": "= - ( - $NTASKS_OCN // 128)"
+         }
+      },
       "GEOM_FILE": {
          "description": "default = ocean_geometry.nc\nThe file into which to write the ocean geometry.\n",
          "datatype": "string",

--- a/param_templates/json/input_nml.json
+++ b/param_templates/json/input_nml.json
@@ -55,6 +55,12 @@
       },
       "max_axes": {
          "values": 90
+      },
+      "auto_merge_nc": {
+         "values": {
+            "$OCN_GRID in [\"tx2_3v2\", \"tx0.25v1\"]": ".true.",
+            "else": ".false."
+         }
       }
    },
    "mpp_io_nml": {


### PR DESCRIPTION
(This is one of three PRs to enable automated parallel IO in MOM6 within CESM.)

Two changes:
- For `tx2_3v2` and `tx0.25v1`, set a default value for `TARGET_IO_PES` and turn on auto merging of partitioned netcdf files.
- Update lbe.py to reflect the changes in https://github.com/NCAR/MOM6/pull/342

testing: aux_mom.derecho

This PR should be evaulated in conjunction with:
https://github.com/NCAR/MOM6/pull/342
https://github.com/ESCOMP/FMS/pull/5 