### PR TITLE
More MARBL updates for CESM3

### DIFF
--- a/param_templates/MOM_input.yaml
+++ b/param_templates/MOM_input.yaml
@@ -340,8 +340,27 @@ Global:
             for the MARBL tracer package."
         datatype: string
         value:
-            $MARBL_CONFIG == "latest": ecosys_jan_IC_omip_latlon_1x1_180W_c250613.nc
-            $MARBL_CONFIG == "latest+4p2z": ecosys_jan_IC_omip_latlon_1x1_180W_c250613.nc
+            $RUN_TYPE == "hybrid":
+                = f'./{$RUN_REFCASE}.mom6{$INST_SUFFIX}.r.{$RUN_REFDATE}-{$RUN_REFTOD}.nc'
+            else:
+                $MARBL_CONFIG == "latest": ${DIN_LOC_ROOT}/ocn/mom/grid_indpt/ecosys_jan_IC_omip_latlon_1x1_180W_c250613.nc
+                $MARBL_CONFIG == "latest+4p2z": ${DIN_LOC_ROOT}/ocn/mom/grid_indpt/ecosys_jan_IC_omip_latlon_1x1_180W_c250613.nc
+    MARBL_TRACERS_IC_FILE_IS_Z:
+        description: |
+            "[Boolean] default = True
+            If true, MARBL_TRACERS_IC_FILE is in depth space, not layer space."
+        datatype: logical
+        units: Boolean
+        value:
+            $RUN_TYPE == "hybrid": False
+    MARBL_IC_MIN_VAL:
+        description: |
+            Minimum value of tracer initial conditions
+        datatype: real
+        units: conc units
+        value:
+            $TEST: 1e-50
+            $RUN_TYPE == "hybrid": -1e30
     MARBL_FESEDFLUX_FILE:
         description: |
             "Name of file containing iron sediment flux
@@ -377,6 +396,8 @@ Global:
         value:
             '"BASE_BIO_ON=TRUE" in $MARBL_TRACER_OPTS and $OCN_GRID == "tx2_3v2" and $ROF_GRID == "JRA025"': riv_nut.gnews_gnm.rJRA025_to_tx2_3v2_nnsm_e333r100_230415.20240202.nc
             '"BASE_BIO_ON=TRUE" in $MARBL_TRACER_OPTS and $OCN_GRID == "tx2_3v2" and $ROF_GRID == "r05"': riv_nut.gnews_gnm.r05_to_tx2_3v2_nnsm_e250r250_230914.20240202.nc
+            '"BASE_BIO_ON=TRUE" in $MARBL_TRACER_OPTS and $OCN_GRID == "tx2_3v3" and $ROF_GRID == "JRA025"': riv_nut.gnews_gnm.rJRA025_to_tx2_3v3_nnsm_e100r100_260306.20260424.nc
+            '"BASE_BIO_ON=TRUE" in $MARBL_TRACER_OPTS and $OCN_GRID == "tx2_3v3" and $ROF_GRID == "r05"': riv_nut.gnews_gnm.r05_to_tx2_3v3_nnsm_e100r100_260306.20260424.nc
     MARBL_D14C_FILE_1:
         description: |
             "Name of file containing D14C forcing from 30 N to 90 N."

--- a/param_templates/MOM_input.yaml
+++ b/param_templates/MOM_input.yaml
@@ -361,27 +361,14 @@ Global:
         value:
             $TEST: 1e-50
             $RUN_TYPE == "hybrid": -1e30
-    MARBL_FESEDFLUX_FILE:
+    MARBL_FEFLUX_FILE:
         description: |
-            "Name of file containing iron sediment flux
-             forcing field for the MARBL tracer package."
+            "Name of file containing iron sediment fluxes and vent
+             flux forcing fields for the MARBL tracer package."
         datatype: string
         value:
             '"BASE_BIO_ON=TRUE" in $MARBL_TRACER_OPTS and $OCN_GRID == "tx2_3v2"': fesedflux_2024algo_tx2_3v2.c251229.nc
-    MARBL_FESEDFLUXRED_FILE:
-        description: |
-            "Name of file containing iron reducing sediment flux
-             forcing field for the MARBL tracer package."
-        datatype: string
-        value:
-            '"BASE_BIO_ON=TRUE" in $MARBL_TRACER_OPTS and $OCN_GRID == "tx2_3v2"': fesedfluxRed_2024algo_tx2_3v2.c251229.nc
-    MARBL_FEVENTFLUX_FILE:
-        description: |
-            "Name of file containing iron sediment flux
-             forcing field for the MARBL tracer package."
-        datatype: string
-        value:
-            '"BASE_BIO_ON=TRUE" in $MARBL_TRACER_OPTS and $OCN_GRID == "tx2_3v2"': feventflux_5gmol_tx2_3v2.c231205.nc
+            '"BASE_BIO_ON=TRUE" in $MARBL_TRACER_OPTS and $OCN_GRID == "tx2_3v3"': fefluxes_sed2024algo_vent2026algo_tx2_3v3.c260625.nc
     READ_RIV_FLUXES:
         description: |
             "Use river fluxes provided by RIV_FLUX_FILE."

--- a/param_templates/MOM_input.yaml
+++ b/param_templates/MOM_input.yaml
@@ -361,14 +361,14 @@ Global:
         value:
             $TEST: 1e-50
             $RUN_TYPE == "hybrid": -1e30
-    MARBL_FEFLUX_FILE:
+    MARBL_FE_INTERIOR_SOURCE_FILE:
         description: |
             "Name of file containing iron sediment fluxes and vent
              flux forcing fields for the MARBL tracer package."
         datatype: string
         value:
             '"BASE_BIO_ON=TRUE" in $MARBL_TRACER_OPTS and $OCN_GRID == "tx2_3v2"': fesedflux_2024algo_tx2_3v2.c251229.nc
-            '"BASE_BIO_ON=TRUE" in $MARBL_TRACER_OPTS and $OCN_GRID == "tx2_3v3"': fefluxes_sed2024algo_vent2026algo_tx2_3v3.c260625.nc
+            '"BASE_BIO_ON=TRUE" in $MARBL_TRACER_OPTS and $OCN_GRID == "tx2_3v3"': fe_sources_sed2024algo_vent2026algo_tx2_3v3.c260701.nc
     READ_RIV_FLUXES:
         description: |
             "Use river fluxes provided by RIV_FLUX_FILE."

--- a/param_templates/input_data_list.yaml
+++ b/param_templates/input_data_list.yaml
@@ -63,18 +63,16 @@ mom.input_data_list:
     MARBL_TRACERS_IC_FILE:
         $MARBL_CONFIG == "latest": "${DIN_LOC_ROOT}/ocn/mom/grid_indpt/ecosys_jan_IC_omip_latlon_1x1_180W_c250613.nc"
         $MARBL_CONFIG == "latest+4p2z": "${DIN_LOC_ROOT}/ocn/mom/grid_indpt/ecosys_jan_IC_omip_latlon_1x1_180W_c250613.nc"
-    MARBL_FEFLUX_FILE:
+    MARBL_FE_INTERIOR_SOURCE_FILE:
         '"BASE_BIO_ON=TRUE" in $MARBL_TRACER_OPTS':
             $OCN_GRID == "tx2_3v2": "${INPUTDIR}/fesedflux_2024algo_tx2_3v2.c251229.nc"
             $OCN_GRID == "tx2_3v3": "${INPUTDIR}/fefluxes_sed2024algo_vent2026algo_tx2_3v3.c260625.nc"
     RIV_FLUX_FILE:
         '"BASE_BIO_ON=TRUE" in $MARBL_TRACER_OPTS':
-            $OCN_GRID == "tx2_3v2":
-                $ROF_GRID == "JRA025": "${INPUTDIR}/riv_nut.gnews_gnm.rJRA025_to_tx2_3v2_nnsm_e333r100_230415.20240202.nc"
-                $ROF_GRID == "r05": "${INPUTDIR}/riv_nut.gnews_gnm.r05_to_tx2_3v2_nnsm_e250r250_230914.20240202.nc"
-            $OCN_GRID == "tx2_3v3":
-                $ROF_GRID == "JRA025": "${INPUTDIR}/riv_nut.gnews_gnm.rJRA025_to_tx2_3v3_nnsm_e100r100_260306.20260424.nc"
-                $ROF_GRID == "r05": "${INPUTDIR}/riv_nut.gnews_gnm.r05_to_tx2_3v3_nnsm_e100r100_260306.20260424.nc"
+            '$OCN_GRID == "tx2_3v2" and $ROF_GRID == "JRA025"': "${INPUTDIR}/riv_nut.gnews_gnm.rJRA025_to_tx2_3v2_nnsm_e333r100_230415.20240202.nc"
+            '$OCN_GRID == "tx2_3v2" and $ROF_GRID == "r05"': "${INPUTDIR}/riv_nut.gnews_gnm.r05_to_tx2_3v2_nnsm_e250r250_230914.20240202.nc"
+            '$OCN_GRID == "tx2_3v3" and $ROF_GRID == "JRA025"': "${INPUTDIR}/riv_nut.gnews_gnm.rJRA025_to_tx2_3v3_nnsm_e100r100_260306.20260424.nc"
+            '$OCN_GRID == "tx2_3v3" and $ROF_GRID == "r05"': "${INPUTDIR}/riv_nut.gnews_gnm.r05_to_tx2_3v3_nnsm_e100r100_260306.20260424.nc"
     MARBL_D14C_FILE_1:
         '"ABIO_DIC_ON=TRUE" in $MARBL_TRACER_OPTS': "${DIN_LOC_ROOT}/ocn/mom/grid_indpt/atm_delta_C14_CMIP6_sector1_global_1850-2015_yearly_v2.0_c240202.nc"
     MARBL_D14C_FILE_2:

--- a/param_templates/input_data_list.yaml
+++ b/param_templates/input_data_list.yaml
@@ -63,21 +63,11 @@ mom.input_data_list:
     MARBL_TRACERS_IC_FILE:
         $MARBL_CONFIG == "latest": "${DIN_LOC_ROOT}/ocn/mom/grid_indpt/ecosys_jan_IC_omip_latlon_1x1_180W_c250613.nc"
         $MARBL_CONFIG == "latest+4p2z": "${DIN_LOC_ROOT}/ocn/mom/grid_indpt/ecosys_jan_IC_omip_latlon_1x1_180W_c250613.nc"
-    MARBL_FESEDFLUX_FILE:
+    MARBL_FEFLUX_FILE:
         '"BASE_BIO_ON=TRUE" in $MARBL_TRACER_OPTS':
             $OCN_GRID == "tx2_3v2": "${INPUTDIR}/fesedflux_2024algo_tx2_3v2.c251229.nc"
         '"BASE_BIO_ON=TRUE" in $MARBL_TRACER_OPTS':
-            $OCN_GRID == "tx2_3v3": "${INPUTDIR}/fesedflux_2024algo_tx2_3v2.c251229.nc"
-    MARBL_FESEDFLUXRED_FILE:
-        '"BASE_BIO_ON=TRUE" in $MARBL_TRACER_OPTS':
-            $OCN_GRID == "tx2_3v2": "${INPUTDIR}/fesedfluxRed_2024algo_tx2_3v2.c251229.nc"
-        '"BASE_BIO_ON=TRUE" in $MARBL_TRACER_OPTS':
-            $OCN_GRID == "tx2_3v3": "${INPUTDIR}/fesedfluxRed_2024algo_tx2_3v2.c251229.nc"
-    MARBL_FEVENTFLUX_FILE:
-        '"BASE_BIO_ON=TRUE" in $MARBL_TRACER_OPTS':
-            $OCN_GRID == "tx2_3v2": "${INPUTDIR}/feventflux_5gmol_tx2_3v2.c231205.nc"
-        '"BASE_BIO_ON=TRUE" in $MARBL_TRACER_OPTS':
-            $OCN_GRID == "tx2_3v3": "${INPUTDIR}/feventflux_5gmol_tx2_3v2.c231205.nc"
+            $OCN_GRID == "tx2_3v3": "${INPUTDIR}/fefluxes_sed2024algo_vent2026algo_tx2_3v3.c260625.nc"
     RIV_FLUX_FILE:
         '"BASE_BIO_ON=TRUE" in $MARBL_TRACER_OPTS':
             '$ROF_GRID == "JRA025" and $OCN_GRID == "tx2_3v2"': "${INPUTDIR}/riv_nut.gnews_gnm.rJRA025_to_tx2_3v2_nnsm_e333r100_230415.20240202.nc"

--- a/param_templates/input_data_list.yaml
+++ b/param_templates/input_data_list.yaml
@@ -66,15 +66,15 @@ mom.input_data_list:
     MARBL_FEFLUX_FILE:
         '"BASE_BIO_ON=TRUE" in $MARBL_TRACER_OPTS':
             $OCN_GRID == "tx2_3v2": "${INPUTDIR}/fesedflux_2024algo_tx2_3v2.c251229.nc"
-        '"BASE_BIO_ON=TRUE" in $MARBL_TRACER_OPTS':
             $OCN_GRID == "tx2_3v3": "${INPUTDIR}/fefluxes_sed2024algo_vent2026algo_tx2_3v3.c260625.nc"
     RIV_FLUX_FILE:
         '"BASE_BIO_ON=TRUE" in $MARBL_TRACER_OPTS':
-            '$ROF_GRID == "JRA025" and $OCN_GRID == "tx2_3v2"': "${INPUTDIR}/riv_nut.gnews_gnm.rJRA025_to_tx2_3v2_nnsm_e333r100_230415.20240202.nc"
-            '$ROF_GRID == "r05" and $OCN_GRID == "tx2_3v2"': "${INPUTDIR}/riv_nut.gnews_gnm.r05_to_tx2_3v2_nnsm_e250r250_230914.20240202.nc"
-        '"BASE_BIO_ON=TRUE" in $MARBL_TRACER_OPTS':
-            '$ROF_GRID == "JRA025" and $OCN_GRID == "tx2_3v3"': "${INPUTDIR}/riv_nut.gnews_gnm.rJRA025_to_tx2_3v3_nnsm_e100r100_260306.20260424.nc"
-            '$ROF_GRID == "r05" and $OCN_GRID == "tx2_3v3"': "${INPUTDIR}/riv_nut.gnews_gnm.r05_to_tx2_3v3_nnsm_e100r100_260306.20260424.nc"
+            $OCN_GRID == "tx2_3v2":
+                $ROF_GRID == "JRA025": "${INPUTDIR}/riv_nut.gnews_gnm.rJRA025_to_tx2_3v2_nnsm_e333r100_230415.20240202.nc"
+                $ROF_GRID == "r05": "${INPUTDIR}/riv_nut.gnews_gnm.r05_to_tx2_3v2_nnsm_e250r250_230914.20240202.nc"
+            $OCN_GRID == "tx2_3v3":
+                $ROF_GRID == "JRA025": "${INPUTDIR}/riv_nut.gnews_gnm.rJRA025_to_tx2_3v3_nnsm_e100r100_260306.20260424.nc"
+                $ROF_GRID == "r05": "${INPUTDIR}/riv_nut.gnews_gnm.r05_to_tx2_3v3_nnsm_e100r100_260306.20260424.nc"
     MARBL_D14C_FILE_1:
         '"ABIO_DIC_ON=TRUE" in $MARBL_TRACER_OPTS': "${DIN_LOC_ROOT}/ocn/mom/grid_indpt/atm_delta_C14_CMIP6_sector1_global_1850-2015_yearly_v2.0_c240202.nc"
     MARBL_D14C_FILE_2:

--- a/param_templates/input_data_list.yaml
+++ b/param_templates/input_data_list.yaml
@@ -61,21 +61,30 @@ mom.input_data_list:
     DIAG_COORD_DEF_RHO2:
         $OCN_GRID == "tx2_3v2":  "${INPUTDIR}/ocean_rho2_190917.nc"
     MARBL_TRACERS_IC_FILE:
-        $MARBL_CONFIG == "latest": "${INPUTDIR}/ecosys_jan_IC_omip_latlon_1x1_180W_c250613.nc"
-        $MARBL_CONFIG == "latest+4p2z": "${INPUTDIR}/ecosys_jan_IC_omip_latlon_1x1_180W_c250613.nc"
+        $MARBL_CONFIG == "latest": "${DIN_LOC_ROOT}/ocn/mom/grid_indpt/ecosys_jan_IC_omip_latlon_1x1_180W_c250613.nc"
+        $MARBL_CONFIG == "latest+4p2z": "${DIN_LOC_ROOT}/ocn/mom/grid_indpt/ecosys_jan_IC_omip_latlon_1x1_180W_c250613.nc"
     MARBL_FESEDFLUX_FILE:
         '"BASE_BIO_ON=TRUE" in $MARBL_TRACER_OPTS':
             $OCN_GRID == "tx2_3v2": "${INPUTDIR}/fesedflux_2024algo_tx2_3v2.c251229.nc"
+        '"BASE_BIO_ON=TRUE" in $MARBL_TRACER_OPTS':
+            $OCN_GRID == "tx2_3v3": "${INPUTDIR}/fesedflux_2024algo_tx2_3v2.c251229.nc"
     MARBL_FESEDFLUXRED_FILE:
         '"BASE_BIO_ON=TRUE" in $MARBL_TRACER_OPTS':
             $OCN_GRID == "tx2_3v2": "${INPUTDIR}/fesedfluxRed_2024algo_tx2_3v2.c251229.nc"
+        '"BASE_BIO_ON=TRUE" in $MARBL_TRACER_OPTS':
+            $OCN_GRID == "tx2_3v3": "${INPUTDIR}/fesedfluxRed_2024algo_tx2_3v2.c251229.nc"
     MARBL_FEVENTFLUX_FILE:
         '"BASE_BIO_ON=TRUE" in $MARBL_TRACER_OPTS':
             $OCN_GRID == "tx2_3v2": "${INPUTDIR}/feventflux_5gmol_tx2_3v2.c231205.nc"
+        '"BASE_BIO_ON=TRUE" in $MARBL_TRACER_OPTS':
+            $OCN_GRID == "tx2_3v3": "${INPUTDIR}/feventflux_5gmol_tx2_3v2.c231205.nc"
     RIV_FLUX_FILE:
         '"BASE_BIO_ON=TRUE" in $MARBL_TRACER_OPTS':
             '$ROF_GRID == "JRA025" and $OCN_GRID == "tx2_3v2"': "${INPUTDIR}/riv_nut.gnews_gnm.rJRA025_to_tx2_3v2_nnsm_e333r100_230415.20240202.nc"
             '$ROF_GRID == "r05" and $OCN_GRID == "tx2_3v2"': "${INPUTDIR}/riv_nut.gnews_gnm.r05_to_tx2_3v2_nnsm_e250r250_230914.20240202.nc"
+        '"BASE_BIO_ON=TRUE" in $MARBL_TRACER_OPTS':
+            '$ROF_GRID == "JRA025" and $OCN_GRID == "tx2_3v3"': "${INPUTDIR}/riv_nut.gnews_gnm.rJRA025_to_tx2_3v3_nnsm_e100r100_260306.20260424.nc"
+            '$ROF_GRID == "r05" and $OCN_GRID == "tx2_3v3"': "${INPUTDIR}/riv_nut.gnews_gnm.r05_to_tx2_3v3_nnsm_e100r100_260306.20260424.nc"
     MARBL_D14C_FILE_1:
         '"ABIO_DIC_ON=TRUE" in $MARBL_TRACER_OPTS': "${DIN_LOC_ROOT}/ocn/mom/grid_indpt/atm_delta_C14_CMIP6_sector1_global_1850-2015_yearly_v2.0_c240202.nc"
     MARBL_D14C_FILE_2:

--- a/param_templates/json/MOM_input.json
+++ b/param_templates/json/MOM_input.json
@@ -267,25 +267,12 @@
             "$RUN_TYPE == \"hybrid\"": "-1e30"
          }
       },
-      "MARBL_FESEDFLUX_FILE": {
-         "description": "\"Name of file containing iron sediment flux\n forcing field for the MARBL tracer package.\"\n",
+      "MARBL_FEFLUX_FILE": {
+         "description": "\"Name of file containing iron sediment fluxes and vent\n flux forcing fields for the MARBL tracer package.\"\n",
          "datatype": "string",
          "value": {
-            "\"BASE_BIO_ON=TRUE\" in $MARBL_TRACER_OPTS and $OCN_GRID == \"tx2_3v2\"": "fesedflux_2024algo_tx2_3v2.c251229.nc"
-         }
-      },
-      "MARBL_FESEDFLUXRED_FILE": {
-         "description": "\"Name of file containing iron reducing sediment flux\n forcing field for the MARBL tracer package.\"\n",
-         "datatype": "string",
-         "value": {
-            "\"BASE_BIO_ON=TRUE\" in $MARBL_TRACER_OPTS and $OCN_GRID == \"tx2_3v2\"": "fesedfluxRed_2024algo_tx2_3v2.c251229.nc"
-         }
-      },
-      "MARBL_FEVENTFLUX_FILE": {
-         "description": "\"Name of file containing iron sediment flux\n forcing field for the MARBL tracer package.\"\n",
-         "datatype": "string",
-         "value": {
-            "\"BASE_BIO_ON=TRUE\" in $MARBL_TRACER_OPTS and $OCN_GRID == \"tx2_3v2\"": "feventflux_5gmol_tx2_3v2.c231205.nc"
+            "\"BASE_BIO_ON=TRUE\" in $MARBL_TRACER_OPTS and $OCN_GRID == \"tx2_3v2\"": "fesedflux_2024algo_tx2_3v2.c251229.nc",
+            "\"BASE_BIO_ON=TRUE\" in $MARBL_TRACER_OPTS and $OCN_GRID == \"tx2_3v3\"": "fefluxes_sed2024algo_vent2026algo_tx2_3v3.c260625.nc"
          }
       },
       "READ_RIV_FLUXES": {

--- a/param_templates/json/MOM_input.json
+++ b/param_templates/json/MOM_input.json
@@ -267,12 +267,12 @@
             "$RUN_TYPE == \"hybrid\"": "-1e30"
          }
       },
-      "MARBL_FEFLUX_FILE": {
+      "MARBL_FE_INTERIOR_SOURCE_FILE": {
          "description": "\"Name of file containing iron sediment fluxes and vent\n flux forcing fields for the MARBL tracer package.\"\n",
          "datatype": "string",
          "value": {
             "\"BASE_BIO_ON=TRUE\" in $MARBL_TRACER_OPTS and $OCN_GRID == \"tx2_3v2\"": "fesedflux_2024algo_tx2_3v2.c251229.nc",
-            "\"BASE_BIO_ON=TRUE\" in $MARBL_TRACER_OPTS and $OCN_GRID == \"tx2_3v3\"": "fefluxes_sed2024algo_vent2026algo_tx2_3v3.c260625.nc"
+            "\"BASE_BIO_ON=TRUE\" in $MARBL_TRACER_OPTS and $OCN_GRID == \"tx2_3v3\"": "fe_sources_sed2024algo_vent2026algo_tx2_3v3.c260701.nc"
          }
       },
       "READ_RIV_FLUXES": {

--- a/param_templates/json/MOM_input.json
+++ b/param_templates/json/MOM_input.json
@@ -243,8 +243,28 @@
          "description": "\"Name of file containing initial conditions\nfor the MARBL tracer package.\"\n",
          "datatype": "string",
          "value": {
-            "$MARBL_CONFIG == \"latest\"": "ecosys_jan_IC_omip_latlon_1x1_180W_c250613.nc",
-            "$MARBL_CONFIG == \"latest+4p2z\"": "ecosys_jan_IC_omip_latlon_1x1_180W_c250613.nc"
+            "$RUN_TYPE == \"hybrid\"": "= f'./{$RUN_REFCASE}.mom6{$INST_SUFFIX}.r.{$RUN_REFDATE}-{$RUN_REFTOD}.nc'",
+            "else": {
+               "$MARBL_CONFIG == \"latest\"": "${DIN_LOC_ROOT}/ocn/mom/grid_indpt/ecosys_jan_IC_omip_latlon_1x1_180W_c250613.nc",
+               "$MARBL_CONFIG == \"latest+4p2z\"": "${DIN_LOC_ROOT}/ocn/mom/grid_indpt/ecosys_jan_IC_omip_latlon_1x1_180W_c250613.nc"
+            }
+         }
+      },
+      "MARBL_TRACERS_IC_FILE_IS_Z": {
+         "description": "\"[Boolean] default = True\nIf true, MARBL_TRACERS_IC_FILE is in depth space, not layer space.\"\n",
+         "datatype": "logical",
+         "units": "Boolean",
+         "value": {
+            "$RUN_TYPE == \"hybrid\"": false
+         }
+      },
+      "MARBL_IC_MIN_VAL": {
+         "description": "Minimum value of tracer initial conditions\n",
+         "datatype": "real",
+         "units": "conc units",
+         "value": {
+            "$TEST": "1e-50",
+            "$RUN_TYPE == \"hybrid\"": "-1e30"
          }
       },
       "MARBL_FESEDFLUX_FILE": {
@@ -280,7 +300,9 @@
          "datatype": "string",
          "value": {
             "\"BASE_BIO_ON=TRUE\" in $MARBL_TRACER_OPTS and $OCN_GRID == \"tx2_3v2\" and $ROF_GRID == \"JRA025\"": "riv_nut.gnews_gnm.rJRA025_to_tx2_3v2_nnsm_e333r100_230415.20240202.nc",
-            "\"BASE_BIO_ON=TRUE\" in $MARBL_TRACER_OPTS and $OCN_GRID == \"tx2_3v2\" and $ROF_GRID == \"r05\"": "riv_nut.gnews_gnm.r05_to_tx2_3v2_nnsm_e250r250_230914.20240202.nc"
+            "\"BASE_BIO_ON=TRUE\" in $MARBL_TRACER_OPTS and $OCN_GRID == \"tx2_3v2\" and $ROF_GRID == \"r05\"": "riv_nut.gnews_gnm.r05_to_tx2_3v2_nnsm_e250r250_230914.20240202.nc",
+            "\"BASE_BIO_ON=TRUE\" in $MARBL_TRACER_OPTS and $OCN_GRID == \"tx2_3v3\" and $ROF_GRID == \"JRA025\"": "riv_nut.gnews_gnm.rJRA025_to_tx2_3v3_nnsm_e100r100_260306.20260424.nc",
+            "\"BASE_BIO_ON=TRUE\" in $MARBL_TRACER_OPTS and $OCN_GRID == \"tx2_3v3\" and $ROF_GRID == \"r05\"": "riv_nut.gnews_gnm.r05_to_tx2_3v3_nnsm_e100r100_260306.20260424.nc"
          }
       },
       "MARBL_D14C_FILE_1": {

--- a/param_templates/json/input_data_list.json
+++ b/param_templates/json/input_data_list.json
@@ -81,7 +81,7 @@
          "$MARBL_CONFIG == \"latest\"": "${DIN_LOC_ROOT}/ocn/mom/grid_indpt/ecosys_jan_IC_omip_latlon_1x1_180W_c250613.nc",
          "$MARBL_CONFIG == \"latest+4p2z\"": "${DIN_LOC_ROOT}/ocn/mom/grid_indpt/ecosys_jan_IC_omip_latlon_1x1_180W_c250613.nc"
       },
-      "MARBL_FEFLUX_FILE": {
+      "MARBL_FE_INTERIOR_SOURCE_FILE": {
          "\"BASE_BIO_ON=TRUE\" in $MARBL_TRACER_OPTS": {
             "$OCN_GRID == \"tx2_3v2\"": "${INPUTDIR}/fesedflux_2024algo_tx2_3v2.c251229.nc",
             "$OCN_GRID == \"tx2_3v3\"": "${INPUTDIR}/fefluxes_sed2024algo_vent2026algo_tx2_3v3.c260625.nc"
@@ -89,14 +89,10 @@
       },
       "RIV_FLUX_FILE": {
          "\"BASE_BIO_ON=TRUE\" in $MARBL_TRACER_OPTS": {
-            "$OCN_GRID == \"tx2_3v2\"": {
-               "$ROF_GRID == \"JRA025\"": "${INPUTDIR}/riv_nut.gnews_gnm.rJRA025_to_tx2_3v2_nnsm_e333r100_230415.20240202.nc",
-               "$ROF_GRID == \"r05\"": "${INPUTDIR}/riv_nut.gnews_gnm.r05_to_tx2_3v2_nnsm_e250r250_230914.20240202.nc"
-            },
-            "$OCN_GRID == \"tx2_3v3\"": {
-               "$ROF_GRID == \"JRA025\"": "${INPUTDIR}/riv_nut.gnews_gnm.rJRA025_to_tx2_3v3_nnsm_e100r100_260306.20260424.nc",
-               "$ROF_GRID == \"r05\"": "${INPUTDIR}/riv_nut.gnews_gnm.r05_to_tx2_3v3_nnsm_e100r100_260306.20260424.nc"
-            }
+            "$OCN_GRID == \"tx2_3v2\" and $ROF_GRID == \"JRA025\"": "${INPUTDIR}/riv_nut.gnews_gnm.rJRA025_to_tx2_3v2_nnsm_e333r100_230415.20240202.nc",
+            "$OCN_GRID == \"tx2_3v2\" and $ROF_GRID == \"r05\"": "${INPUTDIR}/riv_nut.gnews_gnm.r05_to_tx2_3v2_nnsm_e250r250_230914.20240202.nc",
+            "$OCN_GRID == \"tx2_3v3\" and $ROF_GRID == \"JRA025\"": "${INPUTDIR}/riv_nut.gnews_gnm.rJRA025_to_tx2_3v3_nnsm_e100r100_260306.20260424.nc",
+            "$OCN_GRID == \"tx2_3v3\" and $ROF_GRID == \"r05\"": "${INPUTDIR}/riv_nut.gnews_gnm.r05_to_tx2_3v3_nnsm_e100r100_260306.20260424.nc"
          }
       },
       "MARBL_D14C_FILE_1": {

--- a/param_templates/json/input_data_list.json
+++ b/param_templates/json/input_data_list.json
@@ -83,13 +83,20 @@
       },
       "MARBL_FEFLUX_FILE": {
          "\"BASE_BIO_ON=TRUE\" in $MARBL_TRACER_OPTS": {
+            "$OCN_GRID == \"tx2_3v2\"": "${INPUTDIR}/fesedflux_2024algo_tx2_3v2.c251229.nc",
             "$OCN_GRID == \"tx2_3v3\"": "${INPUTDIR}/fefluxes_sed2024algo_vent2026algo_tx2_3v3.c260625.nc"
          }
       },
       "RIV_FLUX_FILE": {
          "\"BASE_BIO_ON=TRUE\" in $MARBL_TRACER_OPTS": {
-            "$ROF_GRID == \"JRA025\" and $OCN_GRID == \"tx2_3v3\"": "${INPUTDIR}/riv_nut.gnews_gnm.rJRA025_to_tx2_3v3_nnsm_e100r100_260306.20260424.nc",
-            "$ROF_GRID == \"r05\" and $OCN_GRID == \"tx2_3v3\"": "${INPUTDIR}/riv_nut.gnews_gnm.r05_to_tx2_3v3_nnsm_e100r100_260306.20260424.nc"
+            "$OCN_GRID == \"tx2_3v2\"": {
+               "$ROF_GRID == \"JRA025\"": "${INPUTDIR}/riv_nut.gnews_gnm.rJRA025_to_tx2_3v2_nnsm_e333r100_230415.20240202.nc",
+               "$ROF_GRID == \"r05\"": "${INPUTDIR}/riv_nut.gnews_gnm.r05_to_tx2_3v2_nnsm_e250r250_230914.20240202.nc"
+            },
+            "$OCN_GRID == \"tx2_3v3\"": {
+               "$ROF_GRID == \"JRA025\"": "${INPUTDIR}/riv_nut.gnews_gnm.rJRA025_to_tx2_3v3_nnsm_e100r100_260306.20260424.nc",
+               "$ROF_GRID == \"r05\"": "${INPUTDIR}/riv_nut.gnews_gnm.r05_to_tx2_3v3_nnsm_e100r100_260306.20260424.nc"
+            }
          }
       },
       "MARBL_D14C_FILE_1": {

--- a/param_templates/json/input_data_list.json
+++ b/param_templates/json/input_data_list.json
@@ -78,28 +78,28 @@
          "$OCN_GRID == \"tx2_3v2\"": "${INPUTDIR}/ocean_rho2_190917.nc"
       },
       "MARBL_TRACERS_IC_FILE": {
-         "$MARBL_CONFIG == \"latest\"": "${INPUTDIR}/ecosys_jan_IC_omip_latlon_1x1_180W_c250613.nc",
-         "$MARBL_CONFIG == \"latest+4p2z\"": "${INPUTDIR}/ecosys_jan_IC_omip_latlon_1x1_180W_c250613.nc"
+         "$MARBL_CONFIG == \"latest\"": "${DIN_LOC_ROOT}/ocn/mom/grid_indpt/ecosys_jan_IC_omip_latlon_1x1_180W_c250613.nc",
+         "$MARBL_CONFIG == \"latest+4p2z\"": "${DIN_LOC_ROOT}/ocn/mom/grid_indpt/ecosys_jan_IC_omip_latlon_1x1_180W_c250613.nc"
       },
       "MARBL_FESEDFLUX_FILE": {
          "\"BASE_BIO_ON=TRUE\" in $MARBL_TRACER_OPTS": {
-            "$OCN_GRID == \"tx2_3v2\"": "${INPUTDIR}/fesedflux_2024algo_tx2_3v2.c251229.nc"
+            "$OCN_GRID == \"tx2_3v3\"": "${INPUTDIR}/fesedflux_2024algo_tx2_3v2.c251229.nc"
          }
       },
       "MARBL_FESEDFLUXRED_FILE": {
          "\"BASE_BIO_ON=TRUE\" in $MARBL_TRACER_OPTS": {
-            "$OCN_GRID == \"tx2_3v2\"": "${INPUTDIR}/fesedfluxRed_2024algo_tx2_3v2.c251229.nc"
+            "$OCN_GRID == \"tx2_3v3\"": "${INPUTDIR}/fesedfluxRed_2024algo_tx2_3v2.c251229.nc"
          }
       },
       "MARBL_FEVENTFLUX_FILE": {
          "\"BASE_BIO_ON=TRUE\" in $MARBL_TRACER_OPTS": {
-            "$OCN_GRID == \"tx2_3v2\"": "${INPUTDIR}/feventflux_5gmol_tx2_3v2.c231205.nc"
+            "$OCN_GRID == \"tx2_3v3\"": "${INPUTDIR}/feventflux_5gmol_tx2_3v2.c231205.nc"
          }
       },
       "RIV_FLUX_FILE": {
          "\"BASE_BIO_ON=TRUE\" in $MARBL_TRACER_OPTS": {
-            "$ROF_GRID == \"JRA025\" and $OCN_GRID == \"tx2_3v2\"": "${INPUTDIR}/riv_nut.gnews_gnm.rJRA025_to_tx2_3v2_nnsm_e333r100_230415.20240202.nc",
-            "$ROF_GRID == \"r05\" and $OCN_GRID == \"tx2_3v2\"": "${INPUTDIR}/riv_nut.gnews_gnm.r05_to_tx2_3v2_nnsm_e250r250_230914.20240202.nc"
+            "$ROF_GRID == \"JRA025\" and $OCN_GRID == \"tx2_3v3\"": "${INPUTDIR}/riv_nut.gnews_gnm.rJRA025_to_tx2_3v3_nnsm_e100r100_260306.20260424.nc",
+            "$ROF_GRID == \"r05\" and $OCN_GRID == \"tx2_3v3\"": "${INPUTDIR}/riv_nut.gnews_gnm.r05_to_tx2_3v3_nnsm_e100r100_260306.20260424.nc"
          }
       },
       "MARBL_D14C_FILE_1": {

--- a/param_templates/json/input_data_list.json
+++ b/param_templates/json/input_data_list.json
@@ -81,19 +81,9 @@
          "$MARBL_CONFIG == \"latest\"": "${DIN_LOC_ROOT}/ocn/mom/grid_indpt/ecosys_jan_IC_omip_latlon_1x1_180W_c250613.nc",
          "$MARBL_CONFIG == \"latest+4p2z\"": "${DIN_LOC_ROOT}/ocn/mom/grid_indpt/ecosys_jan_IC_omip_latlon_1x1_180W_c250613.nc"
       },
-      "MARBL_FESEDFLUX_FILE": {
+      "MARBL_FEFLUX_FILE": {
          "\"BASE_BIO_ON=TRUE\" in $MARBL_TRACER_OPTS": {
-            "$OCN_GRID == \"tx2_3v3\"": "${INPUTDIR}/fesedflux_2024algo_tx2_3v2.c251229.nc"
-         }
-      },
-      "MARBL_FESEDFLUXRED_FILE": {
-         "\"BASE_BIO_ON=TRUE\" in $MARBL_TRACER_OPTS": {
-            "$OCN_GRID == \"tx2_3v3\"": "${INPUTDIR}/fesedfluxRed_2024algo_tx2_3v2.c251229.nc"
-         }
-      },
-      "MARBL_FEVENTFLUX_FILE": {
-         "\"BASE_BIO_ON=TRUE\" in $MARBL_TRACER_OPTS": {
-            "$OCN_GRID == \"tx2_3v3\"": "${INPUTDIR}/feventflux_5gmol_tx2_3v2.c231205.nc"
+            "$OCN_GRID == \"tx2_3v3\"": "${INPUTDIR}/fefluxes_sed2024algo_vent2026algo_tx2_3v3.c260625.nc"
          }
       },
       "RIV_FLUX_FILE": {


### PR DESCRIPTION
Need to set some grid-specific BGC parameters for the `tx2_3v3` grid, and also https://github.com/NCAR/MOM6/pull/434 changes how MOM6 expects to some BGC forcing data to be provided (so this PR updates `MOM_input`). There might be some other parameter changes coming from @kristenkrumhardt, she is tuning MARBL and I don't know if the MOM6 parameters should be set ParamGen or if we'll just update the default values in the Fortran code. I'll take this out of draft mode when all of that has been finalized.