### PR TITLE
make sure this works for branch runs

### DIFF
--- a/param_templates/input_nml.yaml
+++ b/param_templates/input_nml.yaml
@@ -60,7 +60,8 @@ mpp_io_nml:
 nam_stochy:
     stochini:
         values:
-          $CONTINUE_RUN == True: .true.
+          $CONTINUE_RUN == True : .true.
+          $RUN_TYPE == "branch" : .true.
           else: .false.
     new_lscale:
         values: .true.

--- a/param_templates/json/input_nml.json
+++ b/param_templates/json/input_nml.json
@@ -73,6 +73,7 @@
       "stochini": {
          "values": {
             "$CONTINUE_RUN == True": ".true.",
+            "$RUN_TYPE == \"branch\"": ".true.",
             "else": ".false."
          }
       },


### PR DESCRIPTION
This adds support for reading the stochastic restart file on branch runs and passes test
ERI.ne30pg3_t232.B1850C_LTso.derecho_intel
We should wait to merge this until after new tags for stochastic_physics and
MOM6 are created so that those updated submodules can be represented here.
Also now that we have this working should it be the default?  If so that change should also be made so that 
DO_SKEB=.true.
SKEB_USE_GM=.true.
are set by default.