### PR TITLE
Fix unused/deprecated parameter warnings

### DIFF
--- a/param_templates/MOM_input.yaml
+++ b/param_templates/MOM_input.yaml
@@ -2359,14 +2359,14 @@ Global:
         datatype: real
         units: Pa
         value: 0.0004
-    FIX_USTAR_GUSTLESS_BUG:
+    USTAR_GUSTLESS_BUG:
         description: |
             "[Boolean] default = False
-            If true correct a bug in the time-averaging of the gustless wind
+            If true include a bug in the time-averaging of the gustless wind
             friction velocity."
         datatype: logical
         units: Boolean
-        value: True
+        value: False
     RESTART_CONTROL:
         description: |
             "default = 1
@@ -3881,7 +3881,7 @@ KPP:
                RW16     = Function of Langmuir number based on RW16
         datatype: string
         value:
-            $COMP_WAV == "ww3": VR12
+            $COMP_WAV == "ww3" and $MOM6_WW3_CPL_METHOD == "legacy" : VR12
     KPP_LT_VT2_METHOD:
         description: |
             default = "CONSTANT"
@@ -3892,7 +3892,7 @@ KPP:
                LF17     = Function of Langmuir number based on LF17
         datatype: string
         value:
-            $COMP_WAV == "ww3": VR12
+            $COMP_WAV == "ww3" and $MOM6_WW3_CPL_METHOD =="legacy" : VR12
     KPP_CVt2:
         description: |
             "[nondim] default = 1.6

--- a/param_templates/json/MOM_input.json
+++ b/param_templates/json/MOM_input.json
@@ -1864,11 +1864,11 @@
          "units": "Pa",
          "value": 0.0004
       },
-      "FIX_USTAR_GUSTLESS_BUG": {
-         "description": "\"[Boolean] default = False\nIf true correct a bug in the time-averaging of the gustless wind\nfriction velocity.\"\n",
+      "USTAR_GUSTLESS_BUG": {
+         "description": "\"[Boolean] default = False\nIf true include a bug in the time-averaging of the gustless wind\nfriction velocity.\"\n",
          "datatype": "logical",
          "units": "Boolean",
-         "value": true
+         "value": false
       },
       "RESTART_CONTROL": {
          "description": "\"default = 1\nAn integer whose bits encode which restart files are\nwritten. Add 2 (bit 1) for a time-stamped file, and odd\n(bit 0) for a non-time-stamped file. A non-time-stamped\nrestart file is saved at the end of the run segment\nfor any non-negative value.\"\n",
@@ -3166,14 +3166,14 @@
          "description": "default = \"CONSTANT\"\nMethod to enhance mixing coefficient in KPP. Valid options are:\n   CONSTANT = Constant value (KPP_K_ENH_FAC)\n   VR12     = Function of Langmuir number based on VR12\n   RW16     = Function of Langmuir number based on RW16\n",
          "datatype": "string",
          "value": {
-            "$COMP_WAV == \"ww3\"": "VR12"
+            "$COMP_WAV == \"ww3\" and $MOM6_WW3_CPL_METHOD == \"legacy\"": "VR12"
          }
       },
       "KPP_LT_VT2_METHOD": {
          "description": "default = \"CONSTANT\"\nMethod to enhance Vt2 in KPP. Valid options are:\n   CONSTANT = Constant value (KPP_VT2_ENH_FAC)\n   VR12     = Function of Langmuir number based on VR12\n   RW16     = Function of Langmuir number based on RW16\n   LF17     = Function of Langmuir number based on LF17\n",
          "datatype": "string",
          "value": {
-            "$COMP_WAV == \"ww3\"": "VR12"
+            "$COMP_WAV == \"ww3\" and $MOM6_WW3_CPL_METHOD ==\"legacy\"": "VR12"
          }
       },
       "KPP_CVt2": {


### PR DESCRIPTION
Fix unused/deprecated parameter warnings for:

 - KPP_LT_K_METHOD
 - KPP_LT_V_2_METHOD
 - USTAR_GUSTLESS_BUG