### PR TITLE
Turn off t232 parallel IO for non-test runs

### DIFF
--- a/param_templates/MOM_input.yaml
+++ b/param_templates/MOM_input.yaml
@@ -3657,7 +3657,7 @@ Global:
             nearest smaller number of PEs that is achievable.
         datatype: integer
         value:
-            $OCN_GRID == "tx2_3v2": = - ( - $NTASKS_OCN // 256) 
+            $OCN_GRID == "tx2_3v2" and $TEST: = - ( - $NTASKS_OCN // 256)
             $OCN_GRID == "tx0.25v1": = - ( - $NTASKS_OCN // 128) 
     GEOM_FILE:
         description: |

--- a/param_templates/json/MOM_input.json
+++ b/param_templates/json/MOM_input.json
@@ -2963,7 +2963,7 @@
          "description": "When AUTO_MASKTABLE is enabled, target number of IO PEs. If the given target\nnumber of IO PEs is not achievable, the target number of IO PEs is set to the\nnearest smaller number of PEs that is achievable.\n",
          "datatype": "integer",
          "value": {
-            "$OCN_GRID == \"tx2_3v2\"": "= - ( - $NTASKS_OCN // 256)",
+            "$OCN_GRID == \"tx2_3v2\" and $TEST": "= - ( - $NTASKS_OCN // 256)",
             "$OCN_GRID == \"tx0.25v1\"": "= - ( - $NTASKS_OCN // 128)"
          }
       },


### PR DESCRIPTION
Although there are no remaining known issues, this PR disables parallel I/O for non-test runs on the t232 grid as a precaution. The performance benefits for this grid are minimal anyway, but we may turn it on again in the next beta series, particularly for MARBL compsets.