### PR TITLE
Additional fields in diag_table and turn off RESTART_CHECKSUMS_REQUIRED for non-test runs

### DIFF
--- a/param_templates/MOM_input.yaml
+++ b/param_templates/MOM_input.yaml
@@ -3678,7 +3678,15 @@ Global:
             Fraction of GM work that is added to backscatter rate."
         datatype: real
         value: 0.75
-
+    RESTART_CHECKSUMS_REQUIRED:
+        description: |
+            "[Boolean] default = True
+            If true, require the restart checksums to match and error out otherwise. Users
+            may want to avoid this comparison if for example the restarts are made from a
+            run with a different mask_table than the current run, in which case the
+            checksums will not match and cause crash.
+        datatype: logical
+        value: $TEST
 KPP:
     N_SMOOTH:
         description: |

--- a/param_templates/diag_table.yaml
+++ b/param_templates/diag_table.yaml
@@ -4,11 +4,11 @@
 ###############################################################################
 ---
 FieldLists:
-    - &prognostic       ["uo", "vo", "h", "e", "thetao", "so", "KE", "MEKE", "rhopot0"]
+    - &prognostic       ["uo", "vo", "h", "e", "thetao", "so", "KE", "MEKE", "rhopot0", "rhopot2", "difvho", "difvso", "Kv_u", "Kv_v", "taux_bot", "tauy_bot"]
 
-    - &prognostic_z     ["uo", "vo", "h", "thetao", "so", "agessc", "rhopot0", "N2_int"]
+    - &prognostic_z     ["uo", "vo", "h", "thetao", "so", "agessc", "rhopot0", "N2_int", "rhopot2", "difvho", "difvso", "Kv_u", "Kv_v"]
 
-    - &prognostic_rho2  ["thetao", "so", "agessc"]
+    - &prognostic_rho2  ["thetao", "so", "agessc", "e"]
 
     - &hist_additional  ["soga", "thetaoga", "uh", "vh", "vhbt", "uhbt", "rsdo"]
 
@@ -60,6 +60,10 @@ FieldLists:
     - &cfc_2d  ["cfc11_flux", "cfc12_flux", "ice_fraction", "u10_sqr"]
 
     - &geothermal  ["Geo_heat"]
+
+    - &glc_terms ["frunoff_glc", "lrunoff_glc"]
+
+    - &kpp_test ["KPP_QminusSW", "KPP_netSalt", "KPP_NLT_dTdt", "KPP_NLT_dSdT", "KPP_NLT_temp_budget", "KPP_NLT_saln_budget"]
 
 ###############################################################################
 # Section 2: File lists:
@@ -128,6 +132,12 @@ Files:
                 lists3:
                     $USE_CFC_CAP == "True":
                         [ *cfc_2d ]
+                lists4:
+                    $COMP_ATM == "cam":
+                        [ *glc_terms ]
+                lists5:
+                    $TEST == True:
+                        [ *kpp_test ]
 
     # essential variable mapped to z_space
     hist_z_space:

--- a/param_templates/diag_table.yaml
+++ b/param_templates/diag_table.yaml
@@ -63,7 +63,7 @@ FieldLists:
 
     - &glc_terms ["frunoff_glc", "lrunoff_glc"]
 
-    - &kpp_test ["KPP_QminusSW", "KPP_netSalt", "KPP_NLT_dTdt", "KPP_NLT_dSdT", "KPP_NLT_temp_budget", "KPP_NLT_saln_budget"]
+    - &kpp_test ["KPP_QminusSW", "KPP_netSalt", "KPP_NLT_dTdt", "KPP_NLT_dSdt", "KPP_NLT_temp_budget", "KPP_NLT_saln_budget"]
 
 ###############################################################################
 # Section 2: File lists:
@@ -168,7 +168,7 @@ Files:
 
     surface_avg:
         suffix: 
-            $TEST == True: "h.sfc%4yr-%2mo-2dy"
+            $TEST == True: "h.sfc%4yr-%2mo-%2dy"
             else: "h.sfc%4yr-%2mo"
         output_freq:
             $OCN_DIAG_MODE == "spinup": 5
@@ -182,7 +182,7 @@ Files:
         reduction_method: "mean"    # time average
         regional_section: "none"    # global
         fields:
-            $OCN_DIAG_MODE != "none" and $TEST is not True :
+            $OCN_DIAG_MODE != "none":
                 module:   "ocean_model"    # native
                 packing: = 1 if $TEST else 2
                 lists:    [ *surface_flds_common,

--- a/param_templates/json/MOM_input.json
+++ b/param_templates/json/MOM_input.json
@@ -2981,6 +2981,11 @@
          "description": "\"[nondim] default = 0.0\nFraction of GM work that is added to backscatter rate.\"\n",
          "datatype": "real",
          "value": 0.75
+      },
+      "RESTART_CHECKSUMS_REQUIRED": {
+         "description": "\"[Boolean] default = True\nIf true, require the restart checksums to match and error out otherwise. Users\nmay want to avoid this comparison if for example the restarts are made from a\nrun with a different mask_table than the current run, in which case the\nchecksums will not match and cause crash.\n",
+         "datatype": "logical",
+         "value": "$TEST"
       }
    },
    "KPP": {

--- a/param_templates/json/diag_table.json
+++ b/param_templates/json/diag_table.json
@@ -9,7 +9,14 @@
          "so",
          "KE",
          "MEKE",
-         "rhopot0"
+         "rhopot0",
+         "rhopot2",
+         "difvho",
+         "difvso",
+         "Kv_u",
+         "Kv_v",
+         "taux_bot",
+         "tauy_bot"
       ],
       [
          "uo",
@@ -19,12 +26,18 @@
          "so",
          "agessc",
          "rhopot0",
-         "N2_int"
+         "N2_int",
+         "rhopot2",
+         "difvho",
+         "difvso",
+         "Kv_u",
+         "Kv_v"
       ],
       [
          "thetao",
          "so",
-         "agessc"
+         "agessc",
+         "e"
       ],
       [
          "soga",
@@ -192,6 +205,18 @@
       ],
       [
          "Geo_heat"
+      ],
+      [
+         "frunoff_glc",
+         "lrunoff_glc"
+      ],
+      [
+         "KPP_QminusSW",
+         "KPP_netSalt",
+         "KPP_NLT_dTdt",
+         "KPP_NLT_dSdT",
+         "KPP_NLT_temp_budget",
+         "KPP_NLT_saln_budget"
       ]
    ],
    "Files": {
@@ -230,7 +255,8 @@
                   [
                      "thetao",
                      "so",
-                     "agessc"
+                     "agessc",
+                     "e"
                   ]
                ],
                "lists2": {
@@ -312,7 +338,14 @@
                         "so",
                         "KE",
                         "MEKE",
-                        "rhopot0"
+                        "rhopot0",
+                        "rhopot2",
+                        "difvho",
+                        "difvso",
+                        "Kv_u",
+                        "Kv_v",
+                        "taux_bot",
+                        "tauy_bot"
                      ],
                      [
                         "KPP_OBLdepth:oml",
@@ -387,6 +420,26 @@
                         "u10_sqr"
                      ]
                   ]
+               },
+               "lists4": {
+                  "$COMP_ATM == \"cam\"": [
+                     [
+                        "frunoff_glc",
+                        "lrunoff_glc"
+                     ]
+                  ]
+               },
+               "lists5": {
+                  "$TEST == True": [
+                     [
+                        "KPP_QminusSW",
+                        "KPP_netSalt",
+                        "KPP_NLT_dTdt",
+                        "KPP_NLT_dSdT",
+                        "KPP_NLT_temp_budget",
+                        "KPP_NLT_saln_budget"
+                     ]
+                  ]
                }
             }
          }
@@ -422,7 +475,12 @@
                      "so",
                      "agessc",
                      "rhopot0",
-                     "N2_int"
+                     "N2_int",
+                     "rhopot2",
+                     "difvho",
+                     "difvso",
+                     "Kv_u",
+                     "Kv_v"
                   ],
                   [
                      "volcello",

--- a/param_templates/json/diag_table.json
+++ b/param_templates/json/diag_table.json
@@ -214,7 +214,7 @@
          "KPP_QminusSW",
          "KPP_netSalt",
          "KPP_NLT_dTdt",
-         "KPP_NLT_dSdT",
+         "KPP_NLT_dSdt",
          "KPP_NLT_temp_budget",
          "KPP_NLT_saln_budget"
       ]
@@ -435,7 +435,7 @@
                         "KPP_QminusSW",
                         "KPP_netSalt",
                         "KPP_NLT_dTdt",
-                        "KPP_NLT_dSdT",
+                        "KPP_NLT_dSdt",
                         "KPP_NLT_temp_budget",
                         "KPP_NLT_saln_budget"
                      ]
@@ -505,7 +505,7 @@
       },
       "surface_avg": {
          "suffix": {
-            "$TEST == True": "h.sfc%4yr-%2mo-2dy",
+            "$TEST == True": "h.sfc%4yr-%2mo-%2dy",
             "else": "h.sfc%4yr-%2mo"
          },
          "output_freq": {
@@ -522,7 +522,7 @@
          "reduction_method": "mean",
          "regional_section": "none",
          "fields": {
-            "$OCN_DIAG_MODE != \"none\" and $TEST is not True": {
+            "$OCN_DIAG_MODE != \"none\"": {
                "module": "ocean_model",
                "packing": "= 1 if $TEST else 2",
                "lists": [


### PR DESCRIPTION
- "add KPP_QminusSW, KPP_netSalt, KPP_NLT_dTdt, KPP_NLT_dSdT, KPP_NLT_temp_budget, and KPP_NLT_saln_budget to the diag table with TEST=TRUE
- Add "e" into the rho2 file.
- Add "rhopot2" into the z and native files.
- Add total vertical viscosity and diffusivity in the z and native files.
- Add bottom stress terms in the native file.
- Add _GLC terms in the native file (only in B compsets).

Also, turn off `RESTART_CHECKSUMS_REQUIRED` for non-test runs.