### PR TITLE
Update derecho PE layouts

### DIFF
--- a/cime_config/config_pes.xml
+++ b/cime_config/config_pes.xml
@@ -114,10 +114,10 @@
       <pes pesize="any" compset="_DATM.+_CICE.*_MOM6(?!.*%MARBL-BIO).+_SWAV">
         <comment>none</comment>
         <ntasks>
-          <ntasks_atm>128</ntasks_atm>
-          <ntasks_rof>128</ntasks_rof>
-          <ntasks_cpl>128</ntasks_cpl>
-          <ntasks_ice>128</ntasks_ice>
+          <ntasks_atm>256</ntasks_atm>
+          <ntasks_rof>256</ntasks_rof>
+          <ntasks_cpl>256</ntasks_cpl>
+          <ntasks_ice>256</ntasks_ice>
           <ntasks_ocn>896</ntasks_ocn>
           <ntasks_lnd>1</ntasks_lnd>
           <ntasks_wav>1</ntasks_wav>
@@ -138,7 +138,7 @@
           <rootpe_rof>0</rootpe_rof>
           <rootpe_cpl>0</rootpe_cpl>
           <rootpe_ice>0</rootpe_ice>
-          <rootpe_ocn>128</rootpe_ocn>
+          <rootpe_ocn>256</rootpe_ocn>
           <rootpe_lnd>0</rootpe_lnd>
           <rootpe_wav>0</rootpe_wav>
           <rootpe_glc>0</rootpe_glc>
@@ -150,7 +150,7 @@
           <ntasks_atm>128</ntasks_atm>
           <ntasks_rof>128</ntasks_rof>
           <ntasks_cpl>128</ntasks_cpl>
-          <ntasks_ice>128</ntasks_ice>
+          <ntasks_ice>256</ntasks_ice>
           <ntasks_ocn>2560</ntasks_ocn>
           <ntasks_lnd>1</ntasks_lnd>
           <ntasks_wav>1</ntasks_wav>
@@ -171,7 +171,7 @@
           <rootpe_rof>0</rootpe_rof>
           <rootpe_cpl>0</rootpe_cpl>
           <rootpe_ice>128</rootpe_ice>
-          <rootpe_ocn>256</rootpe_ocn>
+          <rootpe_ocn>384</rootpe_ocn>
           <rootpe_lnd>0</rootpe_lnd>
           <rootpe_wav>0</rootpe_wav>
           <rootpe_glc>0</rootpe_glc>
@@ -180,10 +180,10 @@
       <pes pesize="any" compset="_DATM.+_CICE.*_MOM6(?!.*%MARBL-BIO).+_WW3">
         <comment>none</comment>
         <ntasks>
-          <ntasks_atm>128</ntasks_atm>
-          <ntasks_rof>128</ntasks_rof>
-          <ntasks_cpl>128</ntasks_cpl>
-          <ntasks_ice>128</ntasks_ice>
+          <ntasks_atm>384</ntasks_atm>
+          <ntasks_rof>384</ntasks_rof>
+          <ntasks_cpl>384</ntasks_cpl>
+          <ntasks_ice>384</ntasks_ice>
           <ntasks_ocn>896</ntasks_ocn>
           <ntasks_lnd>1</ntasks_lnd>
           <ntasks_wav>128</ntasks_wav>
@@ -204,19 +204,19 @@
           <rootpe_rof>0</rootpe_rof>
           <rootpe_cpl>0</rootpe_cpl>
           <rootpe_ice>0</rootpe_ice>
-          <rootpe_ocn>256</rootpe_ocn>
+          <rootpe_ocn>512</rootpe_ocn>
           <rootpe_lnd>0</rootpe_lnd>
-          <rootpe_wav>128</rootpe_wav>
+          <rootpe_wav>384</rootpe_wav>
           <rootpe_glc>0</rootpe_glc>
         </rootpe>
       </pes>
       <pes pesize="any" compset="_DATM.+_CICE.*_MOM6%[^_]*MARBL-BIO.+_WW3">
         <comment>none</comment>
         <ntasks>
-          <ntasks_atm>128</ntasks_atm>
-          <ntasks_rof>128</ntasks_rof>
-          <ntasks_cpl>128</ntasks_cpl>
-          <ntasks_ice>128</ntasks_ice>
+          <ntasks_atm>384</ntasks_atm>
+          <ntasks_rof>384</ntasks_rof>
+          <ntasks_cpl>384</ntasks_cpl>
+          <ntasks_ice>384</ntasks_ice>
           <ntasks_ocn>2560</ntasks_ocn>
           <ntasks_lnd>1</ntasks_lnd>
           <ntasks_wav>128</ntasks_wav>
@@ -237,9 +237,9 @@
           <rootpe_rof>0</rootpe_rof>
           <rootpe_cpl>0</rootpe_cpl>
           <rootpe_ice>0</rootpe_ice>
-          <rootpe_ocn>256</rootpe_ocn>
+          <rootpe_ocn>512</rootpe_ocn>
           <rootpe_lnd>0</rootpe_lnd>
-          <rootpe_wav>128</rootpe_wav>
+          <rootpe_wav>384</rootpe_wav>
           <rootpe_glc>0</rootpe_glc>
         </rootpe>
       </pes>


### PR DESCRIPTION
Bump up CICE cores both with WW3 (for FSD) and with SWAV (because it is faster and cheaper).

In the timing table below, note the following:
* `GW_JRA` and `GW1850MARBL_JRA` compsets do not use FSD in the old timing but turn that feature of CICE on in the new timing. (This commit should go into the alpha tag where CICE turns FSD on by default for compsets using WW3.)
* `G_JRA` and `G1850MARBL_JRA` increase the number of nodes used by 1 (from 8 to 9 and 22 to 23, respectively); `GW_JRA` and `GW1850MARBL_JRA` increase the number of nodes used by 2 (from 8 to 10 and 22 to 24, respectively)
* All of these runs were 1 month long with the default `diag_table`, using the intel compiler on derecho. Case roots are in `/glade/work/mlevy/codes/CESM/cesm3_0_alpha07h/cases`.

| Compset | Old Throughput / Cost | New Throughput / Cost |
| --- | --- | --- |
| `G_JRA` | 15.12 SYPD / 1625.88 cpu-hrs/sim-yr | 17.63 SYPD / 1567.91 cpu-hrs/sim-yr |
| `GW_JRA` | 13.44 SYPD / 2056.49 cpu-hrs/sim-yr | 15.14 SYPD / 2231.49 cpu-hrs/sim-yr |
| `G1850MARBL_JRA` | 10.87 SYPD / 6217.27 cpu-hrs/sim-yr | 12.06 SYPD / 5856.84 cpu-hrs/sim-yr |
| `GW1850MARBL_JRA` | 10.18 SYPD / 6640.67 cpu-hrs/sim-yr | 12.08 SYPD / 6102.05 cpu-hrs/sim-yr |

I did not run any of the test suites, just the one-off timing tests. I did play with keeping CMEPS and CDEPS on a single node (pairing them with WW3 instead of CICE), but that did not improve performance at all. Also, I didn't touch the 1/4° pe layouts.