### PR TITLE
add RESTARTFILE_APPENDIX_PREFIX to MOM_input

### DIFF
--- a/param_templates/MOM_input.yaml
+++ b/param_templates/MOM_input.yaml
@@ -3709,6 +3709,15 @@ Global:
             checksums will not match and cause crash.
         datatype: logical
         value: $TEST
+    RESTARTFILE_APPENDIX_PREFIX:
+        description: |
+            "default = ''
+            The prefix for the restart file appendix (i.e., ensemble id for ensemble
+            runs). If this prefix is found in the restart file name, the appendix is added
+            right after the first occurrence of the prefix. If not found, the appendix is
+            added to the end of the file name. This parameter is ignored for non-ensemble runs."
+        datatype: string
+        value: ".mom6"
 KPP:
     N_SMOOTH:
         description: |

--- a/param_templates/json/MOM_input.json
+++ b/param_templates/json/MOM_input.json
@@ -3003,6 +3003,11 @@
          "description": "\"[Boolean] default = True\nIf true, require the restart checksums to match and error out otherwise. Users\nmay want to avoid this comparison if for example the restarts are made from a\nrun with a different mask_table than the current run, in which case the\nchecksums will not match and cause crash.\n",
          "datatype": "logical",
          "value": "$TEST"
+      },
+      "RESTARTFILE_APPENDIX_PREFIX": {
+         "description": "\"default = ''\nThe prefix for the restart file appendix (i.e., ensemble id for ensemble\nruns). If this prefix is found in the restart file name, the appendix is added\nright after the first occurrence of the prefix. If not found, the appendix is\nadded to the end of the file name. This parameter is ignored for non-ensemble runs.\"\n",
+         "datatype": "string",
+         "value": ".mom6"
       }
    },
    "KPP": {


### PR DESCRIPTION
This PR partially addresses https://github.com/ESCOMP/MOM_interface/issues/238 when combined with https://github.com/NCAR/MOM6/pull/366

In this PR, the newly added `RESTARTFILE_APPENDIX_PREFIX` parameter is set by default to ".mom6", ensuring that ensemble instance suffix follows the component name (mom6) instead of being appended to the end of file, to be consistent with other CESM components.
