### PR TITLE
Fix name of fully-coupled compset

### DIFF
--- a/cime_config/testdefs/testlist_mom.xml
+++ b/cime_config/testdefs/testlist_mom.xml
@@ -91,7 +91,7 @@
       <option name="wallclock">01:00:00</option>
     </options>
   </test>
-  <test name="SMS_Ld2" grid="ne30pg3_t232" compset="BLT1850">
+  <test name="SMS_Ld2" grid="ne30pg3_t232" compset="B1850C_LTso">
     <machines>
       <machine name="derecho" compiler="intel" category="aux_mom"/>
       <machine name="derecho" compiler="intel" category="pr_mom"/>


### PR DESCRIPTION
Rename `BLT1850` to `B1850C_LTso`.

Passes the `pr_mom` tests.

Fixes https://github.com/ESCOMP/MOM_interface/issues/285