### PR TITLE
Add .$DATENAME to ocean rpointer file pattern in config_archive.xml

### DIFF
--- a/cime_config/config_archive.xml
+++ b/cime_config/config_archive.xml
@@ -17,7 +17,7 @@
     <hist_file_extension>e</hist_file_extension>
     <hist_file_ext_regex>\w+\.\w+(\._\d*)?</hist_file_ext_regex>
     <rpointer>
-      <rpointer_file>rpointer.ocn$NINST_STRING</rpointer_file>
+      <rpointer_file>rpointer.ocn$NINST_STRING.$DATENAME</rpointer_file>
       <rpointer_content>$CASE.mom6$NINST_STRING.r.$DATENAME.nc</rpointer_content>
     </rpointer>
       <test_file_names>


### PR DESCRIPTION
mom_cap.F90 writes dated rpointer files (rpointer.ocn.YYYY-MM-DD-SSSSS) by default, consistent with other components (CICE, CPL). The <rpointer_file> pattern was missing .$DATENAME, causing the archiver to fail matching the file and move it out of RUNDIR instead of copying it. This left RUNDIR without a rpointer file on the next segment, resulting in a buildnml error. Adding .$DATENAME fixes the match and ensures the file is copied, not moved. This was only a problem when `./xmlchange DOUT_S_SAVE_INTERIM_RESTART_FILES=True`.

Solves #332.