### PR TITLE
When testing, want YYYY-MM-DD.nc suffix

### DIFF
--- a/cime_config/MARBL_scripts/MARBL_diags_to_diag_table.py
+++ b/cime_config/MARBL_scripts/MARBL_diags_to_diag_table.py
@@ -67,7 +67,7 @@ class DiagTableClass(object):
         new_file_freq_units = "days" if self._nstep_output else None
         suffix_dict = {
             '$OCN_DIAG_MODE == "spinup"': "h.bgc.native_annual%4yr",
-            "$TEST == True": "h.bgc.native%4yr-%2mo",
+            "$TEST == True": "h.bgc.native%4yr-%2mo-%2dy",
             "else": "h.bgc.native%4yr-%2mo",
         }
         output_freq_units_dict = {
@@ -83,7 +83,7 @@ class DiagTableClass(object):
         if vert_grid in ["interpolated", "both"]:
             suffix_dict = {
                 '$OCN_DIAG_MODE == "spinup"': "h.bgc.z_annual%4yr",
-                "$TEST == True": "h.bgc.z%4yr-%2mo",
+                "$TEST == True": "h.bgc.z%4yr-%2mo-%2dy",
                 f"{self._nstep_output} == True": "h.bgc.z_nstep%4yr-%2mo-%2dy",
                 "else": "h.bgc.z%4yr-%2mo",
             }


### PR DESCRIPTION
The streams for the CESM test suite are set up to write daily averages, and to write a single day per file. When the suffix is YYYY-MM.nc, the file is overwritten every day until the end of the month (or the test run).

Testing: Ran a single `SMS.TL319_t232.G1850MARBL_JRA.derecho_intel` test and verified it creates

```
${CASE}.mom6.h.bgc.native.0001-01-01.nc
${CASE}.h.bgc.z.0001-01-01.nc
${CASE}.mom6.h.bgc.native.0001-01-02.nc
${CASE}.mom6.h.bgc.z.0001-01-02.nc
${CASE}.mom6.h.bgc.native.0001-01-03.nc
${CASE}.mom6.h.bgc.z.0001-01-03.nc
${CASE}.mom6.h.bgc.native.0001-01-04.nc
${CASE}.mom6.h.bgc.z.0001-01-04.nc
${CASE}.mom6.h.bgc.native.0001-01-05.nc
${CASE}.mom6.h.bgc.z.0001-01-05.nc
```

instead of

```
${CASE}.mom6.h.bgc.native.0001-01.nc
${CASE}.mom6.h.bgc.z.0001-01.nc
```

Fixes #243