### PR TITLE
AUTO_MASKTABLE is FALSE by default

### DIFF
--- a/param_templates/MOM_input.yaml
+++ b/param_templates/MOM_input.yaml
@@ -3648,8 +3648,7 @@ Global:
         description: |
             Turn on automatic mask table generation to eliminate land blocks
         datatype: list
-        value:
-            $OCN_GRID in ["tx2_3v2", "tx0.25v1"]: True
+        value: False
     TARGET_IO_PES:
         description: |
             When AUTO_MASKTABLE is enabled, target number of IO PEs. If the given target

--- a/param_templates/json/MOM_input.json
+++ b/param_templates/json/MOM_input.json
@@ -2955,9 +2955,7 @@
       "AUTO_MASKTABLE": {
          "description": "Turn on automatic mask table generation to eliminate land blocks\n",
          "datatype": "list",
-         "value": {
-            "$OCN_GRID in [\"tx2_3v2\", \"tx0.25v1\"]": true
-         }
+         "value": false
       },
       "TARGET_IO_PES": {
          "description": "When AUTO_MASKTABLE is enabled, target number of IO PEs. If the given target\nnumber of IO PEs is not achievable, the target number of IO PEs is set to the\nnearest smaller number of PEs that is achievable.\n",


### PR DESCRIPTION
Turns off parallel I/O until we can work out the last few issues with it

Testing: Ran a single `SMS.TL319_t232.G1850MARBL_JRA.derecho_intel` test and (a) `AUTO_MASKTABLE = False` in `MOM_parameter_doc.layout`, and (b) no partial netcdf files were created / needed to be stitched together. Note that this particular test took 26 minutes to run instead of 11... between the large PE layout for compsets with MARBL enabled (MOM6 has 20 nodes) and the large amount of output, this configuration is a prime candidate for parallel I/O.