### PR TITLE
Set DO_GEOTHERMAL to False for unknown grids

### DIFF
--- a/param_templates/MOM_input.yaml
+++ b/param_templates/MOM_input.yaml
@@ -2769,6 +2769,7 @@ Global:
         value:
             $OCN_GRID == "tx2_3v2": True
             $OCN_GRID == "tx0.25v1": True
+            else: False
     PARALLEL_RESTARTFILES:
         description: |
             "[Boolean] default = False

--- a/param_templates/json/MOM_input.json
+++ b/param_templates/json/MOM_input.json
@@ -2198,7 +2198,8 @@
          "units": "Boolean",
          "value": {
             "$OCN_GRID == \"tx2_3v2\"": true,
-            "$OCN_GRID == \"tx0.25v1\"": true
+            "$OCN_GRID == \"tx0.25v1\"": true,
+            "else": false
          }
       },
       "PARALLEL_RESTARTFILES": {


### PR DESCRIPTION
This is needed because diag_table.yaml has a conditional that checks whether DO_GEOTHERMAL is True.