### PR TITLE
Add the new 2-degree grid: tx2_0v1

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,7 +2,7 @@
   path = MOM6
   url = https://github.com/NCAR/MOM6.git
   fxDONOTUSEurl = https://github.com/NCAR/MOM6.git
-    fxtag = dev/ncar_260504
+    fxtag = dev/ncar_260624
     fxrequired = AlwaysRequired
 
 [submodule "stochastic_physics"]

--- a/cime_config/config_component.xml
+++ b/cime_config/config_component.xml
@@ -75,6 +75,7 @@
     <values>
       <value grid="oi%tx2_3v2">hycom1</value>
       <value grid="oi%tx2_3v3">hycom1</value>
+      <value grid="oi%tx2_0v1">hycom1</value>
       <value grid="oi%tx0.25v1">hycom1</value>
       <value grid="oi%MISOMIP">sigma_shelf_zstar</value>
     </values>

--- a/cime_config/config_pes.xml
+++ b/cime_config/config_pes.xml
@@ -413,6 +413,44 @@
     </mach>
   </grid>
 
+  <grid name="a%(TL319|T62).+oi%tx2_0v1">
+    <mach name="derecho">
+      <pes pesize="any" compset="any">
+        <comment>tx2_0v1 (2-deg): ocn and ice on 128 PEs; ocean concurrent</comment>
+        <ntasks>
+          <ntasks_atm>128</ntasks_atm>
+          <ntasks_rof>128</ntasks_rof>
+          <ntasks_cpl>128</ntasks_cpl>
+          <ntasks_ice>128</ntasks_ice>
+          <ntasks_ocn>128</ntasks_ocn>
+          <ntasks_lnd>1</ntasks_lnd>
+          <ntasks_wav>128</ntasks_wav>
+          <ntasks_glc>1</ntasks_glc>
+        </ntasks>
+        <nthrds>
+          <nthrds_atm>1</nthrds_atm>
+          <nthrds_lnd>1</nthrds_lnd>
+          <nthrds_rof>1</nthrds_rof>
+          <nthrds_ice>1</nthrds_ice>
+          <nthrds_ocn>1</nthrds_ocn>
+          <nthrds_glc>1</nthrds_glc>
+          <nthrds_wav>1</nthrds_wav>
+          <nthrds_cpl>1</nthrds_cpl>
+        </nthrds>
+        <rootpe>
+          <rootpe_atm>0</rootpe_atm>
+          <rootpe_rof>0</rootpe_rof>
+          <rootpe_cpl>0</rootpe_cpl>
+          <rootpe_ice>0</rootpe_ice>
+          <rootpe_ocn>128</rootpe_ocn>
+          <rootpe_lnd>0</rootpe_lnd>
+          <rootpe_wav>0</rootpe_wav>
+          <rootpe_glc>0</rootpe_glc>
+        </rootpe>
+      </pes>
+    </mach>
+  </grid>
+
   <grid name="a%(TL319|T62).+oi%tx0.25v1">
     <mach name="derecho">
       <pes pesize="any" compset="any">

--- a/cime_config/testdefs/testlist_mom.xml
+++ b/cime_config/testdefs/testlist_mom.xml
@@ -214,6 +214,17 @@
       <option name="wallclock">01:00:00</option>
     </options>
   </test>
+  <test name="ERS_Ld5" grid="TL319_t201" compset="GW_JRA">
+    <machines>
+      <machine name="derecho" compiler="intel" category="aux_mom"/>
+      <machine name="derecho" compiler="intel" category="pr_mom"/>
+      <machine name="derecho" compiler="intel" category="prealpha"/>
+      <machine name="derecho" compiler="intel" category="prebeta"/>
+    </machines>
+    <options>
+      <option name="wallclock">01:30:00</option>
+    </options>
+  </test>
   <!-- fast_mom: a test suite with coarse grids for fast feedback. -->
   <test name="SMS_D" grid="TL319_t232" compset="G_JRA_RYF" testmods="mom/tx3deg">
     <machines>

--- a/param_templates/MOM_input.yaml
+++ b/param_templates/MOM_input.yaml
@@ -44,6 +44,7 @@ Global:
         units: Boolean
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: True
+            $OCN_GRID == "tx2_0v1": True
             $OCN_GRID == "tx0.25v1": True
             else: False
     NIHALO:
@@ -72,6 +73,7 @@ Global:
         datatype: integer
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: 540
+            $OCN_GRID == "tx2_0v1": 180
             $OCN_GRID == "tx0.25v1": 1440
             $OCN_GRID == "MISOMIP": 402
     NJGLOBAL:
@@ -87,6 +89,7 @@ Global:
         datatype: integer
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: 480
+            $OCN_GRID == "tx2_0v1": 128
             $OCN_GRID == "tx0.25v1": 1080
             $OCN_GRID == "MISOMIP": 40
     NK:
@@ -108,6 +111,7 @@ Global:
         units: Boolean
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: False
+            $OCN_GRID == "tx2_0v1": False
     HREF_FOR_MLD:
         description: |
             "[m] default = 0.0
@@ -117,6 +121,7 @@ Global:
         units: m
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: 10.0
+            $OCN_GRID == "tx2_0v1": 10.0
     USE_REGRIDDING:
         description: |
             "[Boolean] default = False
@@ -134,6 +139,7 @@ Global:
         units: Boolean
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: True
+            $OCN_GRID == "tx2_0v1": True
             $OCN_GRID == "tx0.25v1": True
     THICKNESSDIFFUSE_FIRST:
         description: |
@@ -144,6 +150,7 @@ Global:
         units: Boolean
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: True
+            $OCN_GRID == "tx2_0v1": True
             $OCN_GRID == "tx0.25v1": True
     DT:
         description: |
@@ -157,6 +164,7 @@ Global:
         value:
             $OCN_GRID == "tx0.25v1": 900.0
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: 1800
+            $OCN_GRID == "tx2_0v1": 3600
             $OCN_GRID == "MISOMIP": 600.0
     DT_THERM:
         description: |
@@ -189,6 +197,7 @@ Global:
         units: m
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: 10.0
+            $OCN_GRID == "tx2_0v1": 10.0
             $OCN_GRID == "tx0.25v1": 20.0
     DTBT_RESET_PERIOD:
         description: |
@@ -202,6 +211,7 @@ Global:
         units: s
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: 7200.0
+            $OCN_GRID == "tx2_0v1": 7200.0
             $OCN_GRID == "tx0.25v1": 3600.0
             else: 0.0
     FRAZIL:
@@ -245,6 +255,7 @@ Global:
         units: J kg-1 K-1
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: 3992.0
+            $OCN_GRID == "tx2_0v1": 3992.0
             $OCN_GRID == "tx0.25v1": 3992.0
             $OCN_GRID == "MISOMIP": 3974.0
     USE_PSURF_IN_EOS:
@@ -263,6 +274,7 @@ Global:
         units: Boolean
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: True
+            $OCN_GRID == "tx2_0v1": True
             $OCN_GRID == "tx0.25v1": True
     SAVE_INITIAL_CONDS:
         description: |
@@ -282,6 +294,7 @@ Global:
         units: Boolean
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: False
+            $OCN_GRID == "tx2_0v1": False
             $OCN_GRID == "tx0.25v1": False
     EQN_OF_STATE:
         description: |
@@ -301,6 +314,7 @@ Global:
         units: deg C Pa-1
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: -7.75E-08
+            $OCN_GRID == "tx2_0v1": -7.75E-08
             $OCN_GRID == "tx0.25v1": -7.75E-08
             $OCN_GRID == "MISOMIP": -7.53E-08
     USE_IDEAL_AGE_TRACER:
@@ -311,6 +325,7 @@ Global:
         units: Boolean
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: True
+            $OCN_GRID == "tx2_0v1": True
             $OCN_GRID == "tx0.25v1": True
     USE_CFC_CAP:
         description: |
@@ -536,6 +551,7 @@ Global:
         value:
             $OCN_GRID == "tx2_3v2": "ocean_hgrid_221123.nc"
             $OCN_GRID == "tx2_3v3": "ocean_hgrid_250930.nc"
+            $OCN_GRID == "tx2_0v1": "ocean_hgrid_260529.nc"
             $OCN_GRID == "tx0.25v1": "ocean_hgrid.nc"
     USE_TRIPOLAR_GEOLONB_BUG:
         description: |
@@ -546,6 +562,7 @@ Global:
         units: Boolean
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: False
+            $OCN_GRID == "tx2_0v1": False
             $OCN_GRID == "tx0.25v1": False
     RAD_EARTH:
         description: |
@@ -585,6 +602,7 @@ Global:
         value:
             $OCN_GRID == "tx2_3v2": "ocean_topo_tx2_3v2_240501.nc"
             $OCN_GRID == "tx2_3v3": "ocean_topo_tx2_3v3_260305.nc"
+            $OCN_GRID == "tx2_0v1": "ocean_topo_tx2_0v1_260526.nc"
             $OCN_GRID == "tx0.25v1": "ocean_topog.nc"
     TOPO_EDITS_FILE:
         description: |
@@ -602,6 +620,7 @@ Global:
         units: m
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: 6000.0
+            $OCN_GRID == "tx2_0v1": 6000.0
             $OCN_GRID == "tx0.25v1": 6500.0
             $OCN_GRID == "MISOMIP": 720.0
     MINIMUM_DEPTH:
@@ -616,6 +635,7 @@ Global:
         units: m
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: 9.5
+            $OCN_GRID == "tx2_0v1": 9.5
             $OCN_GRID == "tx0.25v1": 9.5
     MASKING_DEPTH:
         description: |
@@ -626,6 +646,7 @@ Global:
         units: m
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: 0.0
+            $OCN_GRID == "tx2_0v1": 0.0
             $OCN_GRID == "tx0.25v1": 0.0
     REMAPPING_SCHEME:
         description: |
@@ -651,6 +672,7 @@ Global:
         units: Boolean
         value:
              $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: True
+             $OCN_GRID == "tx2_0v1": True
     REMAPPING_USE_OM4_SUBCELLS:
         description: |
             "[Boolean] default = True
@@ -662,6 +684,7 @@ Global:
         units: none
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: False
+            $OCN_GRID == "tx2_0v1": False
     INIT_LAYERS_FROM_Z_FILE:
         description: |
             "[Boolean] default = False
@@ -671,7 +694,7 @@ Global:
         datatype: logical
         units: Boolean
         value:
-            $RUN_TYPE != "hybrid" and $OCN_GRID in ["tx2_3v2", "tx2_3v3", "tx0.25v1"]:
+            $RUN_TYPE != "hybrid" and $OCN_GRID in ["tx2_3v2", "tx2_3v3", "tx2_0v1", "tx0.25v1"]:
                 True
             else:
                 False
@@ -683,6 +706,7 @@ Global:
         datatype: string
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: "woa18_04_initial_conditions.nc"
+            $OCN_GRID == "tx2_0v1": "woa18_04_initial_conditions.nc"
             $OCN_GRID == "tx0.25v1": "MOM6_IC_TS.nc"
     Z_INIT_FILE_PTEMP_VAR:
         description: |
@@ -692,6 +716,7 @@ Global:
         datatype: string
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: "theta0"
+            $OCN_GRID == "tx2_0v1": "theta0"
             $OCN_GRID == "tx0.25v1": "temp"
     Z_INIT_FILE_SALT_VAR:
         description: |
@@ -701,6 +726,7 @@ Global:
         datatype: string
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: "s_an"
+            $OCN_GRID == "tx2_0v1": "s_an"
     Z_INIT_REMAP_OLD_ALG:
         description: |
             "[Boolean] default = True
@@ -718,6 +744,7 @@ Global:
         units: Boolean
         value:
             $MOM6_VERTICAL_GRID == "hycom1" and $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: True
+            $MOM6_VERTICAL_GRID == "hycom1" and $OCN_GRID == "tx2_0v1": True
     USE_VARIABLE_MIXING:
         description: |
             "[Boolean] default = False
@@ -730,6 +757,7 @@ Global:
         units: Boolean
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: True
+            $OCN_GRID == "tx2_0v1": True
             $OCN_GRID == "tx0.25v1": True
     RESOLN_SCALED_KH:
         description: |
@@ -741,6 +769,7 @@ Global:
         units: Boolean
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: False
+            $OCN_GRID == "tx2_0v1": False
             $OCN_GRID == "tx0.25v1": True
     KHTH_SLOPE_CFF:
         description: |
@@ -751,6 +780,7 @@ Global:
         units: nondim
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: 0.01
+            $OCN_GRID == "tx2_0v1": 0.01
     DEPTH_SCALED_KHTH:
         description: |
             "[Boolean] default = False
@@ -763,6 +793,7 @@ Global:
         units: Boolean
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: True
+            $OCN_GRID == "tx2_0v1": True
             $OCN_GRID == "tx0.25v1": False
     DEPTH_SCALED_KHTH_H0:
         description: |
@@ -772,6 +803,7 @@ Global:
         units: nondim
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: 500.0
+            $OCN_GRID == "tx2_0v1": 500.0
     KHTR_SLOPE_CFF:
         description: |
             "[nondim] default = 0.0
@@ -790,6 +822,7 @@ Global:
         units: Boolean
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: True
+            $OCN_GRID == "tx2_0v1": True
     RESOLN_SCALED_KHTH:
         description: |
             "[Boolean] default = False
@@ -800,6 +833,7 @@ Global:
         units: Boolean
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: True
+            $OCN_GRID == "tx2_0v1": True
             $OCN_GRID == "tx0.25v1": True
     RESOLN_SCALED_KHTR:
         description: |
@@ -810,6 +844,7 @@ Global:
         units: Boolean
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: True
+            $OCN_GRID == "tx2_0v1": True
     USE_GM_WORK_BUG:
         description: |
             "[Boolean] default = True
@@ -828,6 +863,7 @@ Global:
         units: Boolean
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: True
+            $OCN_GRID == "tx2_0v1": True
             $OCN_GRID == "tx0.25v1": True
     USE_STANLEY_ISO:
         description: |
@@ -837,6 +873,7 @@ Global:
         units: Boolean
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: False
+            $OCN_GRID == "tx2_0v1": False
     ETA_TOLERANCE:
         description: |
             "[m] default = 3.15E-09
@@ -871,6 +908,7 @@ Global:
         units: Boolean
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: True
+            $OCN_GRID == "tx2_0v1": True
     NDIFF_INTERIOR_ONLY:
         description: |
             "[Boolean] default = False
@@ -880,6 +918,7 @@ Global:
         units: Boolean
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: True
+            $OCN_GRID == "tx2_0v1": True
     NDIFF_TAPERING:
         description: |
             "[Boolean] default = False
@@ -890,6 +929,7 @@ Global:
         units: Boolean
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: True
+            $OCN_GRID == "tx2_0v1": True
     USE_HORIZONTAL_BOUNDARY_DIFFUSION:
         description: |
             "[Boolean] default = False
@@ -898,6 +938,7 @@ Global:
         units: Boolean
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: True
+            $OCN_GRID == "tx2_0v1": True
     HBD_LINEAR_TRANSITION:
         description: |
             "[Boolean] default = False
@@ -907,6 +948,7 @@ Global:
         units: Boolean
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: True
+            $OCN_GRID == "tx2_0v1": True
     SIMPLE_TKE_TO_KD:
         description: |
             "[Boolean] default = False
@@ -918,6 +960,7 @@ Global:
         units: Boolean
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: True
+            $OCN_GRID == "tx2_0v1": True
             $OCN_GRID == "tx0.25v1": True
     REGRIDDING_COORDINATE_MODE:
         description: |
@@ -986,6 +1029,8 @@ Global:
         value:
             $MOM6_VERTICAL_GRID == "hycom1" and $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: |
                   '"FILE:${DIN_LOC_ROOT}/ocn/mom/grid_indpt/lev-2025-09-12.nc,Z"'
+            $MOM6_VERTICAL_GRID == "hycom1" and $OCN_GRID == "tx2_0v1": |
+                  '"FILE:${DIN_LOC_ROOT}/ocn/mom/grid_indpt/lev-2025-09-12.nc,Z"'
             $MOM6_VERTICAL_GRID == "hycom1" and $OCN_GRID == "tx0.25v1": '"FNC1:5,8000.0,1.0,.01"'
     MAX_LAYER_THICKNESS_CONFIG:
         description: |
@@ -1002,6 +1047,8 @@ Global:
         datatype: string
         value:
             $MOM6_VERTICAL_GRID == "hycom1" and $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: |
+                  '"FILE:${DIN_LOC_ROOT}/ocn/mom/grid_indpt/dz_max-2025-09-12.nc,dz"'
+            $MOM6_VERTICAL_GRID == "hycom1" and $OCN_GRID == "tx2_0v1": |
                   '"FILE:${DIN_LOC_ROOT}/ocn/mom/grid_indpt/dz_max-2025-09-12.nc,dz"'
             else: '"FNC1:400,31000.0,0.1,.01"'
     BOUND_CORIOLIS:
@@ -1041,6 +1088,7 @@ Global:
         units: Boolean
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: True
+            $OCN_GRID == "tx2_0v1": True
     LAPLACIAN:
         description: |
             "[Boolean] default = False
@@ -1056,6 +1104,7 @@ Global:
         units: Boolean
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: False
+            $OCN_GRID == "tx2_0v1": False
     SMAG_LAP_CONST:
         description: |
             "[nondim] default = 0.0
@@ -1064,6 +1113,7 @@ Global:
         units: nondim
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: 0.15
+            $OCN_GRID == "tx2_0v1": 0.15
     KH:
         description: |
             "[m2 s-1] default = 0.0
@@ -1085,6 +1135,7 @@ Global:
             $OCN_GRID == "MISOMIP": 0.0
             $OCN_GRID == "tx0.25v1": 0.0
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: 0.0
+            $OCN_GRID == "tx2_0v1": 0.0
             else: 0.01
     KH_SIN_LAT:
         description: |
@@ -1095,6 +1146,7 @@ Global:
         units: m2 s-1
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: 0.0
+            $OCN_GRID == "tx2_0v1": 0.0
     BIHARMONIC:
         description: |
             "[Boolean] default = True
@@ -1104,6 +1156,7 @@ Global:
         units: Boolean
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: True
+            $OCN_GRID == "tx2_0v1": True
             $OCN_GRID == "MISOMIP": False
     AH:
         description: |
@@ -1113,6 +1166,7 @@ Global:
         units: m4 s-1
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: 1.0E+12
+            $OCN_GRID == "tx2_0v1": 1.0E+12
     AH_VEL_SCALE:
         description: |
             "[m s-1] default = 0.0
@@ -1135,6 +1189,7 @@ Global:
         units: Boolean
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: True
+            $OCN_GRID == "tx2_0v1": True
     LEITH_AH:
         description: |
             "[Boolean] default = False
@@ -1143,6 +1198,7 @@ Global:
         units: Boolean
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: False
+            $OCN_GRID == "tx2_0v1": False
     LEITH_BI_CONST:
         description: |
             "[nondim] default = 0.0
@@ -1152,6 +1208,7 @@ Global:
         units: nondim
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: 85.0
+            $OCN_GRID == "tx2_0v1": 85.0
     LEITHY_CK:
         description: |
             "[nondim] default = 1.0
@@ -1160,6 +1217,7 @@ Global:
         units: nondim
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: 1.0
+            $OCN_GRID == "tx2_0v1": 1.0
     TAPER_LEITHY:
         description: |
             "[Boolean] default = False
@@ -1168,6 +1226,7 @@ Global:
         units: Boolean
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: True
+            $OCN_GRID == "tx2_0v1": True
     LEITHY_DEPTH:
         description: |
             "[m] default = 800.0
@@ -1176,6 +1235,7 @@ Global:
         units: m
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: 1000.0
+            $OCN_GRID == "tx2_0v1": 1000.0
     LEITHY_WIDTH:
         description: |
             "[m] default = 400.0
@@ -1184,6 +1244,7 @@ Global:
         units: m
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: 500.0
+            $OCN_GRID == "tx2_0v1": 500.0
     USE_LAND_MASK_FOR_HVISC:
         description: |
             "[Boolean] default = False
@@ -1204,6 +1265,7 @@ Global:
         units: Boolean
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: True
+            $OCN_GRID == "tx2_0v1": True
     KH_BG_2D_FILENAME:
         description: |
             "default = 'KH_background_2d.nc'
@@ -1212,6 +1274,7 @@ Global:
         value:
             $OCN_GRID == "tx2_3v2": "KH_BG_2D_tx2_3v2_260427.nc"
             $OCN_GRID == "tx2_3v3": "KH_BG_2D_tx2_3v3_260427.nc"
+            $OCN_GRID == "tx2_0v1": "KH_BG_2D_tx2_0v1_260528.nc"
     KH_BG_2D_VARNAME:
         description: |
             "default = 'Kh'
@@ -1219,6 +1282,7 @@ Global:
         datatype: string
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: "KH"
+            $OCN_GRID == "tx2_0v1": "KH"
     FRICTWORK_BUG:
         description: |
             "[Boolean] default = True
@@ -1260,6 +1324,7 @@ Global:
         units: m
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: 5.0
+            $OCN_GRID == "tx2_0v1": 5.0
     HBBL:
         description: |
             "[m]
@@ -1279,6 +1344,7 @@ Global:
         units: nondim
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: 1.0
+            $OCN_GRID == "tx2_0v1": 1.0
             $OCN_GRID == "tx0.25v1": 1.25
     U_TRUNC_FILE:
         description: |
@@ -1317,6 +1383,7 @@ Global:
         units: s
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: 7200.0
+            $OCN_GRID == "tx2_0v1": 7200.0
     Z_INIT_ALE_REMAPPING:
         description: |
             "[Boolean] default = False
@@ -1325,6 +1392,7 @@ Global:
         units: Boolean
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: True
+            $OCN_GRID == "tx2_0v1": True
             $OCN_GRID == "tx0.25v1": True
     NUM_DIAG_COORDS:
         description: |
@@ -1333,6 +1401,7 @@ Global:
         datatype: integer
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: 2
+            $OCN_GRID == "tx2_0v1": 1
             $OCN_GRID == "tx0.25v1": 1
     DIAG_COORDS:
         description: |
@@ -1342,6 +1411,7 @@ Global:
         datatype: string
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: '"z Z ZSTAR", "rho2 RHO2 RHO"'
+            $OCN_GRID == "tx2_0v1": '"z Z ZSTAR"'
             $OCN_GRID == "tx0.25v1": '"z Z ZSTAR"'
     DIAG_COORD_DEF_RHO2:
         description: |
@@ -1379,6 +1449,7 @@ Global:
         units: Boolean
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: True
+            $OCN_GRID == "tx2_0v1": True
             else: False
     GILL_EQUATORIAL_LD:
         description: |
@@ -1391,6 +1462,7 @@ Global:
         units: Boolean
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: True
+            $OCN_GRID == "tx2_0v1": True
             $OCN_GRID == "tx0.25v1": True
     DRAG_BG_VEL:
         description: |
@@ -1404,6 +1476,7 @@ Global:
         units: m s-1
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: 0.1
+            $OCN_GRID == "tx2_0v1": 0.1
             $OCN_GRID == "tx0.25v1": 0.1
     BBL_USE_EOS:
         description: |
@@ -1435,6 +1508,7 @@ Global:
         units: Boolean
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: True
+            $OCN_GRID == "tx2_0v1": True
     BOUND_BT_CORRECTION:
         description: |
             "[Boolean] default = False
@@ -1460,6 +1534,7 @@ Global:
         units: Boolean
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: True
+            $OCN_GRID == "tx2_0v1": True
             $OCN_GRID == "tx0.25v1": True
     BT_THICK_SCHEME:
         description: |
@@ -1526,6 +1601,7 @@ Global:
         units: m
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: 1.0
+            $OCN_GRID == "tx2_0v1": 1.0
     MAX_P_SURF:
         description: |
             "[Pa] default = -1.0
@@ -1547,6 +1623,7 @@ Global:
         units: m2 s-1
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: 0.0
+            $OCN_GRID == "tx2_0v1": 0.0
             $OCN_GRID == "MISOMIP": 0.0
     KHTH_MIN:
         description: |
@@ -1556,6 +1633,7 @@ Global:
         units: m2 s-1
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: 50.0
+            $OCN_GRID == "tx2_0v1": 50.0
     FULL_DEPTH_KHTH_MIN:
         description: |
             "[Boolean] default = False
@@ -1566,6 +1644,7 @@ Global:
         units: Boolean
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: True
+            $OCN_GRID == "tx2_0v1": True
     KHTH_MAX_CFL:
         description: |
             "[nondimensional] default = 0.8
@@ -1586,6 +1665,7 @@ Global:
         units: Boolean
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: True
+            $OCN_GRID == "tx2_0v1": True
     STANLEY_COEFF:
         description:
             "[nondim] default = -1.0
@@ -1594,6 +1674,7 @@ Global:
         units: nondimensional
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: 0.5
+            $OCN_GRID == "tx2_0v1": 0.5
     USE_KH_IN_MEKE:
         description: |
             "[Boolean] default = False
@@ -1602,6 +1683,7 @@ Global:
         units: Boolean
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: True
+            $OCN_GRID == "tx2_0v1": True
     KHTH_USE_FGNV_STREAMFUNCTION:
         description: |
             "[Boolean] default = False
@@ -1612,6 +1694,7 @@ Global:
         units: Boolean
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: True
+            $OCN_GRID == "tx2_0v1": True
     FGNV_C_MIN:
         description: |
             "[m s-1] default = 0.0
@@ -1621,6 +1704,7 @@ Global:
         units: m s-1
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: 0.01
+            $OCN_GRID == "tx2_0v1": 0.01
     USE_STANLEY_GM:
         description: |
             "[Boolean] default = False
@@ -1629,6 +1713,7 @@ Global:
         units: Boolean
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: False
+            $OCN_GRID == "tx2_0v1": False
     MIXEDLAYER_RESTRAT:
         description: |
             "[Boolean] default = False
@@ -1649,6 +1734,7 @@ Global:
         units: none
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: True
+            $OCN_GRID == "tx2_0v1": True
     MLE_FRONT_LENGTH:
         description: |
             "[m] default = 0.0
@@ -1660,6 +1746,7 @@ Global:
         units: m
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: 1000.0
+            $OCN_GRID == "tx2_0v1": 1000.0
             $OCN_GRID == "tx0.25v1": 500.0
     MLE_MLD_DECAY_TIME:
         description: |
@@ -1672,6 +1759,7 @@ Global:
         units: s
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: 3.45600E+05
+            $OCN_GRID == "tx2_0v1": 3.45600E+05
             $OCN_GRID == "tx0.25v1": 2.592E+06
     USE_STANLEY_ML:
         description: |
@@ -1681,6 +1769,7 @@ Global:
         units: Boolean
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: True
+            $OCN_GRID == "tx2_0v1": True
     USE_CVMix_CONVECTION:
         description: |
             "[Boolean] default = False
@@ -1692,6 +1781,7 @@ Global:
         units: Boolean
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: True
+            $OCN_GRID == "tx2_0v1": True
     BBL_MIXING_AS_MAX:
         description: |
             "[Boolean] default = True
@@ -1702,6 +1792,7 @@ Global:
         units: Boolean
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: False
+            $OCN_GRID == "tx2_0v1": False
             $OCN_GRID == "tx0.25v1": False
     USE_LOTW_BBL_DIFFUSIVITY:
         description: |
@@ -1713,6 +1804,7 @@ Global:
         units: Boolean
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: True
+            $OCN_GRID == "tx2_0v1": True
             $OCN_GRID == "tx0.25v1": True
     KD_MAX:
         description: |
@@ -1724,6 +1816,7 @@ Global:
         units: m2 s-1
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: 0.1
+            $OCN_GRID == "tx2_0v1": 0.1
             $OCN_GRID == "tx0.25v1": 0.1
     HORIZ_VARYING_BACKGROUND:
         description: |
@@ -1734,6 +1827,7 @@ Global:
         units: Boolean
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: True
+            $OCN_GRID == "tx2_0v1": True
             $OCN_GRID == "tx0.25v1": True
     KD:
         description: |
@@ -1745,6 +1839,7 @@ Global:
         units: m2 s-1
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: 1.0E-07
+            $OCN_GRID == "tx2_0v1": 1.0E-07
             $OCN_GRID == "tx0.25v1": 1.5E-05
             $OCN_GRID == "MISOMIP": 5.0E-05
             else: 2.0E-05
@@ -1778,6 +1873,7 @@ Global:
         units: m2 s-1
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]:  1.0E-07
+            $OCN_GRID == "tx2_0v1":  1.0E-07
             else: 2.0E-06
     INT_TIDE_DECAY_SCALE:
         description: |
@@ -1847,6 +1943,7 @@ Global:
         units: Boolean
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: True
+            $OCN_GRID == "tx2_0v1": True
     USE_CVMix_TIDAL:
         description: |
             "[Boolean] default = False
@@ -1855,6 +1952,7 @@ Global:
         units: Boolean
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: True
+            $OCN_GRID == "tx2_0v1": True
     INT_TIDE_DISSIPATION:
         description: |
             "[Boolean] default = False
@@ -1865,6 +1963,7 @@ Global:
         units: Boolean
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: True
+            $OCN_GRID == "tx2_0v1": True
             $OCN_GRID == "tx0.25v1": True
     INT_TIDE_PROFILE:
         description: |
@@ -1886,6 +1985,7 @@ Global:
         value:
             $OCN_GRID == "tx2_3v2": "energy_new_tx2_3_conserve_230415_cdf5.nc"
             $OCN_GRID == "tx2_3v3": "tidal_energy_tx2_3v3_conserve_260306.nc"
+            $OCN_GRID == "tx2_0v1": "tidal_energy_tx2_0v1_conserve_260528.nc"
     TIDAL_ENERGY_TYPE:
         description: |
             "The type of input tidal energy flux dataset. Valid values are   Jayne
@@ -1893,6 +1993,7 @@ Global:
         datatype: string
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: "Jayne"
+            $OCN_GRID == "tx2_0v1": "Jayne"
     USE_LMD94:
         description: |
             "[Boolean] default = False
@@ -1902,6 +2003,7 @@ Global:
         units: Boolean
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: True
+            $OCN_GRID == "tx2_0v1": True
     NU_ZERO:
         description: |
             "[m2 s-1] default = 0.005
@@ -1910,6 +2012,7 @@ Global:
         units: m2 s-1
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: 0.0025
+            $OCN_GRID == "tx2_0v1": 0.0025
     RI_ZERO:
         description: |
             "[nondim] default = 0.8
@@ -1919,6 +2022,7 @@ Global:
         units: nondim
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: 0.5
+            $OCN_GRID == "tx2_0v1": 0.5
     N_SMOOTH_RI:
         description: |
             "default = 0
@@ -1928,6 +2032,7 @@ Global:
         units: nondim
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: 1
+            $OCN_GRID == "tx2_0v1": 1
     USE_CVMIX_DDIFF:
         description: |
             "[Boolean] default = False
@@ -1938,6 +2043,7 @@ Global:
         units: Boolean
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: True
+            $OCN_GRID == "tx2_0v1": True
     MAX_ENT_IT:
         description: |
             "default = 5
@@ -1955,6 +2061,7 @@ Global:
         units: m
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: 1.0E-05
+            $OCN_GRID == "tx2_0v1": 1.0E-05
             $OCN_GRID == "MISOMIP": 1.0E-08
     HMIX_MIN:
         description: |
@@ -1977,6 +2084,7 @@ Global:
         units: Boolean
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: True
+            $OCN_GRID == "tx2_0v1": True
     MSTAR_MODE:
         description: |
             "[units=nondim] default = 0
@@ -2187,6 +2295,7 @@ Global:
         value:
             $OCN_GRID == "tx0.25v1": True
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: True
+            $OCN_GRID == "tx2_0v1": True
     CHL_FILE:
         description: |
             "CHL_FILE is the file containing chl_a concentrations in the variable CHL_A."
@@ -2195,6 +2304,7 @@ Global:
             $OCN_GRID == "tx0.25v1": "seawifs-clim-1997-2010.1440x1080.v20180328.nc"
             $OCN_GRID == "tx2_3v2": "seawifs-clim-1997-2010-tx2_3v2.230416.nc"
             $OCN_GRID == "tx2_3v3": "seawifs-clim-1997-2010-tx2_3v3_260305.nc"
+            $OCN_GRID == "tx2_0v1": "seawifs-clim-1997-2010-tx2_0v1_260528.nc"
     CHL_VARNAME:
         description: |
             "default = 'CHL_A'"
@@ -2209,6 +2319,7 @@ Global:
         value:
             $OCN_GRID == "tx0.25v1": 3
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: 2
+            $OCN_GRID == "tx2_0v1": 2
     OPACITY_SCHEME:
         description: |
             "default = 'MANIZZA_05'
@@ -2220,6 +2331,7 @@ Global:
         datatype: string
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: "OHLMANN_03"
+            $OCN_GRID == "tx2_0v1": "OHLMANN_03"
     TRACER_ADVECTION_SCHEME:
         description: |
             "default = 'PLM'
@@ -2229,6 +2341,7 @@ Global:
         datatype: string
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: '"PPM:H3"'
+            $OCN_GRID == "tx2_0v1": '"PPM:H3"'
             $OCN_GRID == "tx0.25v1": '"PPM:H3"'
     KHTR_USE_EBT_STRUCT:
         description: |
@@ -2239,6 +2352,7 @@ Global:
         units: Boolean
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: True
+            $OCN_GRID == "tx2_0v1": True
     KHTR:
         description: |
             "[m2 s-1] default = 0.0
@@ -2255,6 +2369,7 @@ Global:
         units: m2 s-1
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: 50.0
+            $OCN_GRID == "tx2_0v1": 50.0
     FULL_DEPTH_KHTR_MIN:
         description: |
             "[Boolean] default = False
@@ -2265,6 +2380,7 @@ Global:
         units: Boolean
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: True
+            $OCN_GRID == "tx2_0v1": True
     DEBUG:
         description: |
             "If true, write out verbose debugging data."
@@ -2282,6 +2398,7 @@ Global:
         units: Boolean
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: True
+            $OCN_GRID == "tx2_0v1": True
             $OCN_GRID == "tx0.25v1": True
     MAX_TR_DIFFUSION_CFL:
         description: |
@@ -2294,6 +2411,7 @@ Global:
         units: nondim
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: 2.0
+            $OCN_GRID == "tx2_0v1": 2.0
     MAXTRUNC:
         description: |
             "[truncations save_interval-1] default = 0
@@ -2306,6 +2424,7 @@ Global:
         value:
             $OCN_GRID == "tx0.25v1": 100000
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: 1000000
+            $OCN_GRID == "tx2_0v1": 100000
             else: 0
     OCEAN_SURFACE_STAGGER:
         description: |
@@ -2317,6 +2436,7 @@ Global:
         datatype: string
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: "A"
+            $OCN_GRID == "tx2_0v1": "A"
             $OCN_GRID == "tx0.25v1": "A"
     RESTORE_SALINITY:
         description: |
@@ -2328,6 +2448,7 @@ Global:
         units: Boolean
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"] and $COMP_ATM == "datm": True  # for C and G compsets on tx2_3v2
+            $OCN_GRID == "tx2_0v1" and $COMP_ATM == "datm": True  # for C and G compsets on tx2_3v2
             else: False
     WIND_STAGGER:
         description: |
@@ -2354,6 +2475,7 @@ Global:
         units: m day-1
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: 0.1667
+            $OCN_GRID == "tx2_0v1": 0.1667
     SALT_RESTORE_FILE:
         description: |
             "default = 'salt_restore.nc'
@@ -2362,6 +2484,7 @@ Global:
         value:
             $OCN_GRID == "tx2_3v2": "state_restore_tx2_3_20230416.nc"
             $OCN_GRID == "tx2_3v3": "state_restore_tx2_3v3_260305.nc"
+            $OCN_GRID == "tx2_0v1": "state_restore_tx2_0v1_260528.nc"
     ADJUST_NET_FRESH_WATER_TO_ZERO:
         description: |
             "[Boolean] default = False
@@ -2380,6 +2503,7 @@ Global:
         units: PSU or g kg-1
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: 5.0
+            $OCN_GRID == "tx2_0v1": 5.0
     SRESTORE_AS_SFLUX:
         description: |
             "[Boolean] default = False
@@ -2389,6 +2513,7 @@ Global:
         units: Boolean
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: True
+            $OCN_GRID == "tx2_0v1": True
     GUST_CONST:
         description: |
             "[Pa] default = 0.02
@@ -2436,6 +2561,7 @@ Global:
         units: days
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: 1.0
+            $OCN_GRID == "tx2_0v1": 1.0
             $OCN_GRID == "tx0.25v1": 0.25
             $OCN_GRID == "MISOMIP": 1.0
     ENERGETICS_SFC_PBL:
@@ -2459,6 +2585,7 @@ Global:
         value:
             $OCN_GRID == "tx0.25v1": True
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: True
+            $OCN_GRID == "tx2_0v1": True
     MEKE_GMCOEFF:
         description: |
             "[nondim] default = -1.0
@@ -2471,6 +2598,7 @@ Global:
         value:
             $OCN_GRID == "tx0.25v1": 1.0
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: 0.25
+            $OCN_GRID == "tx2_0v1": 0.25
     MEKE_BGSRC:
         description: |
             "[W kg-1] default = 0.0
@@ -2488,6 +2616,7 @@ Global:
         value:
             $OCN_GRID == "tx0.25v1": 1.0
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: 0.75
+            $OCN_GRID == "tx2_0v1": 0.75
     MEKE_VISCOSITY_COEFF_KU:
         description: |
             "[nondim] default = 0.0
@@ -2498,6 +2627,7 @@ Global:
         units: nondim
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: 0.0
+            $OCN_GRID == "tx2_0v1": 0.0
     MEKE_MIN_LSCALE:
         description: |
             "[Boolean] default = False
@@ -2507,6 +2637,7 @@ Global:
         units: Boolean
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: True
+            $OCN_GRID == "tx2_0v1": True
     MEKE_ALPHA_RHINES:
         description: |
             "[nondim] default = 0.05
@@ -2526,6 +2657,7 @@ Global:
         value:
             $OCN_GRID == "tx0.25v1": 0.15
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: 1.0
+            $OCN_GRID == "tx2_0v1": 1.0
     MEKE_FRCOEFF:
         description: |
             "[nondim] default = -1.0
@@ -2535,6 +2667,7 @@ Global:
         units: nondim
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: 0.3
+            $OCN_GRID == "tx2_0v1": 0.3
     MEKE_CT:
         description: |
             "[nondim] default = 50.0
@@ -2544,6 +2677,7 @@ Global:
         units: nondim
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: 0.0
+            $OCN_GRID == "tx2_0v1": 0.0
     MEKE_POSITIVE:
         description: |
             "[Boolean] default = False
@@ -2552,6 +2686,7 @@ Global:
         units: Boolean
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: True
+            $OCN_GRID == "tx2_0v1": True
     USE_SIMPLER_EADY_GROWTH_RATE:
         description: |
             "[Boolean] default = False
@@ -2561,6 +2696,7 @@ Global:
         units: Boolean
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: True
+            $OCN_GRID == "tx2_0v1": True
     KH_RES_SCALE_COEF:
         description: |
             "[nondim] default = 1.0
@@ -2570,6 +2706,7 @@ Global:
         units: nondim
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: 0.5
+            $OCN_GRID == "tx2_0v1": 0.5
     KH_RES_FN_POWER:
         description: |
             "[nondim] default = 2
@@ -2580,6 +2717,7 @@ Global:
         units: nondim
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: 6
+            $OCN_GRID == "tx2_0v1": 6
     VISC_RES_SCALE_COEF:
         description: |
             "[nondim] default = 1.0
@@ -2590,6 +2728,7 @@ Global:
         units: nondim
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: 0.5
+            $OCN_GRID == "tx2_0v1": 0.5
     MEKE_GEOMETRIC:
         description: |
             "[Boolean] default = False
@@ -2599,6 +2738,7 @@ Global:
         units: Boolean
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: True
+            $OCN_GRID == "tx2_0v1": True
     MEKE_GEOMETRIC_ALPHA:
         description: |
             "[nondim] default = 0.05
@@ -2608,6 +2748,7 @@ Global:
         units: nondim
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: 0.07
+            $OCN_GRID == "tx2_0v1": 0.07
     MEKE_KHTH_FAC:
         description: |
             "[nondim] default = 0.0
@@ -2616,6 +2757,7 @@ Global:
         units: nondim
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: 1.0
+            $OCN_GRID == "tx2_0v1": 1.0
     MEKE_KHTR_FAC:
         description: |
             "[nondim] default = 0.0
@@ -2624,6 +2766,7 @@ Global:
         units: nondim
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: 1.0
+            $OCN_GRID == "tx2_0v1": 1.0
     MEKE_CB:
         description: |
             "[nondim] default = 25.0
@@ -2633,6 +2776,7 @@ Global:
         units: nondim
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: 100.0
+            $OCN_GRID == "tx2_0v1": 100.0
     MEKE_CDRAG:
         description: |
             "[nondim] default = 0.003
@@ -2642,6 +2786,7 @@ Global:
         units: nondim
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: 0.0025
+            $OCN_GRID == "tx2_0v1": 0.0025
     MEKE_MIN_GAMMA2:
         description: |
             "[nondim] default = 1.0E-04
@@ -2650,6 +2795,7 @@ Global:
         units: nondim
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: 1.0E-05
+            $OCN_GRID == "tx2_0v1": 1.0E-05
     MEKE_EQUILIBRIUM_ALT:
         description: |
             "[Boolean] default = False
@@ -2659,6 +2805,7 @@ Global:
         units: Boolean
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: True
+            $OCN_GRID == "tx2_0v1": True
     MEKE_VISC_DRAG:
         description: |
             "[Boolean] default = True
@@ -2667,6 +2814,7 @@ Global:
         units: Boolean
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: False
+            $OCN_GRID == "tx2_0v1": False
     MEKE_EQUILIBRIUM_RESTORING:
         description: |
             "[Boolean] default = False
@@ -2676,6 +2824,7 @@ Global:
         units: Boolean
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: False
+            $OCN_GRID == "tx2_0v1": False
     MEKE_ADVECTION_FACTOR:
         description: |
             "[nondim] default = 0.0
@@ -2686,6 +2835,7 @@ Global:
         units: nondim
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: 1.0
+            $OCN_GRID == "tx2_0v1": 1.0
     DIAG_COORD_DEF_Z:
         description: |
             "default = WOA09
@@ -2732,6 +2882,7 @@ Global:
         value:
             $OCN_GRID == "tx0.25v1": "list"
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: "list"
+            $OCN_GRID == "tx2_0v1": "list"
     CHANNEL_LIST_FILE:
         description: |
             "default = MOM_channel_list
@@ -2741,6 +2892,7 @@ Global:
             $OCN_GRID == "tx0.25v1": "MOM_channels_global_025"
             $OCN_GRID == "tx2_3v2":  "channels_tx2_3v2_250107.txt"
             $OCN_GRID == "tx2_3v3":  "channels_tx2_3v3_260304.txt"
+            $OCN_GRID == "tx2_0v1":  "channels_tx2_0v1_260518.txt"
     SMAG_BI_CONST:
         description: |
             "[nondim] default = 0.0
@@ -2806,6 +2958,7 @@ Global:
         units: PPT
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"] or $COMP_ATM == "cam": 75.0
+            $OCN_GRID == "tx2_0v1" or $COMP_ATM == "cam": 75.0
     BAD_VAL_SST_MAX:
         description: |
             "[deg C] default = 45.0, PTripp: changed from 55.0 on 12/28/2017
@@ -2824,6 +2977,7 @@ Global:
         units: degC
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: -3.0
+            $OCN_GRID == "tx2_0v1": -3.0
             $OCN_GRID == "tx0.25v1": -3.0
     DEFAULT_ANSWER_DATE:
         description: |
@@ -2872,6 +3026,7 @@ Global:
         units: Boolean
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: True
+            $OCN_GRID == "tx2_0v1": True
             $OCN_GRID == "tx0.25v1": True
             else: False
     PARALLEL_RESTARTFILES:
@@ -3172,6 +3327,7 @@ Global:
         units: Boolean
         value:
             $MOM6_VERTICAL_GRID == "hycom1" and $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: True
+            $MOM6_VERTICAL_GRID == "hycom1" and $OCN_GRID == "tx2_0v1": True
     ISOMIP_TNUDG:
         description: |
             "default = 0.0 (days)
@@ -3320,6 +3476,7 @@ Global:
         units: m2 s-1
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: 1.0E-06
+            $OCN_GRID == "tx2_0v1": 1.0E-06
             else: 1.0E-04
     KV_BBL_MIN:
         description: |
@@ -3418,6 +3575,7 @@ Global:
         value:
             $OCN_GRID == "MISOMIP": 0.0
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: 0.01
+            $OCN_GRID == "tx2_0v1": 0.01
     IGNORE_FLUXES_OVER_LAND:
         description: |
             "[Boolean] default = False
@@ -3661,6 +3819,7 @@ Global:
         units: W m-2 or various
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: 1.0
+            $OCN_GRID == "tx2_0v1": 1.0
             $OCN_GRID == "tx0.25v1": 1.0
     GEOTHERMAL_FILE:
         description: |
@@ -3671,6 +3830,7 @@ Global:
         value:
             $OCN_GRID == "tx2_3v2": "geothermal_davies2013_tx2_3_20240318_cdf5.nc"
             $OCN_GRID == "tx2_3v3": "geothermal_davies2013_tx2_3v3_260305.nc"
+            $OCN_GRID == "tx2_0v1": "geothermal_davies2013_tx2_0v1_260528.nc"
             $OCN_GRID == "tx0.25v1": "geothermal_davies2013_v1.nc"
     GEOTHERMAL_VARNAME:
         description: |
@@ -3680,6 +3840,7 @@ Global:
         datatype: string
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: "geothermal_hf"
+            $OCN_GRID == "tx2_0v1": "geothermal_hf"
             $OCN_GRID == "tx0.25v1": "geothermal_hf"
     MIX_BOUNDARY_TRACER_ALE:
         description: |
@@ -3768,6 +3929,7 @@ Global:
         datatype: list
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3", "tx0.25v1"]: True
+            $OCN_GRID == "tx2_0v1": False
     TARGET_IO_PES:
         description: |
             When AUTO_MASKTABLE is enabled, target number of IO PEs. If the given target
@@ -3776,6 +3938,7 @@ Global:
         datatype: integer
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"] and $TEST: = - ( - $NTASKS_OCN // 256)
+            $OCN_GRID == "tx2_0v1" and $TEST: = - ( - $NTASKS_OCN // 256)
             $OCN_GRID == "tx0.25v1": = - ( - $NTASKS_OCN // 128)
     GEOM_FILE:
         description: |
@@ -3811,6 +3974,7 @@ Global:
         units: Boolean
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: True
+            $OCN_GRID == "tx2_0v1": True
     SKEB_USE_FRICT:
         description: |
             "default = False
@@ -3819,6 +3983,7 @@ Global:
         units: Boolean
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: True
+            $OCN_GRID == "tx2_0v1": True
     SKEB_USE_GM:
         description: |
             "default = False
@@ -3827,6 +3992,7 @@ Global:
         units: Boolean
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: True
+            $OCN_GRID == "tx2_0v1": True
     SKEB_NPASS:
         description: |
             "[nondim] default = 0
@@ -3834,6 +4000,7 @@ Global:
         datatype: integer
         value:
            $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: 8
+           $OCN_GRID == "tx2_0v1": 8
     SKEB_GM_COEF:
         description: |
             "[nondim] default = 0.0
@@ -3841,6 +4008,7 @@ Global:
         datatype: real
         value:
            $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: 0.75
+           $OCN_GRID == "tx2_0v1": 0.75
 CVMix_CONVECTION:
     BV_SQR_CONV:
         description: |
@@ -3851,6 +4019,7 @@ CVMix_CONVECTION:
         units: 1/s^2
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: -1.0E-08
+            $OCN_GRID == "tx2_0v1": -1.0E-08
 KPP:
     N_SMOOTH:
         description: |
@@ -3860,6 +4029,7 @@ KPP:
         datatype: integer
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: 3
+            $OCN_GRID == "tx2_0v1": 3
     MATCH_TECHNIQUE:
         description: |
             "default = 'SimpleShapes'
@@ -3872,6 +4042,7 @@ KPP:
         datatype: string
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: "MatchGradient"
+            $OCN_GRID == "tx2_0v1": "MatchGradient"
     INTERP_TYPE2:
         description: |
             "Type of interpolation to compute diff and visc at OBL_depth
@@ -3879,6 +4050,7 @@ KPP:
         datatype: string
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: "LMD94"
+            $OCN_GRID == "tx2_0v1": "LMD94"
     KPP_IS_ADDITIVE:
         description: |
             "[Boolean] default = True
@@ -3888,6 +4060,7 @@ KPP:
         units: Boolean
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: False
+            $OCN_GRID == "tx2_0v1": False
     USE_KPP_LT_K:
         description: |
             default = False
@@ -3933,6 +4106,7 @@ KPP:
         units: nondim
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: 1.8
+            $OCN_GRID == "tx2_0v1": 1.8
     ENHANCE_DIFFUSION:
         description: |
             "default = True
@@ -3940,6 +4114,7 @@ KPP:
         datatype: logical
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: False
+            $OCN_GRID == "tx2_0v1": False
     STOKES_MOST:
         description: |
             "default = False
@@ -3955,6 +4130,7 @@ KPP:
         units: Boolean
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: True
+            $OCN_GRID == "tx2_0v1": True
     MINIMUM_OBL_DEPTH:
         description: |
             "[m] default = 0.0
@@ -3963,6 +4139,7 @@ KPP:
         datatype: real
         value:
            $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: 5.0
+           $OCN_GRID == "tx2_0v1": 5.0
 
 MLE:
     USE_BODNER23:
@@ -3974,6 +4151,7 @@ MLE:
         units: Boolean
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: True
+            $OCN_GRID == "tx2_0v1": True
     CR:
         description: |
            "[nondim] default = 0.0
@@ -3982,6 +4160,7 @@ MLE:
         units: nondim
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: 0.01
+            $OCN_GRID == "tx2_0v1": 0.01
     USE_CR_GRID:
         description: |
             "[Boolean] default = False
@@ -4006,6 +4185,7 @@ MLE:
         units: Boolean
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: True
+            $OCN_GRID == "tx2_0v1": True
     MIN_WSTAR2:
         description: |
             "[m2 s-2] default = 1.0E-24
@@ -4018,6 +4198,7 @@ MLE:
         units: m2 s-2
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: 1.0E-09
+            $OCN_GRID == "tx2_0v1": 1.0E-09
     BLD_DECAYING_TFILTER:
         description: |
             "default = 0.0
@@ -4028,6 +4209,7 @@ MLE:
         units: s
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: 8.64E+04
+            $OCN_GRID == "tx2_0v1": 8.64E+04
     BLD_GROWING_TFILTER:
         description: |
             "[s] default = 0.0
@@ -4038,6 +4220,7 @@ MLE:
         units: s
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: 300.0
+            $OCN_GRID == "tx2_0v1": 300.0
     MLD_GROWING_TFILTER:
         description: |
             "[s] default = 0.0
@@ -4048,6 +4231,7 @@ MLE:
         units: s
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: 3600.0
+            $OCN_GRID == "tx2_0v1": 3600.0
     MLD_DECAYING_TFILTER:
         description: |
             "[s] default = 0.0
@@ -4058,4 +4242,5 @@ MLE:
         units: s
         value:
             $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: 2.592E+06
+            $OCN_GRID == "tx2_0v1": 2.592E+06
 ...

--- a/param_templates/input_data_list.yaml
+++ b/param_templates/input_data_list.yaml
@@ -4,6 +4,7 @@ mom.input_data_list:
     GRID_FILE:
         $OCN_GRID == "tx2_3v2":  "${INPUTDIR}/ocean_hgrid_221123.nc"
         $OCN_GRID == "tx2_3v3":  "${INPUTDIR}/ocean_hgrid_250930.nc"
+        $OCN_GRID == "tx2_0v1":  "${INPUTDIR}/ocean_hgrid_260529.nc"
         $OCN_GRID == "tx0.25v1": "${INPUTDIR}/ocean_hgrid.nc"
     ALE_COORDINATE_CONFIG:
         $MOM6_VERTICAL_GRID == "zstar_75L": "${INPUTDIR}/zstar_75layer_2.5m_248.4m-2024-03-29.nc"
@@ -13,8 +14,10 @@ mom.input_data_list:
         $OCN_GRID == "tx0.25v1": "${INPUTDIR}/hycom1_75_800m.nc"
     MAXIMUM_INT_DEPTH_CONFIG:
         $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: "${DIN_LOC_ROOT}/ocn/mom/grid_indpt/lev-2025-09-12.nc"
+        $OCN_GRID == "tx2_0v1": "${DIN_LOC_ROOT}/ocn/mom/grid_indpt/lev-2025-09-12.nc"
     MAX_LAYER_THICKNESS_CONFIG:
         $OCN_GRID in ["tx2_3v2", "tx2_3v3"]: "${DIN_LOC_ROOT}/ocn/mom/grid_indpt/dz_max-2025-09-12.nc"
+        $OCN_GRID == "tx2_0v1": "${DIN_LOC_ROOT}/ocn/mom/grid_indpt/dz_max-2025-09-12.nc"
     DIAG_COORD_DEF_Z:
         $OCN_GRID == "tx0.25v1": "${INPUTDIR}/interpolate_zgrid_40L.nc"
     COORD_FILE:
@@ -22,6 +25,7 @@ mom.input_data_list:
     TOPO_FILE:
         $OCN_GRID == "tx2_3v2":  "${INPUTDIR}/ocean_topo_tx2_3v2_240501.nc"
         $OCN_GRID == "tx2_3v3":  "${INPUTDIR}/ocean_topo_tx2_3v3_260305.nc"
+        $OCN_GRID == "tx2_0v1":  "${INPUTDIR}/ocean_topo_tx2_0v1_260526.nc"
         $OCN_GRID == "tx0.25v1": "${INPUTDIR}/ocean_topog.nc"
     TOPO_EDITS_FILE:
         $OCN_GRID == "tx2_3v2": "${INPUTDIR}/topo_edits_tx2_3v2_250107.nc"
@@ -30,30 +34,39 @@ mom.input_data_list:
         $OCN_GRID in ["tx2_3v2", "tx2_3v3", "tx0.25v1"]:
             $INIT_LAYERS_FROM_Z_FILE == "True":
                 "${INPUTDIR}/${TEMP_SALT_Z_INIT_FILE}"
+        $OCN_GRID == "tx2_0v1":
+            $INIT_LAYERS_FROM_Z_FILE == "True":
+                "${INPUTDIR}/${TEMP_SALT_Z_INIT_FILE}"
     KH_BG_2D:
         $OCN_GRID == "tx2_3v3": "${INPUTDIR}/KH_BG_2D_tx2_3v3_260427.nc"
         $OCN_GRID == "tx2_3v2": "${INPUTDIR}/KH_BG_2D_tx2_3v2_260427.nc"
+        $OCN_GRID == "tx2_0v1": "${INPUTDIR}/KH_BG_2D_tx2_0v1_260528.nc"
     SURFACE_PRESSURE_FILE:
         $OCN_GRID == "MISOMIP": "${INPUTDIR}/MISOMIP_181108.nc"
     SALT_RESTORE_FILE:
         $OCN_GRID == "tx2_3v2":  "${INPUTDIR}/state_restore_tx2_3_20230416.nc"
         $OCN_GRID == "tx2_3v3":  "${INPUTDIR}/state_restore_tx2_3v3_260305.nc"
+        $OCN_GRID == "tx2_0v1":  "${INPUTDIR}/state_restore_tx2_0v1_260528.nc"
     TIDAL_ENERGY_FILE:
         $OCN_GRID == "tx2_3v2": "${INPUTDIR}/energy_new_tx2_3_conserve_230415_cdf5.nc"
         $OCN_GRID == "tx2_3v3": "${INPUTDIR}/tidal_energy_tx2_3v3_conserve_260306.nc"
+        $OCN_GRID == "tx2_0v1": "${INPUTDIR}/tidal_energy_tx2_0v1_conserve_260528.nc"
         $OCN_GRID == "tx0.25v1": "${INPUTDIR}/tidal_amplitude.v20140616.nc"
     CHANNEL_LIST_FILE:
         $OCN_GRID == "tx2_3v2": "${INPUTDIR}/channels_tx2_3v2_250107.txt"
         $OCN_GRID == "tx2_3v3": "${INPUTDIR}/channels_tx2_3v3_260304.txt"
+        $OCN_GRID == "tx2_0v1": "${INPUTDIR}/channels_tx2_0v1_260518.txt"
         $OCN_GRID == "tx0.25v1": "${INPUTDIR}/MOM_channels_global_025"
     GEOTHERMAL_FILE:
         $OCN_GRID == "tx2_3v2": "${INPUTDIR}/geothermal_davies2013_tx2_3_20240318_cdf5.nc"
         $OCN_GRID == "tx2_3v3": "${INPUTDIR}/geothermal_davies2013_tx2_3v3_260305.nc"
+        $OCN_GRID == "tx2_0v1": "${INPUTDIR}/geothermal_davies2013_tx2_0v1_260528.nc"
         $OCN_GRID == "tx0.25v1": "${INPUTDIR}/geothermal_davies2013_v1.nc"
     CHL_FILE:
         $OCN_GRID == "tx0.25v1": "${INPUTDIR}/seawifs-clim-1997-2010.1440x1080.v20180328.nc"
         $OCN_GRID == "tx2_3v2": "${INPUTDIR}/seawifs-clim-1997-2010-tx2_3v2.230416.nc"
         $OCN_GRID == "tx2_3v3": "${INPUTDIR}/seawifs-clim-1997-2010-tx2_3v3_260305.nc"
+        $OCN_GRID == "tx2_0v1": "${INPUTDIR}/seawifs-clim-1997-2010-tx2_0v1_260528.nc"
     CR_FILE:
         $OCN_GRID == "tx2_3v2": "${INPUTDIR}/mle-cr-mask_20250627.nc"
         $OCN_GRID == "tx2_3v3": "${INPUTDIR}/mle_cr_labsea_mask_tx2_3v3_260306.nc"

--- a/param_templates/json/MOM_input.json
+++ b/param_templates/json/MOM_input.json
@@ -11,6 +11,7 @@
          "units": "Boolean",
          "value": {
             "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": true,
+            "$OCN_GRID == \"tx2_0v1\"": true,
             "$OCN_GRID == \"tx0.25v1\"": true,
             "else": false
          }
@@ -30,6 +31,7 @@
          "datatype": "integer",
          "value": {
             "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 540,
+            "$OCN_GRID == \"tx2_0v1\"": 180,
             "$OCN_GRID == \"tx0.25v1\"": 1440,
             "$OCN_GRID == \"MISOMIP\"": 402
          }
@@ -39,6 +41,7 @@
          "datatype": "integer",
          "value": {
             "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 480,
+            "$OCN_GRID == \"tx2_0v1\"": 128,
             "$OCN_GRID == \"tx0.25v1\"": 1080,
             "$OCN_GRID == \"MISOMIP\"": 40
          }
@@ -58,7 +61,8 @@
          "datatype": "logical",
          "units": "Boolean",
          "value": {
-            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": false
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": false,
+            "$OCN_GRID == \"tx2_0v1\"": false
          }
       },
       "HREF_FOR_MLD": {
@@ -66,7 +70,8 @@
          "datatype": "real",
          "units": "m",
          "value": {
-            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 10.0
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 10.0,
+            "$OCN_GRID == \"tx2_0v1\"": 10.0
          }
       },
       "USE_REGRIDDING": {
@@ -81,6 +86,7 @@
          "units": "Boolean",
          "value": {
             "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": true,
+            "$OCN_GRID == \"tx2_0v1\"": true,
             "$OCN_GRID == \"tx0.25v1\"": true
          }
       },
@@ -90,6 +96,7 @@
          "units": "Boolean",
          "value": {
             "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": true,
+            "$OCN_GRID == \"tx2_0v1\"": true,
             "$OCN_GRID == \"tx0.25v1\"": true
          }
       },
@@ -100,6 +107,7 @@
          "value": {
             "$OCN_GRID == \"tx0.25v1\"": 900.0,
             "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 1800,
+            "$OCN_GRID == \"tx2_0v1\"": 3600,
             "$OCN_GRID == \"MISOMIP\"": 600.0
          }
       },
@@ -118,6 +126,7 @@
          "units": "m",
          "value": {
             "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 10.0,
+            "$OCN_GRID == \"tx2_0v1\"": 10.0,
             "$OCN_GRID == \"tx0.25v1\"": 20.0
          }
       },
@@ -127,6 +136,7 @@
          "units": "s",
          "value": {
             "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 7200.0,
+            "$OCN_GRID == \"tx2_0v1\"": 7200.0,
             "$OCN_GRID == \"tx0.25v1\"": 3600.0,
             "else": 0.0
          }
@@ -158,6 +168,7 @@
          "units": "J kg-1 K-1",
          "value": {
             "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 3992.0,
+            "$OCN_GRID == \"tx2_0v1\"": 3992.0,
             "$OCN_GRID == \"tx0.25v1\"": 3992.0,
             "$OCN_GRID == \"MISOMIP\"": 3974.0
          }
@@ -174,6 +185,7 @@
          "units": "Boolean",
          "value": {
             "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": true,
+            "$OCN_GRID == \"tx2_0v1\"": true,
             "$OCN_GRID == \"tx0.25v1\"": true
          }
       },
@@ -189,6 +201,7 @@
          "units": "Boolean",
          "value": {
             "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": false,
+            "$OCN_GRID == \"tx2_0v1\"": false,
             "$OCN_GRID == \"tx0.25v1\"": false
          }
       },
@@ -206,6 +219,7 @@
          "units": "deg C Pa-1",
          "value": {
             "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": -7.75e-08,
+            "$OCN_GRID == \"tx2_0v1\"": -7.75e-08,
             "$OCN_GRID == \"tx0.25v1\"": -7.75e-08,
             "$OCN_GRID == \"MISOMIP\"": -7.53e-08
          }
@@ -216,6 +230,7 @@
          "units": "Boolean",
          "value": {
             "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": true,
+            "$OCN_GRID == \"tx2_0v1\"": true,
             "$OCN_GRID == \"tx0.25v1\"": true
          }
       },
@@ -418,6 +433,7 @@
          "value": {
             "$OCN_GRID == \"tx2_3v2\"": "ocean_hgrid_221123.nc",
             "$OCN_GRID == \"tx2_3v3\"": "ocean_hgrid_250930.nc",
+            "$OCN_GRID == \"tx2_0v1\"": "ocean_hgrid_260529.nc",
             "$OCN_GRID == \"tx0.25v1\"": "ocean_hgrid.nc"
          }
       },
@@ -427,6 +443,7 @@
          "units": "Boolean",
          "value": {
             "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": false,
+            "$OCN_GRID == \"tx2_0v1\"": false,
             "$OCN_GRID == \"tx0.25v1\"": false
          }
       },
@@ -450,6 +467,7 @@
          "value": {
             "$OCN_GRID == \"tx2_3v2\"": "ocean_topo_tx2_3v2_240501.nc",
             "$OCN_GRID == \"tx2_3v3\"": "ocean_topo_tx2_3v3_260305.nc",
+            "$OCN_GRID == \"tx2_0v1\"": "ocean_topo_tx2_0v1_260526.nc",
             "$OCN_GRID == \"tx0.25v1\"": "ocean_topog.nc"
          }
       },
@@ -467,6 +485,7 @@
          "units": "m",
          "value": {
             "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 6000.0,
+            "$OCN_GRID == \"tx2_0v1\"": 6000.0,
             "$OCN_GRID == \"tx0.25v1\"": 6500.0,
             "$OCN_GRID == \"MISOMIP\"": 720.0
          }
@@ -477,6 +496,7 @@
          "units": "m",
          "value": {
             "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 9.5,
+            "$OCN_GRID == \"tx2_0v1\"": 9.5,
             "$OCN_GRID == \"tx0.25v1\"": 9.5
          }
       },
@@ -486,6 +506,7 @@
          "units": "m",
          "value": {
             "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 0.0,
+            "$OCN_GRID == \"tx2_0v1\"": 0.0,
             "$OCN_GRID == \"tx0.25v1\"": 0.0
          }
       },
@@ -499,7 +520,8 @@
          "datatype": "logical",
          "units": "Boolean",
          "value": {
-            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": true
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": true,
+            "$OCN_GRID == \"tx2_0v1\"": true
          }
       },
       "REMAPPING_USE_OM4_SUBCELLS": {
@@ -507,7 +529,8 @@
          "datatype": "bool",
          "units": "none",
          "value": {
-            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": false
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": false,
+            "$OCN_GRID == \"tx2_0v1\"": false
          }
       },
       "INIT_LAYERS_FROM_Z_FILE": {
@@ -515,7 +538,7 @@
          "datatype": "logical",
          "units": "Boolean",
          "value": {
-            "$RUN_TYPE != \"hybrid\" and $OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\", \"tx0.25v1\"]": true,
+            "$RUN_TYPE != \"hybrid\" and $OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\", \"tx2_0v1\", \"tx0.25v1\"]": true,
             "else": false
          }
       },
@@ -524,6 +547,7 @@
          "datatype": "string",
          "value": {
             "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": "woa18_04_initial_conditions.nc",
+            "$OCN_GRID == \"tx2_0v1\"": "woa18_04_initial_conditions.nc",
             "$OCN_GRID == \"tx0.25v1\"": "MOM6_IC_TS.nc"
          }
       },
@@ -532,6 +556,7 @@
          "datatype": "string",
          "value": {
             "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": "theta0",
+            "$OCN_GRID == \"tx2_0v1\"": "theta0",
             "$OCN_GRID == \"tx0.25v1\"": "temp"
          }
       },
@@ -539,7 +564,8 @@
          "description": "\"default = 'salt'\nThe name of the salinity variable in\nTEMP_SALT_Z_INIT_FILE.\"\n",
          "datatype": "string",
          "value": {
-            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": "s_an"
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": "s_an",
+            "$OCN_GRID == \"tx2_0v1\"": "s_an"
          }
       },
       "Z_INIT_REMAP_OLD_ALG": {
@@ -553,7 +579,8 @@
          "datatype": "logical",
          "units": "Boolean",
          "value": {
-            "$MOM6_VERTICAL_GRID == \"hycom1\" and $OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": true
+            "$MOM6_VERTICAL_GRID == \"hycom1\" and $OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": true,
+            "$MOM6_VERTICAL_GRID == \"hycom1\" and $OCN_GRID == \"tx2_0v1\"": true
          }
       },
       "USE_VARIABLE_MIXING": {
@@ -562,6 +589,7 @@
          "units": "Boolean",
          "value": {
             "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": true,
+            "$OCN_GRID == \"tx2_0v1\"": true,
             "$OCN_GRID == \"tx0.25v1\"": true
          }
       },
@@ -571,6 +599,7 @@
          "units": "Boolean",
          "value": {
             "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": false,
+            "$OCN_GRID == \"tx2_0v1\"": false,
             "$OCN_GRID == \"tx0.25v1\"": true
          }
       },
@@ -579,7 +608,8 @@
          "datatype": "real",
          "units": "nondim",
          "value": {
-            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 0.01
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 0.01,
+            "$OCN_GRID == \"tx2_0v1\"": 0.01
          }
       },
       "DEPTH_SCALED_KHTH": {
@@ -588,6 +618,7 @@
          "units": "Boolean",
          "value": {
             "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": true,
+            "$OCN_GRID == \"tx2_0v1\"": true,
             "$OCN_GRID == \"tx0.25v1\"": false
          }
       },
@@ -596,7 +627,8 @@
          "datatype": "real",
          "units": "nondim",
          "value": {
-            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 500.0
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 500.0,
+            "$OCN_GRID == \"tx2_0v1\"": 500.0
          }
       },
       "KHTR_SLOPE_CFF": {
@@ -612,7 +644,8 @@
          "datatype": "logical",
          "units": "Boolean",
          "value": {
-            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": true
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": true,
+            "$OCN_GRID == \"tx2_0v1\"": true
          }
       },
       "RESOLN_SCALED_KHTH": {
@@ -621,6 +654,7 @@
          "units": "Boolean",
          "value": {
             "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": true,
+            "$OCN_GRID == \"tx2_0v1\"": true,
             "$OCN_GRID == \"tx0.25v1\"": true
          }
       },
@@ -629,7 +663,8 @@
          "datatype": "logical",
          "units": "Boolean",
          "value": {
-            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": true
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": true,
+            "$OCN_GRID == \"tx2_0v1\"": true
          }
       },
       "USE_GM_WORK_BUG": {
@@ -644,6 +679,7 @@
          "units": "Boolean",
          "value": {
             "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": true,
+            "$OCN_GRID == \"tx2_0v1\"": true,
             "$OCN_GRID == \"tx0.25v1\"": true
          }
       },
@@ -652,7 +688,8 @@
          "datatype": "logical",
          "units": "Boolean",
          "value": {
-            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": false
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": false,
+            "$OCN_GRID == \"tx2_0v1\"": false
          }
       },
       "ETA_TOLERANCE": {
@@ -677,7 +714,8 @@
          "datatype": "logical",
          "units": "Boolean",
          "value": {
-            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": true
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": true,
+            "$OCN_GRID == \"tx2_0v1\"": true
          }
       },
       "NDIFF_INTERIOR_ONLY": {
@@ -685,7 +723,8 @@
          "datatype": "logical",
          "units": "Boolean",
          "value": {
-            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": true
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": true,
+            "$OCN_GRID == \"tx2_0v1\"": true
          }
       },
       "NDIFF_TAPERING": {
@@ -693,7 +732,8 @@
          "datatype": "logical",
          "units": "Boolean",
          "value": {
-            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": true
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": true,
+            "$OCN_GRID == \"tx2_0v1\"": true
          }
       },
       "USE_HORIZONTAL_BOUNDARY_DIFFUSION": {
@@ -701,7 +741,8 @@
          "datatype": "logical",
          "units": "Boolean",
          "value": {
-            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": true
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": true,
+            "$OCN_GRID == \"tx2_0v1\"": true
          }
       },
       "HBD_LINEAR_TRANSITION": {
@@ -709,7 +750,8 @@
          "datatype": "logical",
          "units": "Boolean",
          "value": {
-            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": true
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": true,
+            "$OCN_GRID == \"tx2_0v1\"": true
          }
       },
       "SIMPLE_TKE_TO_KD": {
@@ -718,6 +760,7 @@
          "units": "Boolean",
          "value": {
             "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": true,
+            "$OCN_GRID == \"tx2_0v1\"": true,
             "$OCN_GRID == \"tx0.25v1\"": true
          }
       },
@@ -753,6 +796,7 @@
          "datatype": "string",
          "value": {
             "$MOM6_VERTICAL_GRID == \"hycom1\" and $OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": "'\"FILE:${DIN_LOC_ROOT}/ocn/mom/grid_indpt/lev-2025-09-12.nc,Z\"'\n",
+            "$MOM6_VERTICAL_GRID == \"hycom1\" and $OCN_GRID == \"tx2_0v1\"": "'\"FILE:${DIN_LOC_ROOT}/ocn/mom/grid_indpt/lev-2025-09-12.nc,Z\"'\n",
             "$MOM6_VERTICAL_GRID == \"hycom1\" and $OCN_GRID == \"tx0.25v1\"": "\"FNC1:5,8000.0,1.0,.01\""
          }
       },
@@ -761,6 +805,7 @@
          "datatype": "string",
          "value": {
             "$MOM6_VERTICAL_GRID == \"hycom1\" and $OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": "'\"FILE:${DIN_LOC_ROOT}/ocn/mom/grid_indpt/dz_max-2025-09-12.nc,dz\"'\n",
+            "$MOM6_VERTICAL_GRID == \"hycom1\" and $OCN_GRID == \"tx2_0v1\"": "'\"FILE:${DIN_LOC_ROOT}/ocn/mom/grid_indpt/dz_max-2025-09-12.nc,dz\"'\n",
             "else": "\"FNC1:400,31000.0,0.1,.01\""
          }
       },
@@ -787,7 +832,8 @@
          "datatype": "logical",
          "units": "Boolean",
          "value": {
-            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": true
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": true,
+            "$OCN_GRID == \"tx2_0v1\"": true
          }
       },
       "LAPLACIAN": {
@@ -801,7 +847,8 @@
          "datatype": "logical",
          "units": "Boolean",
          "value": {
-            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": false
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": false,
+            "$OCN_GRID == \"tx2_0v1\"": false
          }
       },
       "SMAG_LAP_CONST": {
@@ -809,7 +856,8 @@
          "datatype": "real",
          "units": "nondim",
          "value": {
-            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 0.15
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 0.15,
+            "$OCN_GRID == \"tx2_0v1\"": 0.15
          }
       },
       "KH": {
@@ -828,6 +876,7 @@
             "$OCN_GRID == \"MISOMIP\"": 0.0,
             "$OCN_GRID == \"tx0.25v1\"": 0.0,
             "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 0.0,
+            "$OCN_GRID == \"tx2_0v1\"": 0.0,
             "else": 0.01
          }
       },
@@ -836,7 +885,8 @@
          "datatype": "real",
          "units": "m2 s-1",
          "value": {
-            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 0.0
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 0.0,
+            "$OCN_GRID == \"tx2_0v1\"": 0.0
          }
       },
       "BIHARMONIC": {
@@ -845,6 +895,7 @@
          "units": "Boolean",
          "value": {
             "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": true,
+            "$OCN_GRID == \"tx2_0v1\"": true,
             "$OCN_GRID == \"MISOMIP\"": false
          }
       },
@@ -853,7 +904,8 @@
          "datatype": "real",
          "units": "m4 s-1",
          "value": {
-            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 1000000000000.0
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 1000000000000.0,
+            "$OCN_GRID == \"tx2_0v1\"": 1000000000000.0
          }
       },
       "AH_VEL_SCALE": {
@@ -870,7 +922,8 @@
          "datatype": "logical",
          "units": "Boolean",
          "value": {
-            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": true
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": true,
+            "$OCN_GRID == \"tx2_0v1\"": true
          }
       },
       "LEITH_AH": {
@@ -878,7 +931,8 @@
          "datatype": "logical",
          "units": "Boolean",
          "value": {
-            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": false
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": false,
+            "$OCN_GRID == \"tx2_0v1\"": false
          }
       },
       "LEITH_BI_CONST": {
@@ -886,7 +940,8 @@
          "datatype": "real",
          "units": "nondim",
          "value": {
-            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 85.0
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 85.0,
+            "$OCN_GRID == \"tx2_0v1\"": 85.0
          }
       },
       "LEITHY_CK": {
@@ -894,7 +949,8 @@
          "datatype": "real",
          "units": "nondim",
          "value": {
-            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 1.0
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 1.0,
+            "$OCN_GRID == \"tx2_0v1\"": 1.0
          }
       },
       "TAPER_LEITHY": {
@@ -902,7 +958,8 @@
          "datatype": "logical",
          "units": "Boolean",
          "value": {
-            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": true
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": true,
+            "$OCN_GRID == \"tx2_0v1\"": true
          }
       },
       "LEITHY_DEPTH": {
@@ -910,7 +967,8 @@
          "datatype": "real",
          "units": "m",
          "value": {
-            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 1000.0
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 1000.0,
+            "$OCN_GRID == \"tx2_0v1\"": 1000.0
          }
       },
       "LEITHY_WIDTH": {
@@ -918,7 +976,8 @@
          "datatype": "real",
          "units": "m",
          "value": {
-            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 500.0
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 500.0,
+            "$OCN_GRID == \"tx2_0v1\"": 500.0
          }
       },
       "USE_LAND_MASK_FOR_HVISC": {
@@ -932,7 +991,8 @@
          "datatype": "logical",
          "units": "Boolean",
          "value": {
-            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": true
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": true,
+            "$OCN_GRID == \"tx2_0v1\"": true
          }
       },
       "KH_BG_2D_FILENAME": {
@@ -940,14 +1000,16 @@
          "datatype": "string",
          "value": {
             "$OCN_GRID == \"tx2_3v2\"": "KH_BG_2D_tx2_3v2_260427.nc",
-            "$OCN_GRID == \"tx2_3v3\"": "KH_BG_2D_tx2_3v3_260427.nc"
+            "$OCN_GRID == \"tx2_3v3\"": "KH_BG_2D_tx2_3v3_260427.nc",
+            "$OCN_GRID == \"tx2_0v1\"": "KH_BG_2D_tx2_0v1_260528.nc"
          }
       },
       "KH_BG_2D_VARNAME": {
          "description": "\"default = 'Kh'\nThe name in the input file of the horizontal viscosity variable.\"\n",
          "datatype": "string",
          "value": {
-            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": "KH"
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": "KH",
+            "$OCN_GRID == \"tx2_0v1\"": "KH"
          }
       },
       "FRICTWORK_BUG": {
@@ -979,7 +1041,8 @@
          "datatype": "real",
          "units": "m",
          "value": {
-            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 5.0
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 5.0,
+            "$OCN_GRID == \"tx2_0v1\"": 5.0
          }
       },
       "HBBL": {
@@ -994,6 +1057,7 @@
          "units": "nondim",
          "value": {
             "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 1.0,
+            "$OCN_GRID == \"tx2_0v1\"": 1.0,
             "$OCN_GRID == \"tx0.25v1\"": 1.25
          }
       },
@@ -1021,7 +1085,8 @@
          "datatype": "real",
          "units": "s",
          "value": {
-            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 7200.0
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 7200.0,
+            "$OCN_GRID == \"tx2_0v1\"": 7200.0
          }
       },
       "Z_INIT_ALE_REMAPPING": {
@@ -1030,6 +1095,7 @@
          "units": "Boolean",
          "value": {
             "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": true,
+            "$OCN_GRID == \"tx2_0v1\"": true,
             "$OCN_GRID == \"tx0.25v1\"": true
          }
       },
@@ -1038,6 +1104,7 @@
          "datatype": "integer",
          "value": {
             "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 2,
+            "$OCN_GRID == \"tx2_0v1\"": 1,
             "$OCN_GRID == \"tx0.25v1\"": 1
          }
       },
@@ -1046,6 +1113,7 @@
          "datatype": "string",
          "value": {
             "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": "\"z Z ZSTAR\", \"rho2 RHO2 RHO\"",
+            "$OCN_GRID == \"tx2_0v1\"": "\"z Z ZSTAR\"",
             "$OCN_GRID == \"tx0.25v1\"": "\"z Z ZSTAR\""
          }
       },
@@ -1069,6 +1137,7 @@
          "units": "Boolean",
          "value": {
             "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": true,
+            "$OCN_GRID == \"tx2_0v1\"": true,
             "else": false
          }
       },
@@ -1078,6 +1147,7 @@
          "units": "Boolean",
          "value": {
             "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": true,
+            "$OCN_GRID == \"tx2_0v1\"": true,
             "$OCN_GRID == \"tx0.25v1\"": true
          }
       },
@@ -1087,6 +1157,7 @@
          "units": "m s-1",
          "value": {
             "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 0.1,
+            "$OCN_GRID == \"tx2_0v1\"": 0.1,
             "$OCN_GRID == \"tx0.25v1\"": 0.1
          }
       },
@@ -1110,7 +1181,8 @@
          "datatype": "logical",
          "units": "Boolean",
          "value": {
-            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": true
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": true,
+            "$OCN_GRID == \"tx2_0v1\"": true
          }
       },
       "BOUND_BT_CORRECTION": {
@@ -1125,6 +1197,7 @@
          "units": "Boolean",
          "value": {
             "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": true,
+            "$OCN_GRID == \"tx2_0v1\"": true,
             "$OCN_GRID == \"tx0.25v1\"": true
          }
       },
@@ -1164,7 +1237,8 @@
          "datatype": "real",
          "units": "m",
          "value": {
-            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 1.0
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 1.0,
+            "$OCN_GRID == \"tx2_0v1\"": 1.0
          }
       },
       "MAX_P_SURF": {
@@ -1181,6 +1255,7 @@
          "units": "m2 s-1",
          "value": {
             "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 0.0,
+            "$OCN_GRID == \"tx2_0v1\"": 0.0,
             "$OCN_GRID == \"MISOMIP\"": 0.0
          }
       },
@@ -1189,7 +1264,8 @@
          "datatype": "real",
          "units": "m2 s-1",
          "value": {
-            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 50.0
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 50.0,
+            "$OCN_GRID == \"tx2_0v1\"": 50.0
          }
       },
       "FULL_DEPTH_KHTH_MIN": {
@@ -1197,7 +1273,8 @@
          "datatype": "logical",
          "units": "Boolean",
          "value": {
-            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": true
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": true,
+            "$OCN_GRID == \"tx2_0v1\"": true
          }
       },
       "KHTH_MAX_CFL": {
@@ -1213,7 +1290,8 @@
          "datatype": "logical",
          "units": "Boolean",
          "value": {
-            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": true
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": true,
+            "$OCN_GRID == \"tx2_0v1\"": true
          }
       },
       "STANLEY_COEFF": {
@@ -1221,7 +1299,8 @@
          "datatype": "real",
          "units": "nondimensional",
          "value": {
-            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 0.5
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 0.5,
+            "$OCN_GRID == \"tx2_0v1\"": 0.5
          }
       },
       "USE_KH_IN_MEKE": {
@@ -1229,7 +1308,8 @@
          "datatype": "logical",
          "units": "Boolean",
          "value": {
-            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": true
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": true,
+            "$OCN_GRID == \"tx2_0v1\"": true
          }
       },
       "KHTH_USE_FGNV_STREAMFUNCTION": {
@@ -1237,7 +1317,8 @@
          "datatype": "logical",
          "units": "Boolean",
          "value": {
-            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": true
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": true,
+            "$OCN_GRID == \"tx2_0v1\"": true
          }
       },
       "FGNV_C_MIN": {
@@ -1245,7 +1326,8 @@
          "datatype": "real",
          "units": "m s-1",
          "value": {
-            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 0.01
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 0.01,
+            "$OCN_GRID == \"tx2_0v1\"": 0.01
          }
       },
       "USE_STANLEY_GM": {
@@ -1253,7 +1335,8 @@
          "datatype": "logical",
          "units": "Boolean",
          "value": {
-            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": false
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": false,
+            "$OCN_GRID == \"tx2_0v1\"": false
          }
       },
       "MIXEDLAYER_RESTRAT": {
@@ -1270,7 +1353,8 @@
          "datatype": "bool",
          "units": "none",
          "value": {
-            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": true
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": true,
+            "$OCN_GRID == \"tx2_0v1\"": true
          }
       },
       "MLE_FRONT_LENGTH": {
@@ -1279,6 +1363,7 @@
          "units": "m",
          "value": {
             "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 1000.0,
+            "$OCN_GRID == \"tx2_0v1\"": 1000.0,
             "$OCN_GRID == \"tx0.25v1\"": 500.0
          }
       },
@@ -1288,6 +1373,7 @@
          "units": "s",
          "value": {
             "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 345600.0,
+            "$OCN_GRID == \"tx2_0v1\"": 345600.0,
             "$OCN_GRID == \"tx0.25v1\"": 2592000.0
          }
       },
@@ -1296,7 +1382,8 @@
          "datatype": "logical",
          "units": "Boolean",
          "value": {
-            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": true
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": true,
+            "$OCN_GRID == \"tx2_0v1\"": true
          }
       },
       "USE_CVMix_CONVECTION": {
@@ -1304,7 +1391,8 @@
          "datatype": "logical",
          "units": "Boolean",
          "value": {
-            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": true
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": true,
+            "$OCN_GRID == \"tx2_0v1\"": true
          }
       },
       "BBL_MIXING_AS_MAX": {
@@ -1313,6 +1401,7 @@
          "units": "Boolean",
          "value": {
             "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": false,
+            "$OCN_GRID == \"tx2_0v1\"": false,
             "$OCN_GRID == \"tx0.25v1\"": false
          }
       },
@@ -1322,6 +1411,7 @@
          "units": "Boolean",
          "value": {
             "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": true,
+            "$OCN_GRID == \"tx2_0v1\"": true,
             "$OCN_GRID == \"tx0.25v1\"": true
          }
       },
@@ -1331,6 +1421,7 @@
          "units": "m2 s-1",
          "value": {
             "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 0.1,
+            "$OCN_GRID == \"tx2_0v1\"": 0.1,
             "$OCN_GRID == \"tx0.25v1\"": 0.1
          }
       },
@@ -1340,6 +1431,7 @@
          "units": "Boolean",
          "value": {
             "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": true,
+            "$OCN_GRID == \"tx2_0v1\"": true,
             "$OCN_GRID == \"tx0.25v1\"": true
          }
       },
@@ -1349,6 +1441,7 @@
          "units": "m2 s-1",
          "value": {
             "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 1e-07,
+            "$OCN_GRID == \"tx2_0v1\"": 1e-07,
             "$OCN_GRID == \"tx0.25v1\"": 1.5e-05,
             "$OCN_GRID == \"MISOMIP\"": 5e-05,
             "else": 2e-05
@@ -1376,6 +1469,7 @@
          "units": "m2 s-1",
          "value": {
             "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 1e-07,
+            "$OCN_GRID == \"tx2_0v1\"": 1e-07,
             "else": 2e-06
          }
       },
@@ -1438,7 +1532,8 @@
          "datatype": "logical",
          "units": "Boolean",
          "value": {
-            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": true
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": true,
+            "$OCN_GRID == \"tx2_0v1\"": true
          }
       },
       "USE_CVMix_TIDAL": {
@@ -1446,7 +1541,8 @@
          "datatype": "logical",
          "units": "Boolean",
          "value": {
-            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": true
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": true,
+            "$OCN_GRID == \"tx2_0v1\"": true
          }
       },
       "INT_TIDE_DISSIPATION": {
@@ -1455,6 +1551,7 @@
          "units": "Boolean",
          "value": {
             "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": true,
+            "$OCN_GRID == \"tx2_0v1\"": true,
             "$OCN_GRID == \"tx0.25v1\"": true
          }
       },
@@ -1470,14 +1567,16 @@
          "datatype": "string",
          "value": {
             "$OCN_GRID == \"tx2_3v2\"": "energy_new_tx2_3_conserve_230415_cdf5.nc",
-            "$OCN_GRID == \"tx2_3v3\"": "tidal_energy_tx2_3v3_conserve_260306.nc"
+            "$OCN_GRID == \"tx2_3v3\"": "tidal_energy_tx2_3v3_conserve_260306.nc",
+            "$OCN_GRID == \"tx2_0v1\"": "tidal_energy_tx2_0v1_conserve_260528.nc"
          }
       },
       "TIDAL_ENERGY_TYPE": {
          "description": "\"The type of input tidal energy flux dataset. Valid values are   Jayne\nER03\"\n",
          "datatype": "string",
          "value": {
-            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": "Jayne"
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": "Jayne",
+            "$OCN_GRID == \"tx2_0v1\"": "Jayne"
          }
       },
       "USE_LMD94": {
@@ -1485,7 +1584,8 @@
          "datatype": "logical",
          "units": "Boolean",
          "value": {
-            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": true
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": true,
+            "$OCN_GRID == \"tx2_0v1\"": true
          }
       },
       "NU_ZERO": {
@@ -1493,7 +1593,8 @@
          "datatype": "real",
          "units": "m2 s-1",
          "value": {
-            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 0.0025
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 0.0025,
+            "$OCN_GRID == \"tx2_0v1\"": 0.0025
          }
       },
       "RI_ZERO": {
@@ -1501,7 +1602,8 @@
          "datatype": "real",
          "units": "nondim",
          "value": {
-            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 0.5
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 0.5,
+            "$OCN_GRID == \"tx2_0v1\"": 0.5
          }
       },
       "N_SMOOTH_RI": {
@@ -1509,7 +1611,8 @@
          "datatype": "integer",
          "units": "nondim",
          "value": {
-            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 1
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 1,
+            "$OCN_GRID == \"tx2_0v1\"": 1
          }
       },
       "USE_CVMIX_DDIFF": {
@@ -1517,7 +1620,8 @@
          "datatype": "logical",
          "units": "Boolean",
          "value": {
-            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": true
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": true,
+            "$OCN_GRID == \"tx2_0v1\"": true
          }
       },
       "MAX_ENT_IT": {
@@ -1534,6 +1638,7 @@
          "units": "m",
          "value": {
             "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 1e-05,
+            "$OCN_GRID == \"tx2_0v1\"": 1e-05,
             "$OCN_GRID == \"MISOMIP\"": 1e-08
          }
       },
@@ -1552,7 +1657,8 @@
          "datatype": "logical",
          "units": "Boolean",
          "value": {
-            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": true
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": true,
+            "$OCN_GRID == \"tx2_0v1\"": true
          }
       },
       "MSTAR_MODE": {
@@ -1729,7 +1835,8 @@
          "units": "Boolean",
          "value": {
             "$OCN_GRID == \"tx0.25v1\"": true,
-            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": true
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": true,
+            "$OCN_GRID == \"tx2_0v1\"": true
          }
       },
       "CHL_FILE": {
@@ -1738,7 +1845,8 @@
          "value": {
             "$OCN_GRID == \"tx0.25v1\"": "seawifs-clim-1997-2010.1440x1080.v20180328.nc",
             "$OCN_GRID == \"tx2_3v2\"": "seawifs-clim-1997-2010-tx2_3v2.230416.nc",
-            "$OCN_GRID == \"tx2_3v3\"": "seawifs-clim-1997-2010-tx2_3v3_260305.nc"
+            "$OCN_GRID == \"tx2_3v3\"": "seawifs-clim-1997-2010-tx2_3v3_260305.nc",
+            "$OCN_GRID == \"tx2_0v1\"": "seawifs-clim-1997-2010-tx2_0v1_260528.nc"
          }
       },
       "CHL_VARNAME": {
@@ -1753,14 +1861,16 @@
          "datatype": "integer",
          "value": {
             "$OCN_GRID == \"tx0.25v1\"": 3,
-            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 2
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 2,
+            "$OCN_GRID == \"tx2_0v1\"": 2
          }
       },
       "OPACITY_SCHEME": {
          "description": "\"default = 'MANIZZA_05'\nThis character string specifies how chlorophyll concentrations are translated\ninto opacities. Currently valid options include:\n       MANIZZA_05 - Use Manizza et al., GRL, 2005.\n       MOREL_88 - Use Morel, JGR, 1988.\n       OHLMANN_03 - Use Ohlmann, J Clim, 2003.\"\n",
          "datatype": "string",
          "value": {
-            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": "OHLMANN_03"
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": "OHLMANN_03",
+            "$OCN_GRID == \"tx2_0v1\"": "OHLMANN_03"
          }
       },
       "TRACER_ADVECTION_SCHEME": {
@@ -1768,6 +1878,7 @@
          "datatype": "string",
          "value": {
             "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": "\"PPM:H3\"",
+            "$OCN_GRID == \"tx2_0v1\"": "\"PPM:H3\"",
             "$OCN_GRID == \"tx0.25v1\"": "\"PPM:H3\""
          }
       },
@@ -1776,7 +1887,8 @@
          "datatype": "logical",
          "units": "Boolean",
          "value": {
-            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": true
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": true,
+            "$OCN_GRID == \"tx2_0v1\"": true
          }
       },
       "KHTR": {
@@ -1792,7 +1904,8 @@
          "datatype": "real",
          "units": "m2 s-1",
          "value": {
-            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 50.0
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 50.0,
+            "$OCN_GRID == \"tx2_0v1\"": 50.0
          }
       },
       "FULL_DEPTH_KHTR_MIN": {
@@ -1800,7 +1913,8 @@
          "datatype": "logical",
          "units": "Boolean",
          "value": {
-            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": true
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": true,
+            "$OCN_GRID == \"tx2_0v1\"": true
          }
       },
       "DEBUG": {
@@ -1815,6 +1929,7 @@
          "units": "Boolean",
          "value": {
             "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": true,
+            "$OCN_GRID == \"tx2_0v1\"": true,
             "$OCN_GRID == \"tx0.25v1\"": true
          }
       },
@@ -1823,7 +1938,8 @@
          "datatype": "real",
          "units": "nondim",
          "value": {
-            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 2.0
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 2.0,
+            "$OCN_GRID == \"tx2_0v1\"": 2.0
          }
       },
       "MAXTRUNC": {
@@ -1833,6 +1949,7 @@
          "value": {
             "$OCN_GRID == \"tx0.25v1\"": 100000,
             "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 1000000,
+            "$OCN_GRID == \"tx2_0v1\"": 100000,
             "else": 0
          }
       },
@@ -1841,6 +1958,7 @@
          "datatype": "string",
          "value": {
             "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": "A",
+            "$OCN_GRID == \"tx2_0v1\"": "A",
             "$OCN_GRID == \"tx0.25v1\"": "A"
          }
       },
@@ -1850,6 +1968,7 @@
          "units": "Boolean",
          "value": {
             "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"] and $COMP_ATM == \"datm\"": true,
+            "$OCN_GRID == \"tx2_0v1\" and $COMP_ATM == \"datm\"": true,
             "else": false
          }
       },
@@ -1869,7 +1988,8 @@
          "datatype": "real",
          "units": "m day-1",
          "value": {
-            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 0.1667
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 0.1667,
+            "$OCN_GRID == \"tx2_0v1\"": 0.1667
          }
       },
       "SALT_RESTORE_FILE": {
@@ -1877,7 +1997,8 @@
          "datatype": "string",
          "value": {
             "$OCN_GRID == \"tx2_3v2\"": "state_restore_tx2_3_20230416.nc",
-            "$OCN_GRID == \"tx2_3v3\"": "state_restore_tx2_3v3_260305.nc"
+            "$OCN_GRID == \"tx2_3v3\"": "state_restore_tx2_3v3_260305.nc",
+            "$OCN_GRID == \"tx2_0v1\"": "state_restore_tx2_0v1_260528.nc"
          }
       },
       "ADJUST_NET_FRESH_WATER_TO_ZERO": {
@@ -1894,7 +2015,8 @@
          "datatype": "real",
          "units": "PSU or g kg-1",
          "value": {
-            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 5.0
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 5.0,
+            "$OCN_GRID == \"tx2_0v1\"": 5.0
          }
       },
       "SRESTORE_AS_SFLUX": {
@@ -1902,7 +2024,8 @@
          "datatype": "logical",
          "units": "Boolean",
          "value": {
-            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": true
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": true,
+            "$OCN_GRID == \"tx2_0v1\"": true
          }
       },
       "GUST_CONST": {
@@ -1940,6 +2063,7 @@
          "units": "days",
          "value": {
             "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 1.0,
+            "$OCN_GRID == \"tx2_0v1\"": 1.0,
             "$OCN_GRID == \"tx0.25v1\"": 0.25,
             "$OCN_GRID == \"MISOMIP\"": 1.0
          }
@@ -1959,7 +2083,8 @@
          "units": "Boolean",
          "value": {
             "$OCN_GRID == \"tx0.25v1\"": true,
-            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": true
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": true,
+            "$OCN_GRID == \"tx2_0v1\"": true
          }
       },
       "MEKE_GMCOEFF": {
@@ -1968,7 +2093,8 @@
          "units": "nondim",
          "value": {
             "$OCN_GRID == \"tx0.25v1\"": 1.0,
-            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 0.25
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 0.25,
+            "$OCN_GRID == \"tx2_0v1\"": 0.25
          }
       },
       "MEKE_BGSRC": {
@@ -1985,7 +2111,8 @@
          "units": "nondim",
          "value": {
             "$OCN_GRID == \"tx0.25v1\"": 1.0,
-            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 0.75
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 0.75,
+            "$OCN_GRID == \"tx2_0v1\"": 0.75
          }
       },
       "MEKE_VISCOSITY_COEFF_KU": {
@@ -1993,7 +2120,8 @@
          "datatype": "real",
          "units": "nondim",
          "value": {
-            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 0.0
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 0.0,
+            "$OCN_GRID == \"tx2_0v1\"": 0.0
          }
       },
       "MEKE_MIN_LSCALE": {
@@ -2001,7 +2129,8 @@
          "datatype": "logical",
          "units": "Boolean",
          "value": {
-            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": true
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": true,
+            "$OCN_GRID == \"tx2_0v1\"": true
          }
       },
       "MEKE_ALPHA_RHINES": {
@@ -2018,7 +2147,8 @@
          "units": "nondim",
          "value": {
             "$OCN_GRID == \"tx0.25v1\"": 0.15,
-            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 1.0
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 1.0,
+            "$OCN_GRID == \"tx2_0v1\"": 1.0
          }
       },
       "MEKE_FRCOEFF": {
@@ -2026,7 +2156,8 @@
          "datatype": "real",
          "units": "nondim",
          "value": {
-            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 0.3
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 0.3,
+            "$OCN_GRID == \"tx2_0v1\"": 0.3
          }
       },
       "MEKE_CT": {
@@ -2034,7 +2165,8 @@
          "datatype": "real",
          "units": "nondim",
          "value": {
-            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 0.0
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 0.0,
+            "$OCN_GRID == \"tx2_0v1\"": 0.0
          }
       },
       "MEKE_POSITIVE": {
@@ -2042,7 +2174,8 @@
          "datatype": "logical",
          "units": "Boolean",
          "value": {
-            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": true
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": true,
+            "$OCN_GRID == \"tx2_0v1\"": true
          }
       },
       "USE_SIMPLER_EADY_GROWTH_RATE": {
@@ -2050,7 +2183,8 @@
          "datatype": "logical",
          "units": "Boolean",
          "value": {
-            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": true
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": true,
+            "$OCN_GRID == \"tx2_0v1\"": true
          }
       },
       "KH_RES_SCALE_COEF": {
@@ -2058,7 +2192,8 @@
          "datatype": "real",
          "units": "nondim",
          "value": {
-            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 0.5
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 0.5,
+            "$OCN_GRID == \"tx2_0v1\"": 0.5
          }
       },
       "KH_RES_FN_POWER": {
@@ -2066,7 +2201,8 @@
          "datatype": "integer",
          "units": "nondim",
          "value": {
-            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 6
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 6,
+            "$OCN_GRID == \"tx2_0v1\"": 6
          }
       },
       "VISC_RES_SCALE_COEF": {
@@ -2074,7 +2210,8 @@
          "datatype": "real",
          "units": "nondim",
          "value": {
-            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 0.5
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 0.5,
+            "$OCN_GRID == \"tx2_0v1\"": 0.5
          }
       },
       "MEKE_GEOMETRIC": {
@@ -2082,7 +2219,8 @@
          "datatype": "logical",
          "units": "Boolean",
          "value": {
-            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": true
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": true,
+            "$OCN_GRID == \"tx2_0v1\"": true
          }
       },
       "MEKE_GEOMETRIC_ALPHA": {
@@ -2090,7 +2228,8 @@
          "datatype": "real",
          "units": "nondim",
          "value": {
-            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 0.07
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 0.07,
+            "$OCN_GRID == \"tx2_0v1\"": 0.07
          }
       },
       "MEKE_KHTH_FAC": {
@@ -2098,7 +2237,8 @@
          "datatype": "real",
          "units": "nondim",
          "value": {
-            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 1.0
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 1.0,
+            "$OCN_GRID == \"tx2_0v1\"": 1.0
          }
       },
       "MEKE_KHTR_FAC": {
@@ -2106,7 +2246,8 @@
          "datatype": "real",
          "units": "nondim",
          "value": {
-            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 1.0
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 1.0,
+            "$OCN_GRID == \"tx2_0v1\"": 1.0
          }
       },
       "MEKE_CB": {
@@ -2114,7 +2255,8 @@
          "datatype": "real",
          "units": "nondim",
          "value": {
-            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 100.0
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 100.0,
+            "$OCN_GRID == \"tx2_0v1\"": 100.0
          }
       },
       "MEKE_CDRAG": {
@@ -2122,7 +2264,8 @@
          "datatype": "real",
          "units": "nondim",
          "value": {
-            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 0.0025
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 0.0025,
+            "$OCN_GRID == \"tx2_0v1\"": 0.0025
          }
       },
       "MEKE_MIN_GAMMA2": {
@@ -2130,7 +2273,8 @@
          "datatype": "real",
          "units": "nondim",
          "value": {
-            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 1e-05
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 1e-05,
+            "$OCN_GRID == \"tx2_0v1\"": 1e-05
          }
       },
       "MEKE_EQUILIBRIUM_ALT": {
@@ -2138,7 +2282,8 @@
          "datatype": "logical",
          "units": "Boolean",
          "value": {
-            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": true
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": true,
+            "$OCN_GRID == \"tx2_0v1\"": true
          }
       },
       "MEKE_VISC_DRAG": {
@@ -2146,7 +2291,8 @@
          "datatype": "logical",
          "units": "Boolean",
          "value": {
-            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": false
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": false,
+            "$OCN_GRID == \"tx2_0v1\"": false
          }
       },
       "MEKE_EQUILIBRIUM_RESTORING": {
@@ -2154,7 +2300,8 @@
          "datatype": "logical",
          "units": "Boolean",
          "value": {
-            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": false
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": false,
+            "$OCN_GRID == \"tx2_0v1\"": false
          }
       },
       "MEKE_ADVECTION_FACTOR": {
@@ -2162,7 +2309,8 @@
          "datatype": "real",
          "units": "nondim",
          "value": {
-            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 1.0
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 1.0,
+            "$OCN_GRID == \"tx2_0v1\"": 1.0
          }
       },
       "DIAG_COORD_DEF_Z": {
@@ -2185,7 +2333,8 @@
          "datatype": "string",
          "value": {
             "$OCN_GRID == \"tx0.25v1\"": "list",
-            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": "list"
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": "list",
+            "$OCN_GRID == \"tx2_0v1\"": "list"
          }
       },
       "CHANNEL_LIST_FILE": {
@@ -2194,7 +2343,8 @@
          "value": {
             "$OCN_GRID == \"tx0.25v1\"": "MOM_channels_global_025",
             "$OCN_GRID == \"tx2_3v2\"": "channels_tx2_3v2_250107.txt",
-            "$OCN_GRID == \"tx2_3v3\"": "channels_tx2_3v3_260304.txt"
+            "$OCN_GRID == \"tx2_3v3\"": "channels_tx2_3v3_260304.txt",
+            "$OCN_GRID == \"tx2_0v1\"": "channels_tx2_0v1_260518.txt"
          }
       },
       "SMAG_BI_CONST": {
@@ -2248,7 +2398,8 @@
          "datatype": "real",
          "units": "PPT",
          "value": {
-            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"] or $COMP_ATM == \"cam\"": 75.0
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"] or $COMP_ATM == \"cam\"": 75.0,
+            "$OCN_GRID == \"tx2_0v1\" or $COMP_ATM == \"cam\"": 75.0
          }
       },
       "BAD_VAL_SST_MAX": {
@@ -2265,6 +2416,7 @@
          "units": "degC",
          "value": {
             "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": -3.0,
+            "$OCN_GRID == \"tx2_0v1\"": -3.0,
             "$OCN_GRID == \"tx0.25v1\"": -3.0
          }
       },
@@ -2304,6 +2456,7 @@
          "units": "Boolean",
          "value": {
             "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": true,
+            "$OCN_GRID == \"tx2_0v1\"": true,
             "$OCN_GRID == \"tx0.25v1\"": true,
             "else": false
          }
@@ -2552,7 +2705,8 @@
          "datatype": "logical",
          "units": "Boolean",
          "value": {
-            "$MOM6_VERTICAL_GRID == \"hycom1\" and $OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": true
+            "$MOM6_VERTICAL_GRID == \"hycom1\" and $OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": true,
+            "$MOM6_VERTICAL_GRID == \"hycom1\" and $OCN_GRID == \"tx2_0v1\"": true
          }
       },
       "ISOMIP_TNUDG": {
@@ -2683,6 +2837,7 @@
          "units": "m2 s-1",
          "value": {
             "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 1e-06,
+            "$OCN_GRID == \"tx2_0v1\"": 1e-06,
             "else": 0.0001
          }
       },
@@ -2757,7 +2912,8 @@
          "units": "nondim",
          "value": {
             "$OCN_GRID == \"MISOMIP\"": 0.0,
-            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 0.01
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 0.01,
+            "$OCN_GRID == \"tx2_0v1\"": 0.01
          }
       },
       "IGNORE_FLUXES_OVER_LAND": {
@@ -2988,6 +3144,7 @@
          "units": "W m-2 or various",
          "value": {
             "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 1.0,
+            "$OCN_GRID == \"tx2_0v1\"": 1.0,
             "$OCN_GRID == \"tx0.25v1\"": 1.0
          }
       },
@@ -2997,6 +3154,7 @@
          "value": {
             "$OCN_GRID == \"tx2_3v2\"": "geothermal_davies2013_tx2_3_20240318_cdf5.nc",
             "$OCN_GRID == \"tx2_3v3\"": "geothermal_davies2013_tx2_3v3_260305.nc",
+            "$OCN_GRID == \"tx2_0v1\"": "geothermal_davies2013_tx2_0v1_260528.nc",
             "$OCN_GRID == \"tx0.25v1\"": "geothermal_davies2013_v1.nc"
          }
       },
@@ -3005,6 +3163,7 @@
          "datatype": "string",
          "value": {
             "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": "geothermal_hf",
+            "$OCN_GRID == \"tx2_0v1\"": "geothermal_hf",
             "$OCN_GRID == \"tx0.25v1\"": "geothermal_hf"
          }
       },
@@ -3083,7 +3242,8 @@
          "description": "Turn on automatic mask table generation to eliminate land blocks\n",
          "datatype": "list",
          "value": {
-            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\", \"tx0.25v1\"]": true
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\", \"tx0.25v1\"]": true,
+            "$OCN_GRID == \"tx2_0v1\"": false
          }
       },
       "TARGET_IO_PES": {
@@ -3091,6 +3251,7 @@
          "datatype": "integer",
          "value": {
             "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"] and $TEST": "= - ( - $NTASKS_OCN // 256)",
+            "$OCN_GRID == \"tx2_0v1\" and $TEST": "= - ( - $NTASKS_OCN // 256)",
             "$OCN_GRID == \"tx0.25v1\"": "= - ( - $NTASKS_OCN // 128)"
          }
       },
@@ -3114,7 +3275,8 @@
          "datatype": "logical",
          "units": "Boolean",
          "value": {
-            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": true
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": true,
+            "$OCN_GRID == \"tx2_0v1\"": true
          }
       },
       "SKEB_USE_FRICT": {
@@ -3122,7 +3284,8 @@
          "datatype": "logical",
          "units": "Boolean",
          "value": {
-            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": true
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": true,
+            "$OCN_GRID == \"tx2_0v1\"": true
          }
       },
       "SKEB_USE_GM": {
@@ -3130,21 +3293,24 @@
          "datatype": "logical",
          "units": "Boolean",
          "value": {
-            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": true
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": true,
+            "$OCN_GRID == \"tx2_0v1\"": true
          }
       },
       "SKEB_NPASS": {
          "description": "\"[nondim] default = 0\n number of passes of a 9-point smoother of the dissipation estimate.\"\n",
          "datatype": "integer",
          "value": {
-            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 8
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 8,
+            "$OCN_GRID == \"tx2_0v1\"": 8
          }
       },
       "SKEB_GM_COEF": {
          "description": "\"[nondim] default = 0.0\nFraction of GM work that is added to backscatter rate.\"\n",
          "datatype": "real",
          "value": {
-            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 0.75
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 0.75,
+            "$OCN_GRID == \"tx2_0v1\"": 0.75
          }
       }
    },
@@ -3154,7 +3320,8 @@
          "datatype": "real",
          "units": "1/s^2",
          "value": {
-            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": -1e-08
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": -1e-08,
+            "$OCN_GRID == \"tx2_0v1\"": -1e-08
          }
       }
    },
@@ -3163,21 +3330,24 @@
          "description": "\"default = 0\nThe number of times the 1-1-4-1-1 Laplacian filter is applied on\nOBL depth purely for diagnostic purposes.\"\n",
          "datatype": "integer",
          "value": {
-            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 3
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 3,
+            "$OCN_GRID == \"tx2_0v1\"": 3
          }
       },
       "MATCH_TECHNIQUE": {
          "description": "\"default = 'SimpleShapes'\nCVMix method to set profile function for diffusivity and NLT,\nas well as matching across OBL base. Allowed values are:\nSimpleShapes      = sigma*(1-sigma)^2 for both diffusivity and NLT\nMatchGradient     = sigma*(1-sigma)^2 for NLT; diffusivity profile from matching\nMatchBoth         = match gradient for both diffusivity and NLT\nParabolicNonLocal = sigma*(1-sigma)^2 for diffusivity; (1-sigma)^2 for NLT\"\n",
          "datatype": "string",
          "value": {
-            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": "MatchGradient"
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": "MatchGradient",
+            "$OCN_GRID == \"tx2_0v1\"": "MatchGradient"
          }
       },
       "INTERP_TYPE2": {
          "description": "\"Type of interpolation to compute diff and visc at OBL_depth\nAllowed types are: linear, quadratic, cubic or LMD94.\"\n",
          "datatype": "string",
          "value": {
-            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": "LMD94"
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": "LMD94",
+            "$OCN_GRID == \"tx2_0v1\"": "LMD94"
          }
       },
       "KPP_IS_ADDITIVE": {
@@ -3185,7 +3355,8 @@
          "datatype": "logical",
          "units": "Boolean",
          "value": {
-            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": false
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": false,
+            "$OCN_GRID == \"tx2_0v1\"": false
          }
       },
       "USE_KPP_LT_K": {
@@ -3223,14 +3394,16 @@
          "datatype": "real",
          "units": "nondim",
          "value": {
-            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 1.8
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 1.8,
+            "$OCN_GRID == \"tx2_0v1\"": 1.8
          }
       },
       "ENHANCE_DIFFUSION": {
          "description": "\"default = True\nIf True, adds enhanced diffusion at the based of the boundary layer.\"\n",
          "datatype": "logical",
          "value": {
-            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": false
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": false,
+            "$OCN_GRID == \"tx2_0v1\"": false
          }
       },
       "STOKES_MOST": {
@@ -3245,14 +3418,16 @@
          "datatype": "logical",
          "units": "Boolean",
          "value": {
-            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": true
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": true,
+            "$OCN_GRID == \"tx2_0v1\"": true
          }
       },
       "MINIMUM_OBL_DEPTH": {
          "description": "\"[m] default = 0.0\nIf non-zero, a minimum depth to use for KPP OBL depth. Independent of this\nparameter, the OBL depth is always at least as deep as the first layer.\"\n",
          "datatype": "real",
          "value": {
-            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 5.0
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 5.0,
+            "$OCN_GRID == \"tx2_0v1\"": 5.0
          }
       }
    },
@@ -3262,7 +3437,8 @@
          "datatype": "logical",
          "units": "Boolean",
          "value": {
-            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": true
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": true,
+            "$OCN_GRID == \"tx2_0v1\"": true
          }
       },
       "CR": {
@@ -3270,7 +3446,8 @@
          "datatype": "real",
          "units": "nondim",
          "value": {
-            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 0.01
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 0.01,
+            "$OCN_GRID == \"tx2_0v1\"": 0.01
          }
       },
       "USE_CR_GRID": {
@@ -3295,7 +3472,8 @@
          "datatype": "logical",
          "units": "Boolean",
          "value": {
-            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": true
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": true,
+            "$OCN_GRID == \"tx2_0v1\"": true
          }
       },
       "MIN_WSTAR2": {
@@ -3303,7 +3481,8 @@
          "datatype": "real",
          "units": "m2 s-2",
          "value": {
-            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 1e-09
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 1e-09,
+            "$OCN_GRID == \"tx2_0v1\"": 1e-09
          }
       },
       "BLD_DECAYING_TFILTER": {
@@ -3311,7 +3490,8 @@
          "datatype": "real",
          "units": "s",
          "value": {
-            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 86400.0
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 86400.0,
+            "$OCN_GRID == \"tx2_0v1\"": 86400.0
          }
       },
       "BLD_GROWING_TFILTER": {
@@ -3319,7 +3499,8 @@
          "datatype": "real",
          "units": "s",
          "value": {
-            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 300.0
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 300.0,
+            "$OCN_GRID == \"tx2_0v1\"": 300.0
          }
       },
       "MLD_GROWING_TFILTER": {
@@ -3327,7 +3508,8 @@
          "datatype": "real",
          "units": "s",
          "value": {
-            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 3600.0
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 3600.0,
+            "$OCN_GRID == \"tx2_0v1\"": 3600.0
          }
       },
       "MLD_DECAYING_TFILTER": {
@@ -3335,7 +3517,8 @@
          "datatype": "real",
          "units": "s",
          "value": {
-            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 2592000.0
+            "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": 2592000.0,
+            "$OCN_GRID == \"tx2_0v1\"": 2592000.0
          }
       }
    }

--- a/param_templates/json/input_data_list.json
+++ b/param_templates/json/input_data_list.json
@@ -3,6 +3,7 @@
       "GRID_FILE": {
          "$OCN_GRID == \"tx2_3v2\"": "${INPUTDIR}/ocean_hgrid_221123.nc",
          "$OCN_GRID == \"tx2_3v3\"": "${INPUTDIR}/ocean_hgrid_250930.nc",
+         "$OCN_GRID == \"tx2_0v1\"": "${INPUTDIR}/ocean_hgrid_260529.nc",
          "$OCN_GRID == \"tx0.25v1\"": "${INPUTDIR}/ocean_hgrid.nc"
       },
       "ALE_COORDINATE_CONFIG": {
@@ -13,10 +14,12 @@
          "$OCN_GRID == \"tx0.25v1\"": "${INPUTDIR}/hycom1_75_800m.nc"
       },
       "MAXIMUM_INT_DEPTH_CONFIG": {
-         "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": "${DIN_LOC_ROOT}/ocn/mom/grid_indpt/lev-2025-09-12.nc"
+         "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": "${DIN_LOC_ROOT}/ocn/mom/grid_indpt/lev-2025-09-12.nc",
+         "$OCN_GRID == \"tx2_0v1\"": "${DIN_LOC_ROOT}/ocn/mom/grid_indpt/lev-2025-09-12.nc"
       },
       "MAX_LAYER_THICKNESS_CONFIG": {
-         "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": "${DIN_LOC_ROOT}/ocn/mom/grid_indpt/dz_max-2025-09-12.nc"
+         "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\"]": "${DIN_LOC_ROOT}/ocn/mom/grid_indpt/dz_max-2025-09-12.nc",
+         "$OCN_GRID == \"tx2_0v1\"": "${DIN_LOC_ROOT}/ocn/mom/grid_indpt/dz_max-2025-09-12.nc"
       },
       "DIAG_COORD_DEF_Z": {
          "$OCN_GRID == \"tx0.25v1\"": "${INPUTDIR}/interpolate_zgrid_40L.nc"
@@ -27,6 +30,7 @@
       "TOPO_FILE": {
          "$OCN_GRID == \"tx2_3v2\"": "${INPUTDIR}/ocean_topo_tx2_3v2_240501.nc",
          "$OCN_GRID == \"tx2_3v3\"": "${INPUTDIR}/ocean_topo_tx2_3v3_260305.nc",
+         "$OCN_GRID == \"tx2_0v1\"": "${INPUTDIR}/ocean_topo_tx2_0v1_260526.nc",
          "$OCN_GRID == \"tx0.25v1\"": "${INPUTDIR}/ocean_topog.nc"
       },
       "TOPO_EDITS_FILE": {
@@ -36,38 +40,47 @@
       "TEMP_SALT_Z_INIT_FILE": {
          "$OCN_GRID in [\"tx2_3v2\", \"tx2_3v3\", \"tx0.25v1\"]": {
             "$INIT_LAYERS_FROM_Z_FILE == \"True\"": "${INPUTDIR}/${TEMP_SALT_Z_INIT_FILE}"
+         },
+         "$OCN_GRID == \"tx2_0v1\"": {
+            "$INIT_LAYERS_FROM_Z_FILE == \"True\"": "${INPUTDIR}/${TEMP_SALT_Z_INIT_FILE}"
          }
       },
       "KH_BG_2D": {
          "$OCN_GRID == \"tx2_3v3\"": "${INPUTDIR}/KH_BG_2D_tx2_3v3_260427.nc",
-         "$OCN_GRID == \"tx2_3v2\"": "${INPUTDIR}/KH_BG_2D_tx2_3v2_260427.nc"
+         "$OCN_GRID == \"tx2_3v2\"": "${INPUTDIR}/KH_BG_2D_tx2_3v2_260427.nc",
+         "$OCN_GRID == \"tx2_0v1\"": "${INPUTDIR}/KH_BG_2D_tx2_0v1_260528.nc"
       },
       "SURFACE_PRESSURE_FILE": {
          "$OCN_GRID == \"MISOMIP\"": "${INPUTDIR}/MISOMIP_181108.nc"
       },
       "SALT_RESTORE_FILE": {
          "$OCN_GRID == \"tx2_3v2\"": "${INPUTDIR}/state_restore_tx2_3_20230416.nc",
-         "$OCN_GRID == \"tx2_3v3\"": "${INPUTDIR}/state_restore_tx2_3v3_260305.nc"
+         "$OCN_GRID == \"tx2_3v3\"": "${INPUTDIR}/state_restore_tx2_3v3_260305.nc",
+         "$OCN_GRID == \"tx2_0v1\"": "${INPUTDIR}/state_restore_tx2_0v1_260528.nc"
       },
       "TIDAL_ENERGY_FILE": {
          "$OCN_GRID == \"tx2_3v2\"": "${INPUTDIR}/energy_new_tx2_3_conserve_230415_cdf5.nc",
          "$OCN_GRID == \"tx2_3v3\"": "${INPUTDIR}/tidal_energy_tx2_3v3_conserve_260306.nc",
+         "$OCN_GRID == \"tx2_0v1\"": "${INPUTDIR}/tidal_energy_tx2_0v1_conserve_260528.nc",
          "$OCN_GRID == \"tx0.25v1\"": "${INPUTDIR}/tidal_amplitude.v20140616.nc"
       },
       "CHANNEL_LIST_FILE": {
          "$OCN_GRID == \"tx2_3v2\"": "${INPUTDIR}/channels_tx2_3v2_250107.txt",
          "$OCN_GRID == \"tx2_3v3\"": "${INPUTDIR}/channels_tx2_3v3_260304.txt",
+         "$OCN_GRID == \"tx2_0v1\"": "${INPUTDIR}/channels_tx2_0v1_260518.txt",
          "$OCN_GRID == \"tx0.25v1\"": "${INPUTDIR}/MOM_channels_global_025"
       },
       "GEOTHERMAL_FILE": {
          "$OCN_GRID == \"tx2_3v2\"": "${INPUTDIR}/geothermal_davies2013_tx2_3_20240318_cdf5.nc",
          "$OCN_GRID == \"tx2_3v3\"": "${INPUTDIR}/geothermal_davies2013_tx2_3v3_260305.nc",
+         "$OCN_GRID == \"tx2_0v1\"": "${INPUTDIR}/geothermal_davies2013_tx2_0v1_260528.nc",
          "$OCN_GRID == \"tx0.25v1\"": "${INPUTDIR}/geothermal_davies2013_v1.nc"
       },
       "CHL_FILE": {
          "$OCN_GRID == \"tx0.25v1\"": "${INPUTDIR}/seawifs-clim-1997-2010.1440x1080.v20180328.nc",
          "$OCN_GRID == \"tx2_3v2\"": "${INPUTDIR}/seawifs-clim-1997-2010-tx2_3v2.230416.nc",
-         "$OCN_GRID == \"tx2_3v3\"": "${INPUTDIR}/seawifs-clim-1997-2010-tx2_3v3_260305.nc"
+         "$OCN_GRID == \"tx2_3v3\"": "${INPUTDIR}/seawifs-clim-1997-2010-tx2_3v3_260305.nc",
+         "$OCN_GRID == \"tx2_0v1\"": "${INPUTDIR}/seawifs-clim-1997-2010-tx2_0v1_260528.nc"
       },
       "CR_FILE": {
          "$OCN_GRID == \"tx2_3v2\"": "${INPUTDIR}/mle-cr-mask_20250627.nc",

--- a/tests/check_input_data_list.py
+++ b/tests/check_input_data_list.py
@@ -123,17 +123,22 @@ def get_input_data_list_files(input_data_list_yaml, MOM_input_files):
             varname, extract_values(input_data_list[varname])
         )
         if _files:
-            # Expand expandable variables in the input_data_list.yaml file
-            for i, _file in enumerate(_files):
+            # Expand expandable variables in the input_data_list.yaml file.
+            expanded_files = []
+            for _file in _files:
                 # Find all expandable variables in the file name:
                 expandable_vars = re.findall(r"\$\{.*\}|\b\$.*\b", _file)
+                replaced = False
                 for expandable_var in expandable_vars:
-                    if expandable_var.strip("${}") in MOM_input_files:
-                        # Replace the expandable variable with the corresponding file name from MOM_input.yaml
-                        _files.pop(i)
-                        _files.extend(MOM_input_files[expandable_var.strip("${}")])
+                    varkey = expandable_var.strip("${}")
+                    if varkey in MOM_input_files:
+                        # Replace the expandable variable with the corresponding file name(s) from MOM_input.yaml
+                        expanded_files.extend(MOM_input_files[varkey])
+                        replaced = True
+                if not replaced:
+                    expanded_files.append(_file)
 
-            files[varname] = _files
+            files[varname] = expanded_files
 
     return files
 


### PR DESCRIPTION
Add tx2_0v1 as a supported MOM6 grid
- MOM_input.yaml: tx2_0v1 grid defaults  (dims, input files, hybrid
  75-layer vgrid, WOA cold-start init, tx2_3-family physics)
- input_data_list.yaml: tx2_0v1 input-data entries
- config_component.xml: default hycom1 vertical grid for tx2_0v1
- config_pes.xml: tx2_0v1 PE layout (ocn/ice on 128, ocean concurrent)
- regenerate json templates

Note: parameterizations are currently based on tx2_3v3.
todo: will add a test to aux_mom.