### PR TITLE
Use tx2_3v2 PE layouts for tx2_3v3

### DIFF
--- a/cime_config/config_pes.xml
+++ b/cime_config/config_pes.xml
@@ -41,7 +41,7 @@
     </mach>
   </grid>
 
-  <grid name="a%(TL319|T62).+oi%tx2_3v2">
+  <grid name="a%(TL319|T62).+oi%tx2_3v[23]">
     <mach name="any">
       <pes pesize="any" compset="any">
         <comment>none</comment>


### PR DESCRIPTION
Update `config_pes.xml` so the new `tx2_3v3` grid is recognized on derecho.