### PR TITLE
Add new parameter defaults for beta06 and fixes typo in diag_table

### DIFF
--- a/param_templates/MOM_input.yaml
+++ b/param_templates/MOM_input.yaml
@@ -1517,38 +1517,6 @@ Global:
         value:
             $OCN_GRID == "MISOMIP": False
             else: True
-    USE_BODNER23:
-        description: |
-            "[Boolean] default = False
-            If true, use the Bodner et al., 2023, formulation of the re-stratifying
-            mixed-layer restratification parameterization. This only works in ALE mode."
-        datatype: logical
-        units: Boolean
-        value:
-            $OCN_GRID == "tx2_3v2": True
-    USE_CR_GRID:
-        description: |
-            "[Boolean] default = False
-            true, read in a spatially varying Cr field."
-        datatype: logical
-        units: Boolean
-        value:
-            $OCN_GRID == "tx2_3v2": True
-    CR_FILE:
-        description: |
-            "The path to the file containing the Cr fields."
-        datatype: string
-        value:
-            $OCN_GRID == "tx2_3v2": "mle-cr-tx2_3v2-v10_20250422.nc"
-    BODNER_DETECT_MLD:
-        description: |
-            "[Boolean] default = False
-            If true, the Bodner parameterization will use the mixed-layer depth detected
-            via the density difference criterion defined by MLE_DENSITY_DIFF.
-        datatype: bool
-        units: none
-        value:
-            $OCN_GRID == "tx2_3v2": true
     MLE_DENSITY_DIFF:
         description: |
             "[kg/m3] default = 0.03
@@ -1558,58 +1526,6 @@ Global:
         units: kg/m3
         value:
             $OCN_GRID == "tx2_3v2": 0.02
-    MIN_WSTAR2:
-        description: |
-            "[m2 s-2] default = 1.0E-24
-            The minimum lower bound applied to the vertical momentum flux, w'u', in the
-            Bodner et al. restratification parameterization. This avoids a division-by-zero
-            in the limit when u* and the buoyancy flux are zero. The default is smaller
-            than the product of the molecular viscosity of water and the Coriolis parameter
-            one micron from the equator."
-        datatype: real
-        units: m2 s-2
-        value:
-            $OCN_GRID == "tx2_3v2": 1.0E-09
-    BLD_DECAYING_TFILTER:
-        description: |
-            "default = 0.0
-            The time scale for a running-mean filter applied to the boundary layer depth (BLD)
-            when the BLD is shallower than the running mean. A value of 0 instantaneously sets
-            the running mean to the current BLD value."
-        datatype: real
-        units: s
-        value:
-            $OCN_GRID == "tx2_3v2": 8.64E+04
-    BLD_GROWING_TFILTER:
-        description: |
-            "[s] default = 0.0
-            The time scale for a running-mean filter applied to the boundary layer depth (BLD)
-            when the BLD is deeper than the running mean. A value of 0 instantaneously sets
-            the running mean to the current BLD value."
-        datatype: real
-        units: s
-        value:
-            $OCN_GRID == "tx2_3v2": 300.0
-    MLD_GROWING_TFILTER:
-        description: |
-            "[s] default = 0.0
-            The time scale for a running-mean filter applied to the time-filtered boundary layer depth (BLD),
-            when the filtered BLD is deeper than the running mean. A value of 0 instantaneously sets
-            the running mean to the current filtered BLD value."
-        datatype: real
-        units: s
-        value:
-            $OCN_GRID == "tx2_3v2": 3600.0
-    MLD_DECAYING_TFILTER:
-        description: |
-            "[s] default = 0.0
-            The time scale for a running-mean filter applied to the time-filtered boundary layer depth (BLD),
-            when the filtered BLD is shallower than the running mean. A value of 0 instantaneously sets
-            the running mean to the current filtered BLD value."
-        datatype: real
-        units: s
-        value:
-            $OCN_GRID == "tx2_3v2": 2.592E+06
     FOX_KEMPER_ML_RESTRAT_COEF:
         description: |
             "[nondim] default = 0.0
@@ -3890,5 +3806,89 @@ KPP:
         datatype: real
         value:
            $OCN_GRID == "tx2_3v2": 5.0
+MLE:
+    USE_BODNER23:
+        description: |
+            "[Boolean] default = False
+            If true, use the Bodner et al., 2023, formulation of the re-stratifying
+            mixed-layer restratification parameterization. This only works in ALE mode."
+        datatype: logical
+        units: Boolean
+        value:
+            $OCN_GRID == "tx2_3v2": True
+    USE_CR_GRID:
+        description: |
+            "[Boolean] default = False
+            true, read in a spatially varying Cr field."
+        datatype: logical
+        units: Boolean
+        value:
+            $OCN_GRID == "tx2_3v2": True
+    CR_FILE:
+        description: |
+            "The path to the file containing the Cr fields."
+        datatype: string
+        value:
+            $OCN_GRID == "tx2_3v2": "mle-cr-tx2_3v2-v10_20250422.nc"
+    BODNER_DETECT_MLD:
+        description: |
+            "[Boolean] default = False
+            If true, the Bodner parameterization will use the mixed-layer depth detected
+            via the density difference criterion defined by MLE_DENSITY_DIFF.
+        datatype: bool
+        units: none
+        value:
+            $OCN_GRID == "tx2_3v2": true
+    MIN_WSTAR2:
+        description: |
+            "[m2 s-2] default = 1.0E-24
+            The minimum lower bound applied to the vertical momentum flux, w'u', in the
+            Bodner et al. restratification parameterization. This avoids a division-by-zero
+            in the limit when u* and the buoyancy flux are zero. The default is smaller
+            than the product of the molecular viscosity of water and the Coriolis parameter
+            one micron from the equator."
+        datatype: real
+        units: m2 s-2
+        value:
+            $OCN_GRID == "tx2_3v2": 1.0E-09
+    BLD_DECAYING_TFILTER:
+        description: |
+            "default = 0.0
+            The time scale for a running-mean filter applied to the boundary layer depth (BLD)
+            when the BLD is shallower than the running mean. A value of 0 instantaneously sets
+            the running mean to the current BLD value."
+        datatype: real
+        units: s
+        value:
+            $OCN_GRID == "tx2_3v2": 8.64E+04
+    BLD_GROWING_TFILTER:
+        description: |
+            "[s] default = 0.0
+            The time scale for a running-mean filter applied to the boundary layer depth (BLD)
+            when the BLD is deeper than the running mean. A value of 0 instantaneously sets
+            the running mean to the current BLD value."
+        datatype: real
+        units: s
+        value:
+            $OCN_GRID == "tx2_3v2": 300.0
+    MLD_GROWING_TFILTER:
+        description: |
+            "[s] default = 0.0
+            The time scale for a running-mean filter applied to the time-filtered boundary layer depth (BLD),
+            when the filtered BLD is deeper than the running mean. A value of 0 instantaneously sets
+            the running mean to the current filtered BLD value."
+        datatype: real
+        units: s
+        value:
+            $OCN_GRID == "tx2_3v2": 3600.0
+    MLD_DECAYING_TFILTER:
+        description: |
+            "[s] default = 0.0
+            The time scale for a running-mean filter applied to the time-filtered boundary layer depth (BLD),
+            when the filtered BLD is shallower than the running mean. A value of 0 instantaneously sets
+            the running mean to the current filtered BLD value."
+        datatype: real
+        units: s
+        value:
+            $OCN_GRID == "tx2_3v2": 2.592E+06
 ...
-

--- a/param_templates/MOM_input.yaml
+++ b/param_templates/MOM_input.yaml
@@ -3705,8 +3705,7 @@ KPP:
         description: |
             "default = 0
             The number of times the 1-1-4-1-1 Laplacian filter is applied on
-            OBL depth.
-            purely for diagnostic purposes."
+            OBL depth purely for diagnostic purposes."
         datatype: integer
         value:
             $OCN_GRID == "tx2_3v2": 3
@@ -3834,11 +3833,11 @@ MLE:
         description: |
             "[Boolean] default = False
             If true, the Bodner parameterization will use the mixed-layer depth detected
-            via the density difference criterion defined by MLE_DENSITY_DIFF.
+            via the density difference criterion defined by MLE_DENSITY_DIFF."
         datatype: bool
         units: none
         value:
-            $OCN_GRID == "tx2_3v2": true
+            $OCN_GRID == "tx2_3v2": True
     MIN_WSTAR2:
         description: |
             "[m2 s-2] default = 1.0E-24

--- a/param_templates/MOM_input.yaml
+++ b/param_templates/MOM_input.yaml
@@ -625,6 +625,17 @@ Global:
         units: Boolean
         value:
              $OCN_GRID == "tx2_3v2": True
+    REMAPPING_USE_OM4_SUBCELLS:
+        description: |
+            "[Boolean] default = True
+            This selects the remapping algorithm used in OM4 that does not use the full
+            reconstruction for the top- and lower-most sub-layers. Instead, it assumes
+            they are always vanished (which is untrue) and uses only their edge values.
+            It is recommended to set this option to false."
+        datatype: bool
+        units: none
+        value:
+            $OCN_GRID == "tx2_3v2": False
     INIT_LAYERS_FROM_Z_FILE:
         description: |
             "[Boolean] default = False
@@ -1506,6 +1517,99 @@ Global:
         value:
             $OCN_GRID == "MISOMIP": False
             else: True
+    USE_BODNER23:
+        description: |
+            "[Boolean] default = False
+            If true, use the Bodner et al., 2023, formulation of the re-stratifying
+            mixed-layer restratification parameterization. This only works in ALE mode."
+        datatype: logical
+        units: Boolean
+        value:
+            $OCN_GRID == "tx2_3v2": True
+    USE_CR_GRID:
+        description: |
+            "[Boolean] default = False
+            true, read in a spatially varying Cr field."
+        datatype: logical
+        units: Boolean
+        value:
+            $OCN_GRID == "tx2_3v2": True
+    CR_FILE:
+        description: |
+            "The path to the file containing the Cr fields."
+        datatype: string
+        value:
+            $OCN_GRID == "tx2_3v2": "mle-cr-tx2_3v2-v8_20250215.nc"
+    BODNER_DETECT_MLD:
+        description: |
+            "[Boolean] default = False
+            If true, the Bodner parameterization will use the mixed-layer depth detected
+            via the density difference criterion defined by MLE_DENSITY_DIFF.
+        datatype: bool
+        units: none
+        value:
+            $OCN_GRID == "tx2_3v2": true
+    MLE_DENSITY_DIFF:
+        description: |
+            "[kg/m3] default = 0.03
+            Density difference used to detect the mixed-layer depth for the
+            mixed-layer eddy parameterization by Fox-Kemper et al. (2010)."
+        datatype: real
+        units: kg/m3
+        value:
+            $OCN_GRID == "tx2_3v2": 0.02
+    MIN_WSTAR2:
+        description: |
+            "[m2 s-2] default = 1.0E-24
+            The minimum lower bound applied to the vertical momentum flux, w'u', in the
+            Bodner et al. restratification parameterization. This avoids a division-by-zero
+            in the limit when u* and the buoyancy flux are zero. The default is smaller
+            than the product of the molecular viscosity of water and the Coriolis parameter
+            one micron from the equator."
+        datatype: real
+        units: m2 s-2
+        value:
+            $OCN_GRID == "tx2_3v2": 1.0E-09
+    BLD_DECAYING_TFILTER:
+        description: |
+            "default = 0.0
+            The time scale for a running-mean filter applied to the boundary layer depth (BLD)
+            when the BLD is shallower than the running mean. A value of 0 instantaneously sets
+            the running mean to the current BLD value."
+        datatype: real
+        units: s
+        value:
+            $OCN_GRID == "tx2_3v2": 8.64E+04
+    BLD_GROWING_TFILTER:
+        description: |
+            "[s] default = 0.0
+            The time scale for a running-mean filter applied to the boundary layer depth (BLD)
+            when the BLD is deeper than the running mean. A value of 0 instantaneously sets
+            the running mean to the current BLD value."
+        datatype: real
+        units: s
+        value:
+            $OCN_GRID == "tx2_3v2": 300.0
+    MLD_GROWING_TFILTER:
+        description: |
+            "[s] default = 0.0
+            The time scale for a running-mean filter applied to the time-filtered boundary layer depth (BLD),
+            when the filtered BLD is deeper than the running mean. A value of 0 instantaneously sets
+            the running mean to the current filtered BLD value."
+        datatype: real
+        units: s
+        value:
+            $OCN_GRID == "tx2_3v2": 3600.0
+    MLD_DECAYING_TFILTER:
+        description: |
+            "[s] default = 0.0
+            The time scale for a running-mean filter applied to the time-filtered boundary layer depth (BLD),
+            when the filtered BLD is shallower than the running mean. A value of 0 instantaneously sets
+            the running mean to the current filtered BLD value."
+        datatype: real
+        units: s
+        value:
+            $OCN_GRID == "tx2_3v2": 2.592E+06
     FOX_KEMPER_ML_RESTRAT_COEF:
         description: |
             "[nondim] default = 0.0
@@ -1547,13 +1651,6 @@ Global:
         units: Boolean
         value:
             $OCN_GRID == "tx2_3v2": False
-    MLE_FL_FILE:
-        description: |
-            "The path to the file containing the MLE
-            front-length scale.."
-        datatype: string
-        value:
-            $OCN_GRID == "tx2_3v2": "mle-lf-clim-tx2_3v2_20250115.nc"
     MLE_MLD_DECAY_TIME:
         description: |
             "[s] default = 0.0
@@ -3657,8 +3754,8 @@ Global:
             nearest smaller number of PEs that is achievable.
         datatype: integer
         value:
-            $OCN_GRID == "tx2_3v2": = - ( - $NTASKS_OCN // 256) 
-            $OCN_GRID == "tx0.25v1": = - ( - $NTASKS_OCN // 128) 
+            $OCN_GRID == "tx2_3v2": = - ( - $NTASKS_OCN // 256)
+            $OCN_GRID == "tx0.25v1": = - ( - $NTASKS_OCN // 128)
     GEOM_FILE:
         description: |
             default = ocean_geometry.nc
@@ -3754,6 +3851,14 @@ KPP:
         datatype: string
         value:
             $COMP_WAV == "ww3": VR12
+    KPP_CVt2:
+        description: |
+            "[nondim] default = 1.6
+            Parameter for Stokes MOST convection entrainment."
+        datatype: real
+        units: nondim
+        value:
+            $OCN_GRID == "tx2_3v2": 1.0
     STOKES_MOST:
         description: |
             default = False

--- a/param_templates/MOM_input.yaml
+++ b/param_templates/MOM_input.yaml
@@ -3837,7 +3837,7 @@ MLE:
             "The path to the file containing the Cr fields."
         datatype: string
         value:
-            $OCN_GRID == "tx2_3v2": "mle-cr-tx2_3v2-v10_20250423.nc"
+            $OCN_GRID == "tx2_3v2": "mle-cr-tx2_3v2-v10_20250426.nc"
     MIN_WSTAR2:
         description: |
             "[m2 s-2] default = 1.0E-24

--- a/param_templates/MOM_input.yaml
+++ b/param_templates/MOM_input.yaml
@@ -3829,7 +3829,7 @@ MLE:
             "The path to the file containing the Cr fields."
         datatype: string
         value:
-            $OCN_GRID == "tx2_3v2": "mle-cr-tx2_3v2-v10_20250422.nc"
+            $OCN_GRID == "tx2_3v2": "mle-cr-tx2_3v2-v10_20250423.nc"
     BODNER_DETECT_MLD:
         description: |
             "[Boolean] default = False

--- a/param_templates/MOM_input.yaml
+++ b/param_templates/MOM_input.yaml
@@ -1517,6 +1517,15 @@ Global:
         value:
             $OCN_GRID == "MISOMIP": False
             else: True
+    BODNER_DETECT_MLD:
+        description: |
+            "[Boolean] default = False
+            If true, the Bodner parameterization will use the mixed-layer depth detected
+            via the density difference criterion defined by MLE_DENSITY_DIFF."
+        datatype: bool
+        units: none
+        value:
+            $OCN_GRID == "tx2_3v2": True
     MLE_DENSITY_DIFF:
         description: |
             "[kg/m3] default = 0.03
@@ -3829,15 +3838,6 @@ MLE:
         datatype: string
         value:
             $OCN_GRID == "tx2_3v2": "mle-cr-tx2_3v2-v10_20250423.nc"
-    BODNER_DETECT_MLD:
-        description: |
-            "[Boolean] default = False
-            If true, the Bodner parameterization will use the mixed-layer depth detected
-            via the density difference criterion defined by MLE_DENSITY_DIFF."
-        datatype: bool
-        units: none
-        value:
-            $OCN_GRID == "tx2_3v2": True
     MIN_WSTAR2:
         description: |
             "[m2 s-2] default = 1.0E-24

--- a/param_templates/MOM_input.yaml
+++ b/param_templates/MOM_input.yaml
@@ -1539,7 +1539,7 @@ Global:
             "The path to the file containing the Cr fields."
         datatype: string
         value:
-            $OCN_GRID == "tx2_3v2": "mle-cr-tx2_3v2-v8_20250215.nc"
+            $OCN_GRID == "tx2_3v2": "mle-cr-tx2_3v2-v10_20250422.nc"
     BODNER_DETECT_MLD:
         description: |
             "[Boolean] default = False

--- a/param_templates/diag_table.yaml
+++ b/param_templates/diag_table.yaml
@@ -15,11 +15,11 @@ FieldLists:
     - &tracers          ["agessc", "T_ady_2d", "T_adx_2d", "T_diffy_2d", "T_diffx_2d",
                          "T_hbd_diffx_2d", 'T_hbd_diffy_2d']
 
-    - &surface_flds_common ["tos", "tos:tos_min:min", "tos:tos_max:max", 
-                         "sos", "sos:sos_min:min", "sos:sos_max:max", 
+    - &surface_flds_common ["tos", "tos:tos_min:min", "tos:tos_max:max",
+                         "sos", "sos:sos_min:min", "sos:sos_max:max",
                          "SSU", "SSV", "opottempmint", "somint", "Rd_dx", "speed",
-                         "mlotst", "mlotst:mlots_min:min", "mlotst:mlots_max:max"]
-    
+                         "mlotst", "mlotst:mlotst_min:min", "mlotst:mlotst_max:max"]
+
     - &surface_flds_daily ["zos", "zossq"]
 
     - &surface_flds_monthly ["sst_global", "sss_global", "SSH", "mass_wt"]
@@ -69,8 +69,8 @@ FieldLists:
 Files:
     # sigma2
     sigma2_hist:
-        suffix: 
-            $TEST == True: "h.rho2%4yr-%2mo-%2dy" 
+        suffix:
+            $TEST == True: "h.rho2%4yr-%2mo-%2dy"
             else: "h.rho2%4yr-%2mo"
         output_freq: 1
         output_freq_units:
@@ -94,8 +94,8 @@ Files:
                         [ *cfc_3d ]
     # native grid
     hist:
-        suffix: 
-            $TEST == True: "h.native%4yr-%2mo-%2dy" 
+        suffix:
+            $TEST == True: "h.native%4yr-%2mo-%2dy"
             else: "h.native%4yr-%2mo"
         output_freq: 1
         output_freq_units:
@@ -131,7 +131,7 @@ Files:
 
     # essential variable mapped to z_space
     hist_z_space:
-        suffix: 
+        suffix:
             $TEST == True: "h.z%4yr-%2mo-%2dy"
             else: "h.z%4yr-%2mo"
         output_freq: 1
@@ -157,7 +157,7 @@ Files:
                         [ *cfc_3d ]
 
     surface_avg:
-        suffix: 
+        suffix:
             $TEST == True: "h.sfc%4yr-%2mo-2dy"
             else: "h.sfc%4yr-%2mo"
         output_freq:
@@ -179,7 +179,7 @@ Files:
                             *surface_flds_daily,
                             *kpp_diags ]
     forcing_avg:
-        suffix: 
+        suffix:
             $TEST == True: "h.frc%4yr-%2mo-%2dy"
             else: "h.frc%4yr-%2mo"
         output_freq: 1

--- a/param_templates/input_data_list.yaml
+++ b/param_templates/input_data_list.yaml
@@ -44,7 +44,7 @@ mom.input_data_list:
         $OCN_GRID == "tx0.25v1": "${INPUTDIR}/seawifs-clim-1997-2010.1440x1080.v20180328.nc"
         $OCN_GRID == "tx2_3v2": "${INPUTDIR}/seawifs-clim-1997-2010-tx2_3v2.230416.nc"
     CR_FILE:
-        $OCN_GRID == "tx2_3v2": "${INPUTDIR}/mle-cr-tx2_3v2-v10_20250423.nc"
+        $OCN_GRID == "tx2_3v2": "${INPUTDIR}/mle-cr-tx2_3v2-v10_20250426.nc"
     CFC_BC_FILE: "${DIN_LOC_ROOT}/ocn/mom/grid_indpt/cfc_atm_20230310.nc"
     DIAG_COORD_DEF_RHO2:
         $OCN_GRID == "tx2_3v2":  "${INPUTDIR}/ocean_rho2_190917.nc"

--- a/param_templates/input_data_list.yaml
+++ b/param_templates/input_data_list.yaml
@@ -43,8 +43,8 @@ mom.input_data_list:
     CHL_FILE:
         $OCN_GRID == "tx0.25v1": "${INPUTDIR}/seawifs-clim-1997-2010.1440x1080.v20180328.nc"
         $OCN_GRID == "tx2_3v2": "${INPUTDIR}/seawifs-clim-1997-2010-tx2_3v2.230416.nc"
-    MLE_FL_FILE:
-        $OCN_GRID == "tx2_3v2": "${INPUTDIR}/mle-lf-clim-tx2_3v2_20250115.nc"
+    CR_FILE:
+        $OCN_GRID == "tx2_3v2": "${INPUTDIR}/mle-cr-tx2_3v2-v10_20250423.nc"
     CFC_BC_FILE: "${DIN_LOC_ROOT}/ocn/mom/grid_indpt/cfc_atm_20230310.nc"
     DIAG_COORD_DEF_RHO2:
         $OCN_GRID == "tx2_3v2":  "${INPUTDIR}/ocean_rho2_190917.nc"

--- a/param_templates/json/MOM_input.json
+++ b/param_templates/json/MOM_input.json
@@ -1172,7 +1172,7 @@
          "description": "\"The path to the file containing the Cr fields.\"\n",
          "datatype": "string",
          "value": {
-            "$OCN_GRID == \"tx2_3v2\"": "mle-cr-tx2_3v2-v8_20250215.nc"
+            "$OCN_GRID == \"tx2_3v2\"": "mle-cr-tx2_3v2-v10_20250422.nc"
          }
       },
       "BODNER_DETECT_MLD": {

--- a/param_templates/json/MOM_input.json
+++ b/param_templates/json/MOM_input.json
@@ -3117,7 +3117,7 @@
          "description": "\"The path to the file containing the Cr fields.\"\n",
          "datatype": "string",
          "value": {
-            "$OCN_GRID == \"tx2_3v2\"": "mle-cr-tx2_3v2-v10_20250423.nc"
+            "$OCN_GRID == \"tx2_3v2\"": "mle-cr-tx2_3v2-v10_20250426.nc"
          }
       },
       "MIN_WSTAR2": {

--- a/param_templates/json/MOM_input.json
+++ b/param_templates/json/MOM_input.json
@@ -478,6 +478,14 @@
             "$OCN_GRID == \"tx2_3v2\"": true
          }
       },
+      "REMAPPING_USE_OM4_SUBCELLS": {
+         "description": "\"[Boolean] default = True\nThis selects the remapping algorithm used in OM4 that does not use the full\nreconstruction for the top- and lower-most sub-layers. Instead, it assumes\nthey are always vanished (which is untrue) and uses only their edge values.\nIt is recommended to set this option to false.\"\n",
+         "datatype": "bool",
+         "units": "none",
+         "value": {
+            "$OCN_GRID == \"tx2_3v2\"": false
+         }
+      },
       "INIT_LAYERS_FROM_Z_FILE": {
          "description": "\"[Boolean] default = False\nIf true, intialize the layer thicknesses, temperatures,\nand salnities from a Z-space file on a latitude-\nlongitude grid.\"\n",
          "datatype": "logical",
@@ -1144,6 +1152,85 @@
             "else": true
          }
       },
+      "USE_BODNER23": {
+         "description": "\"[Boolean] default = False\nIf true, use the Bodner et al., 2023, formulation of the re-stratifying\nmixed-layer restratification parameterization. This only works in ALE mode.\"\n",
+         "datatype": "logical",
+         "units": "Boolean",
+         "value": {
+            "$OCN_GRID == \"tx2_3v2\"": true
+         }
+      },
+      "USE_CR_GRID": {
+         "description": "\"[Boolean] default = False\ntrue, read in a spatially varying Cr field.\"\n",
+         "datatype": "logical",
+         "units": "Boolean",
+         "value": {
+            "$OCN_GRID == \"tx2_3v2\"": true
+         }
+      },
+      "CR_FILE": {
+         "description": "\"The path to the file containing the Cr fields.\"\n",
+         "datatype": "string",
+         "value": {
+            "$OCN_GRID == \"tx2_3v2\"": "mle-cr-tx2_3v2-v8_20250215.nc"
+         }
+      },
+      "BODNER_DETECT_MLD": {
+         "description": "\"[Boolean] default = False\nIf true, the Bodner parameterization will use the mixed-layer depth detected\nvia the density difference criterion defined by MLE_DENSITY_DIFF.\n",
+         "datatype": "bool",
+         "units": "none",
+         "value": {
+            "$OCN_GRID == \"tx2_3v2\"": true
+         }
+      },
+      "MLE_DENSITY_DIFF": {
+         "description": "\"[kg/m3] default = 0.03\nDensity difference used to detect the mixed-layer depth for the\nmixed-layer eddy parameterization by Fox-Kemper et al. (2010).\"\n",
+         "datatype": "real",
+         "units": "kg/m3",
+         "value": {
+            "$OCN_GRID == \"tx2_3v2\"": 0.02
+         }
+      },
+      "MIN_WSTAR2": {
+         "description": "\"[m2 s-2] default = 1.0E-24\nThe minimum lower bound applied to the vertical momentum flux, w'u', in the\nBodner et al. restratification parameterization. This avoids a division-by-zero\nin the limit when u* and the buoyancy flux are zero. The default is smaller\nthan the product of the molecular viscosity of water and the Coriolis parameter\none micron from the equator.\"\n",
+         "datatype": "real",
+         "units": "m2 s-2",
+         "value": {
+            "$OCN_GRID == \"tx2_3v2\"": 1e-09
+         }
+      },
+      "BLD_DECAYING_TFILTER": {
+         "description": "\"default = 0.0\nThe time scale for a running-mean filter applied to the boundary layer depth (BLD)\nwhen the BLD is shallower than the running mean. A value of 0 instantaneously sets\nthe running mean to the current BLD value.\"\n",
+         "datatype": "real",
+         "units": "s",
+         "value": {
+            "$OCN_GRID == \"tx2_3v2\"": 86400.0
+         }
+      },
+      "BLD_GROWING_TFILTER": {
+         "description": "\"[s] default = 0.0\nThe time scale for a running-mean filter applied to the boundary layer depth (BLD)\nwhen the BLD is deeper than the running mean. A value of 0 instantaneously sets\nthe running mean to the current BLD value.\"\n",
+         "datatype": "real",
+         "units": "s",
+         "value": {
+            "$OCN_GRID == \"tx2_3v2\"": 300.0
+         }
+      },
+      "MLD_GROWING_TFILTER": {
+         "description": "\"[s] default = 0.0\nThe time scale for a running-mean filter applied to the time-filtered boundary layer depth (BLD),\nwhen the filtered BLD is deeper than the running mean. A value of 0 instantaneously sets\nthe running mean to the current filtered BLD value.\"\n",
+         "datatype": "real",
+         "units": "s",
+         "value": {
+            "$OCN_GRID == \"tx2_3v2\"": 3600.0
+         }
+      },
+      "MLD_DECAYING_TFILTER": {
+         "description": "\"[s] default = 0.0\nThe time scale for a running-mean filter applied to the time-filtered boundary layer depth (BLD),\nwhen the filtered BLD is shallower than the running mean. A value of 0 instantaneously sets\nthe running mean to the current filtered BLD value.\"\n",
+         "datatype": "real",
+         "units": "s",
+         "value": {
+            "$OCN_GRID == \"tx2_3v2\"": 2592000.0
+         }
+      },
       "FOX_KEMPER_ML_RESTRAT_COEF": {
          "description": "\"[nondim] default = 0.0\nA nondimensional coefficient that is proportional to\nthe ratio of the deformation radius to the dominant\nlengthscale of the submesoscale mixed layer\ninstabilities, times the minimum of the ratio of the\nmesoscale eddy kinetic energy to the large-scale\ngeostrophic kinetic energy or 1 plus the square of the\ngrid spacing over the deformation radius, as detailed\nby Fox-Kemper et al. (2010)\nThe file that specifies the vertical grid for\ndepth-space diagnostics, or blank to disable\ndepth-space output.\nThe number of depth-space levels.  This is determined\nfrom the size of the variable zw in the output grid file.\"\n",
          "datatype": "real",
@@ -1168,13 +1255,6 @@
          "units": "Boolean",
          "value": {
             "$OCN_GRID == \"tx2_3v2\"": false
-         }
-      },
-      "MLE_FL_FILE": {
-         "description": "\"The path to the file containing the MLE\nfront-length scale..\"\n",
-         "datatype": "string",
-         "value": {
-            "$OCN_GRID == \"tx2_3v2\"": "mle-lf-clim-tx2_3v2_20250115.nc"
          }
       },
       "MLE_MLD_DECAY_TIME": {
@@ -3041,6 +3121,14 @@
          "datatype": "string",
          "value": {
             "$COMP_WAV == \"ww3\"": "VR12"
+         }
+      },
+      "KPP_CVt2": {
+         "description": "\"[nondim] default = 1.6\nParameter for Stokes MOST convection entrainment.\"\n",
+         "datatype": "real",
+         "units": "nondim",
+         "value": {
+            "$OCN_GRID == \"tx2_3v2\"": 1.0
          }
       },
       "STOKES_MOST": {

--- a/param_templates/json/MOM_input.json
+++ b/param_templates/json/MOM_input.json
@@ -1152,6 +1152,14 @@
             "else": true
          }
       },
+      "BODNER_DETECT_MLD": {
+         "description": "\"[Boolean] default = False\nIf true, the Bodner parameterization will use the mixed-layer depth detected\nvia the density difference criterion defined by MLE_DENSITY_DIFF.\"\n",
+         "datatype": "bool",
+         "units": "none",
+         "value": {
+            "$OCN_GRID == \"tx2_3v2\"": true
+         }
+      },
       "MLE_DENSITY_DIFF": {
          "description": "\"[kg/m3] default = 0.03\nDensity difference used to detect the mixed-layer depth for the\nmixed-layer eddy parameterization by Fox-Kemper et al. (2010).\"\n",
          "datatype": "real",
@@ -3110,14 +3118,6 @@
          "datatype": "string",
          "value": {
             "$OCN_GRID == \"tx2_3v2\"": "mle-cr-tx2_3v2-v10_20250423.nc"
-         }
-      },
-      "BODNER_DETECT_MLD": {
-         "description": "\"[Boolean] default = False\nIf true, the Bodner parameterization will use the mixed-layer depth detected\nvia the density difference criterion defined by MLE_DENSITY_DIFF.\"\n",
-         "datatype": "bool",
-         "units": "none",
-         "value": {
-            "$OCN_GRID == \"tx2_3v2\"": true
          }
       },
       "MIN_WSTAR2": {

--- a/param_templates/json/MOM_input.json
+++ b/param_templates/json/MOM_input.json
@@ -2999,7 +2999,7 @@
    },
    "KPP": {
       "N_SMOOTH": {
-         "description": "\"default = 0\nThe number of times the 1-1-4-1-1 Laplacian filter is applied on\nOBL depth.\npurely for diagnostic purposes.\"\n",
+         "description": "\"default = 0\nThe number of times the 1-1-4-1-1 Laplacian filter is applied on\nOBL depth purely for diagnostic purposes.\"\n",
          "datatype": "integer",
          "value": {
             "$OCN_GRID == \"tx2_3v2\"": 3
@@ -3113,7 +3113,7 @@
          }
       },
       "BODNER_DETECT_MLD": {
-         "description": "\"[Boolean] default = False\nIf true, the Bodner parameterization will use the mixed-layer depth detected\nvia the density difference criterion defined by MLE_DENSITY_DIFF.\n",
+         "description": "\"[Boolean] default = False\nIf true, the Bodner parameterization will use the mixed-layer depth detected\nvia the density difference criterion defined by MLE_DENSITY_DIFF.\"\n",
          "datatype": "bool",
          "units": "none",
          "value": {

--- a/param_templates/json/MOM_input.json
+++ b/param_templates/json/MOM_input.json
@@ -3109,7 +3109,7 @@
          "description": "\"The path to the file containing the Cr fields.\"\n",
          "datatype": "string",
          "value": {
-            "$OCN_GRID == \"tx2_3v2\"": "mle-cr-tx2_3v2-v10_20250422.nc"
+            "$OCN_GRID == \"tx2_3v2\"": "mle-cr-tx2_3v2-v10_20250423.nc"
          }
       },
       "BODNER_DETECT_MLD": {

--- a/param_templates/json/MOM_input.json
+++ b/param_templates/json/MOM_input.json
@@ -1152,83 +1152,12 @@
             "else": true
          }
       },
-      "USE_BODNER23": {
-         "description": "\"[Boolean] default = False\nIf true, use the Bodner et al., 2023, formulation of the re-stratifying\nmixed-layer restratification parameterization. This only works in ALE mode.\"\n",
-         "datatype": "logical",
-         "units": "Boolean",
-         "value": {
-            "$OCN_GRID == \"tx2_3v2\"": true
-         }
-      },
-      "USE_CR_GRID": {
-         "description": "\"[Boolean] default = False\ntrue, read in a spatially varying Cr field.\"\n",
-         "datatype": "logical",
-         "units": "Boolean",
-         "value": {
-            "$OCN_GRID == \"tx2_3v2\"": true
-         }
-      },
-      "CR_FILE": {
-         "description": "\"The path to the file containing the Cr fields.\"\n",
-         "datatype": "string",
-         "value": {
-            "$OCN_GRID == \"tx2_3v2\"": "mle-cr-tx2_3v2-v10_20250422.nc"
-         }
-      },
-      "BODNER_DETECT_MLD": {
-         "description": "\"[Boolean] default = False\nIf true, the Bodner parameterization will use the mixed-layer depth detected\nvia the density difference criterion defined by MLE_DENSITY_DIFF.\n",
-         "datatype": "bool",
-         "units": "none",
-         "value": {
-            "$OCN_GRID == \"tx2_3v2\"": true
-         }
-      },
       "MLE_DENSITY_DIFF": {
          "description": "\"[kg/m3] default = 0.03\nDensity difference used to detect the mixed-layer depth for the\nmixed-layer eddy parameterization by Fox-Kemper et al. (2010).\"\n",
          "datatype": "real",
          "units": "kg/m3",
          "value": {
             "$OCN_GRID == \"tx2_3v2\"": 0.02
-         }
-      },
-      "MIN_WSTAR2": {
-         "description": "\"[m2 s-2] default = 1.0E-24\nThe minimum lower bound applied to the vertical momentum flux, w'u', in the\nBodner et al. restratification parameterization. This avoids a division-by-zero\nin the limit when u* and the buoyancy flux are zero. The default is smaller\nthan the product of the molecular viscosity of water and the Coriolis parameter\none micron from the equator.\"\n",
-         "datatype": "real",
-         "units": "m2 s-2",
-         "value": {
-            "$OCN_GRID == \"tx2_3v2\"": 1e-09
-         }
-      },
-      "BLD_DECAYING_TFILTER": {
-         "description": "\"default = 0.0\nThe time scale for a running-mean filter applied to the boundary layer depth (BLD)\nwhen the BLD is shallower than the running mean. A value of 0 instantaneously sets\nthe running mean to the current BLD value.\"\n",
-         "datatype": "real",
-         "units": "s",
-         "value": {
-            "$OCN_GRID == \"tx2_3v2\"": 86400.0
-         }
-      },
-      "BLD_GROWING_TFILTER": {
-         "description": "\"[s] default = 0.0\nThe time scale for a running-mean filter applied to the boundary layer depth (BLD)\nwhen the BLD is deeper than the running mean. A value of 0 instantaneously sets\nthe running mean to the current BLD value.\"\n",
-         "datatype": "real",
-         "units": "s",
-         "value": {
-            "$OCN_GRID == \"tx2_3v2\"": 300.0
-         }
-      },
-      "MLD_GROWING_TFILTER": {
-         "description": "\"[s] default = 0.0\nThe time scale for a running-mean filter applied to the time-filtered boundary layer depth (BLD),\nwhen the filtered BLD is deeper than the running mean. A value of 0 instantaneously sets\nthe running mean to the current filtered BLD value.\"\n",
-         "datatype": "real",
-         "units": "s",
-         "value": {
-            "$OCN_GRID == \"tx2_3v2\"": 3600.0
-         }
-      },
-      "MLD_DECAYING_TFILTER": {
-         "description": "\"[s] default = 0.0\nThe time scale for a running-mean filter applied to the time-filtered boundary layer depth (BLD),\nwhen the filtered BLD is shallower than the running mean. A value of 0 instantaneously sets\nthe running mean to the current filtered BLD value.\"\n",
-         "datatype": "real",
-         "units": "s",
-         "value": {
-            "$OCN_GRID == \"tx2_3v2\"": 2592000.0
          }
       },
       "FOX_KEMPER_ML_RESTRAT_COEF": {
@@ -3156,6 +3085,79 @@
          "datatype": "real",
          "value": {
             "$OCN_GRID == \"tx2_3v2\"": 5.0
+         }
+      }
+   },
+   "MLE": {
+      "USE_BODNER23": {
+         "description": "\"[Boolean] default = False\nIf true, use the Bodner et al., 2023, formulation of the re-stratifying\nmixed-layer restratification parameterization. This only works in ALE mode.\"\n",
+         "datatype": "logical",
+         "units": "Boolean",
+         "value": {
+            "$OCN_GRID == \"tx2_3v2\"": true
+         }
+      },
+      "USE_CR_GRID": {
+         "description": "\"[Boolean] default = False\ntrue, read in a spatially varying Cr field.\"\n",
+         "datatype": "logical",
+         "units": "Boolean",
+         "value": {
+            "$OCN_GRID == \"tx2_3v2\"": true
+         }
+      },
+      "CR_FILE": {
+         "description": "\"The path to the file containing the Cr fields.\"\n",
+         "datatype": "string",
+         "value": {
+            "$OCN_GRID == \"tx2_3v2\"": "mle-cr-tx2_3v2-v10_20250422.nc"
+         }
+      },
+      "BODNER_DETECT_MLD": {
+         "description": "\"[Boolean] default = False\nIf true, the Bodner parameterization will use the mixed-layer depth detected\nvia the density difference criterion defined by MLE_DENSITY_DIFF.\n",
+         "datatype": "bool",
+         "units": "none",
+         "value": {
+            "$OCN_GRID == \"tx2_3v2\"": true
+         }
+      },
+      "MIN_WSTAR2": {
+         "description": "\"[m2 s-2] default = 1.0E-24\nThe minimum lower bound applied to the vertical momentum flux, w'u', in the\nBodner et al. restratification parameterization. This avoids a division-by-zero\nin the limit when u* and the buoyancy flux are zero. The default is smaller\nthan the product of the molecular viscosity of water and the Coriolis parameter\none micron from the equator.\"\n",
+         "datatype": "real",
+         "units": "m2 s-2",
+         "value": {
+            "$OCN_GRID == \"tx2_3v2\"": 1e-09
+         }
+      },
+      "BLD_DECAYING_TFILTER": {
+         "description": "\"default = 0.0\nThe time scale for a running-mean filter applied to the boundary layer depth (BLD)\nwhen the BLD is shallower than the running mean. A value of 0 instantaneously sets\nthe running mean to the current BLD value.\"\n",
+         "datatype": "real",
+         "units": "s",
+         "value": {
+            "$OCN_GRID == \"tx2_3v2\"": 86400.0
+         }
+      },
+      "BLD_GROWING_TFILTER": {
+         "description": "\"[s] default = 0.0\nThe time scale for a running-mean filter applied to the boundary layer depth (BLD)\nwhen the BLD is deeper than the running mean. A value of 0 instantaneously sets\nthe running mean to the current BLD value.\"\n",
+         "datatype": "real",
+         "units": "s",
+         "value": {
+            "$OCN_GRID == \"tx2_3v2\"": 300.0
+         }
+      },
+      "MLD_GROWING_TFILTER": {
+         "description": "\"[s] default = 0.0\nThe time scale for a running-mean filter applied to the time-filtered boundary layer depth (BLD),\nwhen the filtered BLD is deeper than the running mean. A value of 0 instantaneously sets\nthe running mean to the current filtered BLD value.\"\n",
+         "datatype": "real",
+         "units": "s",
+         "value": {
+            "$OCN_GRID == \"tx2_3v2\"": 3600.0
+         }
+      },
+      "MLD_DECAYING_TFILTER": {
+         "description": "\"[s] default = 0.0\nThe time scale for a running-mean filter applied to the time-filtered boundary layer depth (BLD),\nwhen the filtered BLD is shallower than the running mean. A value of 0 instantaneously sets\nthe running mean to the current filtered BLD value.\"\n",
+         "datatype": "real",
+         "units": "s",
+         "value": {
+            "$OCN_GRID == \"tx2_3v2\"": 2592000.0
          }
       }
    }

--- a/param_templates/json/diag_table.json
+++ b/param_templates/json/diag_table.json
@@ -58,8 +58,8 @@
          "Rd_dx",
          "speed",
          "mlotst",
-         "mlotst:mlots_min:min",
-         "mlotst:mlots_max:max"
+         "mlotst:mlotst_min:min",
+         "mlotst:mlotst_max:max"
       ],
       [
          "zos",
@@ -367,8 +367,8 @@
                         "Rd_dx",
                         "speed",
                         "mlotst",
-                        "mlotst:mlots_min:min",
-                        "mlotst:mlots_max:max"
+                        "mlotst:mlotst_min:min",
+                        "mlotst:mlotst_max:max"
                      ],
                      [
                         "sst_global",
@@ -482,8 +482,8 @@
                      "Rd_dx",
                      "speed",
                      "mlotst",
-                     "mlotst:mlots_min:min",
-                     "mlotst:mlots_max:max"
+                     "mlotst:mlotst_min:min",
+                     "mlotst:mlotst_max:max"
                   ],
                   [
                      "zos",

--- a/param_templates/json/input_data_list.json
+++ b/param_templates/json/input_data_list.json
@@ -56,7 +56,7 @@
          "$OCN_GRID == \"tx2_3v2\"": "${INPUTDIR}/seawifs-clim-1997-2010-tx2_3v2.230416.nc"
       },
       "CR_FILE": {
-         "$OCN_GRID == \"tx2_3v2\"": "${INPUTDIR}/mle-cr-tx2_3v2-v10_20250423.nc"
+         "$OCN_GRID == \"tx2_3v2\"": "${INPUTDIR}/mle-cr-tx2_3v2-v10_20250426.nc"
       },
       "CFC_BC_FILE": "${DIN_LOC_ROOT}/ocn/mom/grid_indpt/cfc_atm_20230310.nc",
       "DIAG_COORD_DEF_RHO2": {

--- a/param_templates/json/input_data_list.json
+++ b/param_templates/json/input_data_list.json
@@ -55,8 +55,8 @@
          "$OCN_GRID == \"tx0.25v1\"": "${INPUTDIR}/seawifs-clim-1997-2010.1440x1080.v20180328.nc",
          "$OCN_GRID == \"tx2_3v2\"": "${INPUTDIR}/seawifs-clim-1997-2010-tx2_3v2.230416.nc"
       },
-      "MLE_FL_FILE": {
-         "$OCN_GRID == \"tx2_3v2\"": "${INPUTDIR}/mle-lf-clim-tx2_3v2_20250115.nc"
+      "CR_FILE": {
+         "$OCN_GRID == \"tx2_3v2\"": "${INPUTDIR}/mle-cr-tx2_3v2-v10_20250423.nc"
       },
       "CFC_BC_FILE": "${DIN_LOC_ROOT}/ocn/mom/grid_indpt/cfc_atm_20230310.nc",
       "DIAG_COORD_DEF_RHO2": {


### PR DESCRIPTION
* Include the parameters used in 2025.075 as default;
* Fixes typos in the min/max variables for mlotst.

Addresses #247 and #251.