### PR TITLE
Update MOM_input parameters for tx2_3v2/tx2_3v3 grids

### DIFF
--- a/param_templates/MOM_input.yaml
+++ b/param_templates/MOM_input.yaml
@@ -1210,8 +1210,8 @@ Global:
             The filename containing a 2d map of Kh."
         datatype: string
         value:
-            $OCN_GRID == "tx2_3v2": "KH_BG_2D_tx2_3v2_260306.nc"
-            $OCN_GRID == "tx2_3v3": "KH_BG_2D_tx2_3v3_260306.nc"
+            $OCN_GRID == "tx2_3v2": "KH_BG_2D_tx2_3v2_260427.nc"
+            $OCN_GRID == "tx2_3v3": "KH_BG_2D_tx2_3v3_260427.nc"
     KH_BG_2D_VARNAME:
         description: |
             "default = 'Kh'

--- a/param_templates/MOM_input.yaml
+++ b/param_templates/MOM_input.yaml
@@ -3995,8 +3995,8 @@ MLE:
             "The path to the file containing the Cr fields."
         datatype: string
         value:
-            $OCN_GRID == "tx2_3v2": "mle-cr-mask_20250627.nc"
-            $OCN_GRID == "tx2_3v3": "mle_cr_labsea_mask_tx2_3v3_260306.nc"
+            $OCN_GRID == "tx2_3v2" and $COMP_ATM == "cam": "mle-cr-mask_20250627.nc"
+            $OCN_GRID == "tx2_3v3" and $COMP_ATM == "cam": "mle_cr_labsea_mask_tx2_3v3_260306.nc"
     WAVE_ENHANCED_USTAR:
         description: |
             "default = False

--- a/param_templates/MOM_input.yaml
+++ b/param_templates/MOM_input.yaml
@@ -1211,6 +1211,13 @@ Global:
         datatype: string
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: "KH_BG_2D_tx2_3v3_260306.nc"
+    KH_BG_2D_VARNAME:
+        description: |
+            "default = 'Kh'
+            The name in the input file of the horizontal viscosity variable."
+        datatype: string
+        value:
+            $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: "KH"
     FRICTWORK_BUG:
         description: |
             "[Boolean] default = True
@@ -1641,15 +1648,6 @@ Global:
         units: none
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: True
-    MLE_DENSITY_DIFF:
-        description: |
-            "[kg/m3] default = 0.03
-            Density difference used to detect the mixed-layer depth for the
-            mixed-layer eddy parameterization by Fox-Kemper et al. (2010)."
-        datatype: real
-        units: kg/m3
-        value:
-            $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: 0.02
     MLE_FRONT_LENGTH:
         description: |
             "[m] default = 0.0

--- a/param_templates/MOM_input.yaml
+++ b/param_templates/MOM_input.yaml
@@ -1210,7 +1210,8 @@ Global:
             The filename containing a 2d map of Kh."
         datatype: string
         value:
-            $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: "KH_BG_2D_tx2_3v3_260306.nc"
+            $OCN_GRID == "tx2_3v2": "KH_BG_2D_tx2_3v2_260306.nc"
+            $OCN_GRID == "tx2_3v3": "KH_BG_2D_tx2_3v3_260306.nc"
     KH_BG_2D_VARNAME:
         description: |
             "default = 'Kh'

--- a/param_templates/MOM_input.yaml
+++ b/param_templates/MOM_input.yaml
@@ -740,7 +740,7 @@ Global:
         datatype: logical
         units: Boolean
         value:
-            $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: True
+            $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: False
             $OCN_GRID == "tx0.25v1": True
     KHTH_SLOPE_CFF:
         description: |
@@ -1055,7 +1055,7 @@ Global:
         datatype: logical
         units: Boolean
         value:
-            $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: True
+            $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: False
     SMAG_LAP_CONST:
         description: |
             "[nondim] default = 0.0
@@ -1151,7 +1151,7 @@ Global:
         datatype: real
         units: nondim
         value:
-            $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: 75.0
+            $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: 85.0
     LEITHY_CK:
         description: |
             "[nondim] default = 1.0
@@ -1159,7 +1159,31 @@ Global:
         datatype: real
         units: nondim
         value:
-            $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: 0.0
+            $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: 1.0
+    TAPER_LEITHY:
+        description: |
+            "[Boolean] default = False
+            If true, Leith+E c_K coefficient is tapered to zero below a threshold depth."
+        datatype: logical
+        units: Boolean
+        value:
+            $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: True
+    LEITHY_DEPTH:
+        description: |
+            "[m] default = 800.0
+            Leith+E backscatter starts tapering below this depth."
+        datatype: real
+        units: m
+        value:
+            $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: 1000.0
+    LEITHY_WIDTH:
+        description: |
+            "[m] default = 400.0
+            Leith+E backscatter is zero below LEITHY_DEPTH+LEITHY_WIDTH."
+        datatype: real
+        units: m
+        value:
+            $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: 500.0
     USE_LAND_MASK_FOR_HVISC:
         description: |
             "[Boolean] default = False
@@ -1171,6 +1195,22 @@ Global:
         datatype: logical
         units: Boolean
         value: True
+    USE_KH_BG_2D:
+        description: |
+            "[Boolean] default = False
+            If true, read a file containing 2-d background harmonic viscosities. The
+            final viscosity is the maximum of the other terms and this background value."
+        datatype: logical
+        units: Boolean
+        value:
+            $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: True
+    KH_BG_2D_FILENAME:
+        description: |
+            "default = 'KH_background_2d.nc'
+            The filename containing a 2d map of Kh."
+        datatype: string
+        value:
+            $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: "KH_BG_2D_tx2_3v3_260306.nc"
     FRICTWORK_BUG:
         description: |
             "[Boolean] default = True
@@ -1202,6 +1242,16 @@ Global:
         value:
             $OCN_GRID == "MISOMIP": False
             else: True
+    CHANNEL_DRAG_MAX_BBL_THICK:
+        description: |
+            "[m] default = -1.0
+            The maximum bottom boundary layer thickness over which the channel drag is
+            exerted, or a negative value for no fixed limit, instead basing the BBL
+            thickness on the bottom stress, rotation and stratification."
+        datatype: real
+        units: m
+        value:
+            $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: 5.0
     HBBL:
         description: |
             "[m]
@@ -1319,7 +1369,9 @@ Global:
             function independently at each point."
         datatype: logical
         units: Boolean
-        value: False
+        value:
+            $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: True
+            else: False
     GILL_EQUATORIAL_LD:
         description: |
             "[Boolean] default = False
@@ -1366,6 +1418,15 @@ Global:
         value:
             $OCN_GRID == "MISOMIP": 2.0
             else: 0.1
+    CORRECT_BBL_BOUNDS:
+        description: |
+            "[Boolean] default = False
+            If true, uses the correct bounds on the BBL thickness and viscosity so that
+            the bottom layer feels the intended drag."
+        datatype: logical
+        units: Boolean
+        value:
+            $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: True
     BOUND_BT_CORRECTION:
         description: |
             "[Boolean] default = False
@@ -2245,6 +2306,7 @@ Global:
         units: truncations save_interval-1
         value:
             $OCN_GRID == "tx0.25v1": 100000
+            $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: 1000000
             else: 0
     OCEAN_SURFACE_STAGGER:
         description: |
@@ -2508,7 +2570,7 @@ Global:
         datatype: real
         units: nondim
         value:
-            $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: 0.9
+            $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: 0.5
     KH_RES_FN_POWER:
         description: |
             "[nondim] default = 2
@@ -2528,7 +2590,7 @@ Global:
         datatype: real
         units: nondim
         value:
-            $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: 0.4
+            $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: 0.5
     MEKE_GEOMETRIC:
         description: |
             "[Boolean] default = False
@@ -2546,7 +2608,7 @@ Global:
         datatype: real
         units: nondim
         value:
-            $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: 0.06
+            $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: 0.07
     MEKE_KHTH_FAC:
         description: |
             "[nondim] default = 0.0
@@ -3356,6 +3418,7 @@ Global:
         units: nondim
         value:
             $OCN_GRID == "MISOMIP": 0.0
+            $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: 0.01
     IGNORE_FLUXES_OVER_LAND:
         description: |
             "[Boolean] default = False
@@ -3927,7 +3990,8 @@ MLE:
         datatype: logical
         units: Boolean
         value:
-            $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: True
+            $OCN_GRID in ["tx2_3v2", "tx2_3v3"] and $COMP_ATM == "cam": True
+            else: False
     CR_FILE:
         description: |
             "The path to the file containing the Cr fields."

--- a/param_templates/input_data_list.yaml
+++ b/param_templates/input_data_list.yaml
@@ -31,8 +31,8 @@ mom.input_data_list:
             $INIT_LAYERS_FROM_Z_FILE == "True":
                 "${INPUTDIR}/${TEMP_SALT_Z_INIT_FILE}"
     KH_BG_2D:
-        $OCN_GRID == "tx2_3v3": "${INPUTDIR}/KH_BG_2D_tx2_3v3_260306.nc"
-        $OCN_GRID == "tx2_3v2": "${INPUTDIR}/KH_BG_2D_tx2_3v2_260306.nc"
+        $OCN_GRID == "tx2_3v3": "${INPUTDIR}/KH_BG_2D_tx2_3v3_260427.nc"
+        $OCN_GRID == "tx2_3v2": "${INPUTDIR}/KH_BG_2D_tx2_3v2_260427.nc"
     SURFACE_PRESSURE_FILE:
         $OCN_GRID == "MISOMIP": "${INPUTDIR}/MISOMIP_181108.nc"
     SALT_RESTORE_FILE:

--- a/param_templates/input_data_list.yaml
+++ b/param_templates/input_data_list.yaml
@@ -30,6 +30,9 @@ mom.input_data_list:
         $OCN_GRID in ["tx2_3v2", "tx2_3v3", "tx0.25v1"]:
             $INIT_LAYERS_FROM_Z_FILE == "True":
                 "${INPUTDIR}/${TEMP_SALT_Z_INIT_FILE}"
+    KH_BG_2D:
+        $OCN_GRID == "tx2_3v3": "${INPUTDIR}/KH_BG_2D_tx2_3v3_260306.nc"
+        $OCN_GRID == "tx2_3v2": "${INPUTDIR}/KH_BG_2D_tx2_3v2_260306.nc"
     SURFACE_PRESSURE_FILE:
         $OCN_GRID == "MISOMIP": "${INPUTDIR}/MISOMIP_181108.nc"
     SALT_RESTORE_FILE:

--- a/param_templates/json/MOM_input.json
+++ b/param_templates/json/MOM_input.json
@@ -939,7 +939,8 @@
          "description": "\"default = 'KH_background_2d.nc'\nThe filename containing a 2d map of Kh.\"\n",
          "datatype": "string",
          "value": {
-            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": "KH_BG_2D_tx2_3v3_260306.nc"
+            "$OCN_GRID == \"tx2_3v2\"": "KH_BG_2D_tx2_3v2_260306.nc",
+            "$OCN_GRID == \"tx2_3v3\"": "KH_BG_2D_tx2_3v3_260306.nc"
          }
       },
       "KH_BG_2D_VARNAME": {

--- a/param_templates/json/MOM_input.json
+++ b/param_templates/json/MOM_input.json
@@ -570,7 +570,7 @@
          "datatype": "logical",
          "units": "Boolean",
          "value": {
-            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": true,
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": false,
             "$OCN_GRID == \"tx0.25v1\"": true
          }
       },
@@ -801,7 +801,7 @@
          "datatype": "logical",
          "units": "Boolean",
          "value": {
-            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": true
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": false
          }
       },
       "SMAG_LAP_CONST": {
@@ -886,7 +886,7 @@
          "datatype": "real",
          "units": "nondim",
          "value": {
-            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 75.0
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 85.0
          }
       },
       "LEITHY_CK": {
@@ -894,7 +894,31 @@
          "datatype": "real",
          "units": "nondim",
          "value": {
-            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 0.0
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 1.0
+         }
+      },
+      "TAPER_LEITHY": {
+         "description": "\"[Boolean] default = False\nIf true, Leith+E c_K coefficient is tapered to zero below a threshold depth.\"\n",
+         "datatype": "logical",
+         "units": "Boolean",
+         "value": {
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": true
+         }
+      },
+      "LEITHY_DEPTH": {
+         "description": "\"[m] default = 800.0\nLeith+E backscatter starts tapering below this depth.\"\n",
+         "datatype": "real",
+         "units": "m",
+         "value": {
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 1000.0
+         }
+      },
+      "LEITHY_WIDTH": {
+         "description": "\"[m] default = 400.0\nLeith+E backscatter is zero below LEITHY_DEPTH+LEITHY_WIDTH.\"\n",
+         "datatype": "real",
+         "units": "m",
+         "value": {
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 500.0
          }
       },
       "USE_LAND_MASK_FOR_HVISC": {
@@ -902,6 +926,21 @@
          "datatype": "logical",
          "units": "Boolean",
          "value": true
+      },
+      "USE_KH_BG_2D": {
+         "description": "\"[Boolean] default = False\nIf true, read a file containing 2-d background harmonic viscosities. The\nfinal viscosity is the maximum of the other terms and this background value.\"\n",
+         "datatype": "logical",
+         "units": "Boolean",
+         "value": {
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": true
+         }
+      },
+      "KH_BG_2D_FILENAME": {
+         "description": "\"default = 'KH_background_2d.nc'\nThe filename containing a 2d map of Kh.\"\n",
+         "datatype": "string",
+         "value": {
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": "KH_BG_2D_tx2_3v3_260306.nc"
+         }
       },
       "FRICTWORK_BUG": {
          "description": "\"[Boolean] default = True\nIf true, retain an answer-changing bug in calculating the FrictWork, which\ncancels the h in thickness flux and the h at velocity point. This is not\nrecommended.\"\n",
@@ -925,6 +964,14 @@
          "value": {
             "$OCN_GRID == \"MISOMIP\"": false,
             "else": true
+         }
+      },
+      "CHANNEL_DRAG_MAX_BBL_THICK": {
+         "description": "\"[m] default = -1.0\nThe maximum bottom boundary layer thickness over which the channel drag is\nexerted, or a negative value for no fixed limit, instead basing the BBL\nthickness on the bottom stress, rotation and stratification.\"\n",
+         "datatype": "real",
+         "units": "m",
+         "value": {
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 5.0
          }
       },
       "HBBL": {
@@ -1012,7 +1059,10 @@
          "description": "\"[Boolean] default = True\nIf true, interpolate the resolution function to the\nvelocity points from the thickness points; otherwise\ninterpolate the wave speed and calculate the resolution\nfunction independently at each point.\"\n",
          "datatype": "logical",
          "units": "Boolean",
-         "value": false
+         "value": {
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": true,
+            "else": false
+         }
       },
       "GILL_EQUATORIAL_LD": {
          "description": "\"[Boolean] default = False\nIf true, uses Gill's definition of the baroclinic\nequatorial deformation radius, otherwise, if false, use\nPedlosky's definition. These definitions differ by a factor\nof 2 infront of the beta term in the denominator. Gill'sis the more appropriate definition.\"\n",
@@ -1045,6 +1095,14 @@
          "value": {
             "$OCN_GRID == \"MISOMIP\"": 2.0,
             "else": 0.1
+         }
+      },
+      "CORRECT_BBL_BOUNDS": {
+         "description": "\"[Boolean] default = False\nIf true, uses the correct bounds on the BBL thickness and viscosity so that\nthe bottom layer feels the intended drag.\"\n",
+         "datatype": "logical",
+         "units": "Boolean",
+         "value": {
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": true
          }
       },
       "BOUND_BT_CORRECTION": {
@@ -1774,6 +1832,7 @@
          "units": "truncations save_interval-1",
          "value": {
             "$OCN_GRID == \"tx0.25v1\"": 100000,
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 1000000,
             "else": 0
          }
       },
@@ -1999,7 +2058,7 @@
          "datatype": "real",
          "units": "nondim",
          "value": {
-            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 0.9
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 0.5
          }
       },
       "KH_RES_FN_POWER": {
@@ -2015,7 +2074,7 @@
          "datatype": "real",
          "units": "nondim",
          "value": {
-            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 0.4
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 0.5
          }
       },
       "MEKE_GEOMETRIC": {
@@ -2031,7 +2090,7 @@
          "datatype": "real",
          "units": "nondim",
          "value": {
-            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 0.06
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 0.07
          }
       },
       "MEKE_KHTH_FAC": {
@@ -2697,7 +2756,8 @@
          "datatype": "real",
          "units": "nondim",
          "value": {
-            "$OCN_GRID == \"MISOMIP\"": 0.0
+            "$OCN_GRID == \"MISOMIP\"": 0.0,
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 0.01
          }
       },
       "IGNORE_FLUXES_OVER_LAND": {
@@ -3218,7 +3278,8 @@
          "datatype": "logical",
          "units": "Boolean",
          "value": {
-            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": true
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"] and $COMP_ATM == \"cam\"": true,
+            "else": false
          }
       },
       "CR_FILE": {

--- a/param_templates/json/MOM_input.json
+++ b/param_templates/json/MOM_input.json
@@ -942,6 +942,13 @@
             "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": "KH_BG_2D_tx2_3v3_260306.nc"
          }
       },
+      "KH_BG_2D_VARNAME": {
+         "description": "\"default = 'Kh'\nThe name in the input file of the horizontal viscosity variable.\"\n",
+         "datatype": "string",
+         "value": {
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": "KH"
+         }
+      },
       "FRICTWORK_BUG": {
          "description": "\"[Boolean] default = True\nIf true, retain an answer-changing bug in calculating the FrictWork, which\ncancels the h in thickness flux and the h at velocity point. This is not\nrecommended.\"\n",
          "datatype": "logical",
@@ -1263,14 +1270,6 @@
          "units": "none",
          "value": {
             "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": true
-         }
-      },
-      "MLE_DENSITY_DIFF": {
-         "description": "\"[kg/m3] default = 0.03\nDensity difference used to detect the mixed-layer depth for the\nmixed-layer eddy parameterization by Fox-Kemper et al. (2010).\"\n",
-         "datatype": "real",
-         "units": "kg/m3",
-         "value": {
-            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 0.02
          }
       },
       "MLE_FRONT_LENGTH": {

--- a/param_templates/json/MOM_input.json
+++ b/param_templates/json/MOM_input.json
@@ -939,8 +939,8 @@
          "description": "\"default = 'KH_background_2d.nc'\nThe filename containing a 2d map of Kh.\"\n",
          "datatype": "string",
          "value": {
-            "$OCN_GRID == \"tx2_3v2\"": "KH_BG_2D_tx2_3v2_260306.nc",
-            "$OCN_GRID == \"tx2_3v3\"": "KH_BG_2D_tx2_3v3_260306.nc"
+            "$OCN_GRID == \"tx2_3v2\"": "KH_BG_2D_tx2_3v2_260427.nc",
+            "$OCN_GRID == \"tx2_3v3\"": "KH_BG_2D_tx2_3v3_260427.nc"
          }
       },
       "KH_BG_2D_VARNAME": {

--- a/param_templates/json/MOM_input.json
+++ b/param_templates/json/MOM_input.json
@@ -3285,8 +3285,8 @@
          "description": "\"The path to the file containing the Cr fields.\"\n",
          "datatype": "string",
          "value": {
-            "$OCN_GRID == \"tx2_3v2\"": "mle-cr-mask_20250627.nc",
-            "$OCN_GRID == \"tx2_3v3\"": "mle_cr_labsea_mask_tx2_3v3_260306.nc"
+            "$OCN_GRID == \"tx2_3v2\" and $COMP_ATM == \"cam\"": "mle-cr-mask_20250627.nc",
+            "$OCN_GRID == \"tx2_3v3\" and $COMP_ATM == \"cam\"": "mle_cr_labsea_mask_tx2_3v3_260306.nc"
          }
       },
       "WAVE_ENHANCED_USTAR": {

--- a/param_templates/json/input_data_list.json
+++ b/param_templates/json/input_data_list.json
@@ -38,6 +38,10 @@
             "$INIT_LAYERS_FROM_Z_FILE == \"True\"": "${INPUTDIR}/${TEMP_SALT_Z_INIT_FILE}"
          }
       },
+      "KH_BG_2D": {
+         "$OCN_GRID == \"tx2_3v3\"": "${INPUTDIR}/KH_BG_2D_tx2_3v3_260306.nc",
+         "$OCN_GRID == \"tx2_3v2\"": "${INPUTDIR}/KH_BG_2D_tx2_3v2_260306.nc"
+      },
       "SURFACE_PRESSURE_FILE": {
          "$OCN_GRID == \"MISOMIP\"": "${INPUTDIR}/MISOMIP_181108.nc"
       },

--- a/param_templates/json/input_data_list.json
+++ b/param_templates/json/input_data_list.json
@@ -39,8 +39,8 @@
          }
       },
       "KH_BG_2D": {
-         "$OCN_GRID == \"tx2_3v3\"": "${INPUTDIR}/KH_BG_2D_tx2_3v3_260306.nc",
-         "$OCN_GRID == \"tx2_3v2\"": "${INPUTDIR}/KH_BG_2D_tx2_3v2_260306.nc"
+         "$OCN_GRID == \"tx2_3v3\"": "${INPUTDIR}/KH_BG_2D_tx2_3v3_260427.nc",
+         "$OCN_GRID == \"tx2_3v2\"": "${INPUTDIR}/KH_BG_2D_tx2_3v2_260427.nc"
       },
       "SURFACE_PRESSURE_FILE": {
          "$OCN_GRID == \"MISOMIP\"": "${INPUTDIR}/MISOMIP_181108.nc"


### PR DESCRIPTION
Updates parameter values in MOM_input.yaml and MOM_input.json for the tx2_3v2 and tx2_3v3 grids. Changes include:

  New parameters:
  - TAPER_LEITHY, LEITHY_DEPTH, LEITHY_WIDTH — enables depth-tapered Leith+E backscatter
  - USE_KH_BG_2D, KH_BG_2D_FILENAME, KH_BG_2D_VARNAME — enables 2D background harmonic viscosity from file
  - CHANNEL_DRAG_MAX_BBL_THICK — limits BBL thickness for channel drag (5 m)
  - CORRECT_BBL_BOUNDS — enables correct BBL thickness/viscosity bounds

  Tuning changes:
  - LEITHY_SMAG_LAP_CONST: 75.0 → 85.0; LEITHY_CK: 0.0 → 1.0
  - BBL_EFFIC: 0.2→ 0.01
  - KH_RES_FN_FACTOR: 0.9 → 0.5; KH_RES_FN_POWER_FACTOR: 0.4 → 0.5
  - MEKE_GMCOEFF: 0.06 → 0.07
  - MEKE_KHTH_FAC: adds 0.01 value for tx2_3 grids
  - INTERPOLATE_RES_FN: enabled for tx2_3 grids
  - TRUNCATION_N_SAVE: set to 1,000,000 for tx2_3 grids
  - USE_OLD_FC_GAMMA_IC and USE_OLD_KHTH_BUG: disabled (True → False) for tx2_3 grids

  Removed: MLE_DENSITY_DIFF (reverts to default)

 USE_CR and CR_FILE are now only set when ATM = cam

Addresses https://github.com/ESCOMP/MOM_interface/issues/307